### PR TITLE
BottomSheet: unsubscribe the observer 

### DIFF
--- a/src/modules/stackables/components/BottomSheet.js
+++ b/src/modules/stackables/components/BottomSheet.js
@@ -20,11 +20,11 @@ export class BottomSheet extends MvuElement {
 			open: false,
 			portrait: false
 		});
-	}
 
-	onInitialize() {
-		this.observe(state => state.mainMenu, data => this.signal(Update_Main_Menu, data), true);
-		this.observe(state => state.media, data => this.signal(Update_Media, data), true);
+		this._subscriptions = [
+			this.observe(state => state.mainMenu, data => this.signal(Update_Main_Menu, data), true),
+			this.observe(state => state.media, data => this.signal(Update_Media, data), true)
+		];
 	}
 
 	update(type, data, model) {
@@ -63,6 +63,14 @@ export class BottomSheet extends MvuElement {
         	${content}
 			<ba-icon id="close-icon" class='tool-container__close-button' .icon='${closeIcon}' .size=${1.6} .color=${'var(--text2)'} .color_hover=${'var(--text2)'} @click=${onDismiss}>
 		</div>` : nothing;
+	}
+
+
+	/**
+	 * @override
+	 */
+	onDisconnect() {
+		this._subscriptions.forEach(unsubscribe => unsubscribe());
 	}
 
 	static get tag() {

--- a/test/modules/stackables/components/BottomSheet.test.js
+++ b/test/modules/stackables/components/BottomSheet.test.js
@@ -14,16 +14,17 @@ window.customElements.define(BottomSheet.tag, BottomSheet);
 describe('BottomSheet', () => {
 
 	let store;
+	const defaultState = {
+		mainMenu: {
+			open: false
+		},
+		media: {
+			portrait: false
+		} };
 
 	const setup = async (content, state = {}) => {
 
-		const initialState = {
-			mainMenu: {
-				open: false
-			},
-			media: {
-				portrait: false
-			},
+		const initialState = { ...defaultState,
 			...state
 		};
 
@@ -35,8 +36,9 @@ describe('BottomSheet', () => {
 	};
 
 	describe('constructor', () => {
-		TestUtils.setupStoreAndDi({});
-		it('sets a default model', async () => {
+
+		it('sets a initial model', async () => {
+			TestUtils.setupStoreAndDi(defaultState);
 			const element = new BottomSheet();
 
 			expect(element.getModel()).toEqual({
@@ -44,6 +46,14 @@ describe('BottomSheet', () => {
 				open: false,
 				portrait: false
 			});
+		});
+
+		it('subscribes to the store', async () => {
+			TestUtils.setupStoreAndDi(defaultState);
+			const element = new BottomSheet();
+
+			expect(element._subscriptions).toHaveSize(2);
+			expect(element._subscriptions.every(subscription => typeof subscription === 'function')).toBeTrue();
 		});
 	});
 
@@ -166,6 +176,21 @@ describe('BottomSheet', () => {
 
 			expect(store.getState().bottomSheet.data).toBeNull();
 
+		});
+	});
+
+	describe('when disconnected', () => {
+
+		it('removes all observers', async () => {
+			const element = await setup();
+			const spy1 = jasmine.createSpy();
+			const spy2 = jasmine.createSpy();
+			element._subscriptions = [spy1, spy2];
+
+			element.onDisconnect(); // we call onDisconnect manually
+
+			expect(spy1).toHaveBeenCalled();
+			expect(spy2).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
fixes #1452

Move the subscription to store changes into the constructor phase and complete the lifecycle with the unsubscribe call in the disconnect-callback.