### PR TITLE
ShareService: handle optional path parameter

### DIFF
--- a/src/domain/pathParameters.js
+++ b/src/domain/pathParameters.js
@@ -4,5 +4,5 @@
  */
 export const PathParameters = Object.freeze({
 	// official parameters
-	EMBED: 'embed'
+	EMBED: 'embed.html'
 });

--- a/src/domain/pathParameters.js
+++ b/src/domain/pathParameters.js
@@ -1,0 +1,8 @@
+/**
+ * Enum which holds all valid path parameter keys.
+ * @enum
+ */
+export const PathParameters = Object.freeze({
+	// official parameters
+	EMBED: 'embed'
+});

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -56,8 +56,8 @@ export class ShareService {
 
 		const searchParams = new URLSearchParams(extractedState);
 		const location = this._environmentService.getWindow().location;
-		const mergedPathParameters = [...location.pathname.split('/'), ...pathParameters];
-		return `${location.protocol}//${location.host}${mergedPathParameters.join('/')}/` + '?' + decodeURIComponent(searchParams.toString());
+		const mergedPathParameters = [...location.pathname.split('/'), ...pathParameters].filter((s) => s.length > 0);
+		return `${location.protocol}//${location.host}/${mergedPathParameters.join('/')}` + '?' + decodeURIComponent(searchParams.toString());
 	}
 
 	/**

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -39,11 +39,12 @@ export class ShareService {
 
 	/**
 	 * Encodes the current state to a URL.
-	 * @param {object} extraParams Additional parameters. Non-existing entries will be added. Existing values will be ignored except for values that are an array.
+	 * @param {object} [extraParams] Additional parameters. Non-existing entries will be added. Existing values will be ignored except for values that are an array.
 	 * In this case, existing values will be concatenated with the additional values.
+	 * @param {array} [pathParameters] Optional path parameters. Will be appended to the current pathname without further checks
 	 * @returns {string} url
 	 */
-	encodeState(extraParams = {}) {
+	encodeState(extraParams = {}, pathParameters = []) {
 		const extractedState = this._mergeExtraParams(
 			{
 				...this._extractPosition(),
@@ -55,7 +56,8 @@ export class ShareService {
 
 		const searchParams = new URLSearchParams(extractedState);
 		const location = this._environmentService.getWindow().location;
-		return `${location.protocol}//${location.host}${location.pathname}` + '?' + decodeURIComponent(searchParams.toString());
+		const mergedPathParameters = [...location.pathname.split('/'), ...pathParameters];
+		return `${location.protocol}//${location.host}${mergedPathParameters.join('/')}/` + '?' + decodeURIComponent(searchParams.toString());
 	}
 
 	/**

--- a/test/domain/pathParameters.test.js
+++ b/test/domain/pathParameters.test.js
@@ -4,6 +4,6 @@ describe('QueryParameters', () => {
 	it('provides an enum of all valid path parameters', () => {
 		expect(Object.keys(PathParameters).length).toBe(1);
 
-		expect(PathParameters.EMBED).toBe('embed');
+		expect(PathParameters.EMBED).toBe('embed.html');
 	});
 });

--- a/test/domain/pathParameters.test.js
+++ b/test/domain/pathParameters.test.js
@@ -1,0 +1,9 @@
+import { PathParameters } from '../../src/domain/pathParameters';
+
+describe('QueryParameters', () => {
+	it('provides an enum of all valid path parameters', () => {
+		expect(Object.keys(PathParameters).length).toBe(1);
+
+		expect(PathParameters.EMBED).toBe('embed');
+	});
+});

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -233,74 +233,148 @@ describe('ShareService', () => {
 		});
 
 		describe('encodeState', () => {
-			const location = {
-				protocol: 'http:',
-				host: 'foo.bar',
-				pathname: '/some'
-			};
+			describe('for pathname "/"', () => {
+				const location = {
+					protocol: 'http:',
+					host: 'foo.bar',
+					pathname: '/'
+				};
 
-			it('encodes a state object to url', () => {
-				setup();
-				const mockWindow = { location: location };
-				spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-				const instanceUnderTest = new ShareService();
-				spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
-				spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
-				spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
-				const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), {}).and.callThrough();
+				it('encodes a state object to url', () => {
+					setup();
+					const mockWindow = { location: location };
+					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+					const instanceUnderTest = new ShareService();
+					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+					const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), {}).and.callThrough();
 
-				const encoded = instanceUnderTest.encodeState();
-				const queryParams = new URLSearchParams(new URL(encoded).search);
+					const encoded = instanceUnderTest.encodeState();
+					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}/?`)).toBeTrue();
-				expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
-				expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
-				expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
-				expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
-				expect(_mergeExtraParamsSpy).toHaveBeenCalled();
+					expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}?`)).toBeTrue();
+					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+					expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+					expect(_mergeExtraParamsSpy).toHaveBeenCalled();
+				});
+
+				it('encodes a state object to url merging extra parameter', () => {
+					setup();
+					const mockWindow = { location: location };
+					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+					const instanceUnderTest = new ShareService();
+					const extraParam = { foo: 'bar' };
+					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+					const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), extraParam).and.callThrough();
+
+					const encoded = instanceUnderTest.encodeState(extraParam);
+					const queryParams = new URLSearchParams(new URL(encoded).search);
+
+					expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}?`)).toBeTrue();
+					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+					expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+					expect(queryParams.get('foo')).toBe('bar');
+					expect(_mergeExtraParamsSpy).toHaveBeenCalled();
+				});
+
+				it('encodes a state object to url appending optional path parameters', () => {
+					setup();
+					const mockWindow = { location: location };
+					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+					const instanceUnderTest = new ShareService();
+					const pathParameters = ['foo', 'bar'];
+					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+
+					const encoded = instanceUnderTest.encodeState({}, pathParameters);
+					const queryParams = new URLSearchParams(new URL(encoded).search);
+
+					expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}foo/bar?`)).toBeTrue();
+					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+					expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+				});
 			});
 
-			it('encodes a state object to url merging extra parameter', () => {
-				setup();
-				const mockWindow = { location: location };
-				spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-				const instanceUnderTest = new ShareService();
-				const extraParam = { foo: 'bar' };
-				spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
-				spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
-				spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
-				const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), extraParam).and.callThrough();
+			describe('for pathname "/some"', () => {
+				const location = {
+					protocol: 'http:',
+					host: 'foo.bar',
+					pathname: '/some'
+				};
 
-				const encoded = instanceUnderTest.encodeState(extraParam);
-				const queryParams = new URLSearchParams(new URL(encoded).search);
+				it('encodes a state object to url', () => {
+					setup();
+					const mockWindow = { location: location };
+					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+					const instanceUnderTest = new ShareService();
+					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+					const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), {}).and.callThrough();
 
-				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}/?`)).toBeTrue();
-				expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
-				expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
-				expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
-				expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
-				expect(queryParams.get('foo')).toBe('bar');
-				expect(_mergeExtraParamsSpy).toHaveBeenCalled();
-			});
+					const encoded = instanceUnderTest.encodeState();
+					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-			it('encodes a state object to url appending optional path parameters', () => {
-				setup();
-				const mockWindow = { location: location };
-				spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-				const instanceUnderTest = new ShareService();
-				const pathParameters = ['foo', 'bar'];
-				spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
-				spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
-				spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+					expect(encoded.startsWith('http://foo.bar/some?')).toBeTrue();
+					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+					expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+					expect(_mergeExtraParamsSpy).toHaveBeenCalled();
+				});
 
-				const encoded = instanceUnderTest.encodeState({}, pathParameters);
-				const queryParams = new URLSearchParams(new URL(encoded).search);
+				it('encodes a state object to url merging extra parameter', () => {
+					setup();
+					const mockWindow = { location: location };
+					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+					const instanceUnderTest = new ShareService();
+					const extraParam = { foo: 'bar' };
+					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+					const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), extraParam).and.callThrough();
 
-				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}/foo/bar/?`)).toBeTrue();
-				expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
-				expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
-				expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
-				expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+					const encoded = instanceUnderTest.encodeState(extraParam);
+					const queryParams = new URLSearchParams(new URL(encoded).search);
+
+					expect(encoded.startsWith('http://foo.bar/some?')).toBeTrue();
+					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+					expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+					expect(queryParams.get('foo')).toBe('bar');
+					expect(_mergeExtraParamsSpy).toHaveBeenCalled();
+				});
+
+				it('encodes a state object to url appending optional path parameters', () => {
+					setup();
+					const mockWindow = { location: location };
+					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+					const instanceUnderTest = new ShareService();
+					const pathParameters = ['foo', 'bar'];
+					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+
+					const encoded = instanceUnderTest.encodeState({}, pathParameters);
+					const queryParams = new URLSearchParams(new URL(encoded).search);
+
+					expect(encoded.startsWith('http://foo.bar/some/foo/bar?')).toBeTrue();
+					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+					expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
+				});
 			});
 		});
 	});

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -252,7 +252,7 @@ describe('ShareService', () => {
 				const encoded = instanceUnderTest.encodeState();
 				const queryParams = new URLSearchParams(new URL(encoded).search);
 
-				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}?`)).toBeTrue();
+				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}/?`)).toBeTrue();
 				expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 				expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 				expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
@@ -274,13 +274,33 @@ describe('ShareService', () => {
 				const encoded = instanceUnderTest.encodeState(extraParam);
 				const queryParams = new URLSearchParams(new URL(encoded).search);
 
-				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}?`)).toBeTrue();
+				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}/?`)).toBeTrue();
 				expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 				expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 				expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
 				expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
 				expect(queryParams.get('foo')).toBe('bar');
 				expect(_mergeExtraParamsSpy).toHaveBeenCalled();
+			});
+
+			it('encodes a state object to url appending optional path parameters', () => {
+				setup();
+				const mockWindow = { location: location };
+				spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+				const instanceUnderTest = new ShareService();
+				const pathParameters = ['foo', 'bar'];
+				spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
+				spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
+				spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
+
+				const encoded = instanceUnderTest.encodeState({}, pathParameters);
+				const queryParams = new URLSearchParams(new URL(encoded).search);
+
+				expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}/foo/bar/?`)).toBeTrue();
+				expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
+				expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
+				expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
+				expect(queryParams.get(QueryParameters.TOPIC)).toBe('someTopic');
 			});
 		});
 	});


### PR DESCRIPTION
Encode current state for embed page:

`shareService.encodeState({}, [PathParameters.EMBED]);`