### PR TITLE
add possibiltiy to expose the current encoded state of an embedded BA app 

### DIFF
--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -46,6 +46,7 @@ import { Proj4JsService } from '../services/Proj4JsService';
 import { BvvMfp3Encoder } from '../modules/olMap/services/Mfp3Encoder';
 import { ElevationProfilePlugin } from '../plugins/ElevationProfilePlugin';
 import { ElevationService } from '../services/ElevationService';
+import { IframeStatePlugin } from '../plugins/IframeStatePlugin';
 
 $injector
 	.registerSingleton('ProjectionService', new Proj4JsService())
@@ -93,6 +94,7 @@ $injector
 	.registerSingleton('SearchPlugin', new SearchPlugin())
 	.registerSingleton('ExportMfpPlugin', new ExportMfpPlugin())
 	.registerSingleton('ElevationProfilePlugin', new ElevationProfilePlugin())
+	.registerSingleton('IframeStatePlugin', new IframeStatePlugin())
 	.registerSingleton('HistoryStatePlugin', new HistoryStatePlugin())
 	.registerModule(mapModule)
 	.registerModule(topicsModule)

--- a/src/plugins/IframeStatePlugin.js
+++ b/src/plugins/IframeStatePlugin.js
@@ -5,8 +5,7 @@ import { BaPlugin } from './BaPlugin';
 
 /**
  * Checks if a surrounding iframe exists and contains the {@link IFRAME_ENCODED_STATE } data-attribute.
- * If so, it updates the attributes value on state changes. Currently only one surrounding iframe is supported.
- * @class
+ * If so, it updates the attributes value on state changes.
  * @author taulinger
  */
 export class IframeStatePlugin extends BaPlugin {

--- a/src/plugins/IframeStatePlugin.js
+++ b/src/plugins/IframeStatePlugin.js
@@ -5,7 +5,7 @@ import { BaPlugin } from './BaPlugin';
 
 /**
  * Checks if a surrounding iframe exists and contains the {@link IFRAME_ENCODED_STATE } data-attribute.
- * If so, it updates the attributes value on state changes.
+ * If so, it updates the attributes value on state changes. Currently only one surrounding iframe is supported.
  * @class
  * @author taulinger
  */

--- a/src/plugins/IframeStatePlugin.js
+++ b/src/plugins/IframeStatePlugin.js
@@ -1,0 +1,49 @@
+import { $injector } from '../injection';
+import { IFRAME_ENCODED_STATE } from '../utils/markup';
+import { observe } from '../utils/storeUtils';
+import { BaPlugin } from './BaPlugin';
+
+/**
+ * Checks if a surrounding iframe exists and contains the {@link IFRAME_ENCODED_STATE } data-attribute.
+ * If so, it updates the attributes value on state changes.
+ * @class
+ * @author taulinger
+ */
+export class IframeStatePlugin extends BaPlugin {
+	constructor() {
+		super();
+		const { EnvironmentService: environmentService, ShareService: shareService } = $injector.inject('EnvironmentService', 'ShareService');
+		this._environmentService = environmentService;
+		this._shareService = shareService;
+		this._currentEncodedState = null;
+	}
+
+	/**
+	 * @override
+	 */
+	async register(store) {
+		if (this._environmentService.isEmbedded()) {
+			const update = () => {
+				this._updateAttribute();
+			};
+
+			observe(store, (state) => state.position.zoom, update);
+			observe(store, (state) => state.position.center, update);
+			observe(store, (state) => state.position.rotation, update);
+			observe(store, (state) => state.layers.active, update);
+			setTimeout(update, 0);
+		}
+	}
+
+	_updateAttribute() {
+		const encodedState = this._shareService.encodeState();
+		if (this._currentEncodedState !== encodedState) {
+			this._findIframe()?.setAttribute(IFRAME_ENCODED_STATE, encodedState);
+			this._currentEncodedState = encodedState;
+		}
+	}
+
+	_findIframe() {
+		return this._environmentService.getWindow().parent.document.querySelector(`iframe[${IFRAME_ENCODED_STATE}]`);
+	}
+}

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -85,7 +85,8 @@ export class StoreService {
 				SearchPlugin: searchPlugin,
 				ExportMfpPlugin: exportMfpPlugin,
 				ElevationProfilePlugin: elevationProfilePlugin,
-				HistoryStatePlugin: historyStatePlugin
+				HistoryStatePlugin: historyStatePlugin,
+				IframeStatePlugin: iframeStatePlugin
 			} = $injector.inject(
 				'TopicsPlugin',
 				'ChipsPlugin',
@@ -103,7 +104,8 @@ export class StoreService {
 				'SearchPlugin',
 				'ExportMfpPlugin',
 				'ElevationProfilePlugin',
-				'HistoryStatePlugin'
+				'HistoryStatePlugin',
+				'IframeStatePlugin'
 			);
 
 			setTimeout(async () => {
@@ -124,6 +126,7 @@ export class StoreService {
 				await searchPlugin.register(this._store);
 				await exportMfpPlugin.register(this._store);
 				await elevationProfilePlugin.register(this._store);
+				await iframeStatePlugin.register(this._store);
 				await historyStatePlugin.register(this._store); // should be registered as last plugin
 			});
 		});

--- a/src/utils/markup.js
+++ b/src/utils/markup.js
@@ -16,6 +16,11 @@ export const REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME = 'data-register-f
 export const LOG_LIFECYLE_ATTRIBUTE_NAME = 'data-log-lifecycle';
 
 /**
+ * An iframe element containing this attribute will expose the current encoded state of an embedded BA app.
+ */
+export const IFRAME_ENCODED_STATE = 'data-iframe-encoded-state';
+
+/**
  * Sets the value of the `data-test-id` attribute for a MvuElement and all of its children.
  * The Test-Id is derived from the DOM hierarchy of the current MvuElement following its parent MvuElements
  *(BaElements are also supported).

--- a/test/injection/config.test.js
+++ b/test/injection/config.test.js
@@ -6,7 +6,7 @@ import { Injector } from '../../src/injection/core/injector.js';
 describe('injector configuration', () => {
 	it('registers the expected dependencies', () => {
 		expect($injector.isReady()).toBeTrue();
-		expect($injector.count()).toBe(58);
+		expect($injector.count()).toBe(59);
 
 		expect($injector.getScope('ProjectionService')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HttpService')).toBe(Injector.SCOPE_PERLOOKUP);
@@ -52,6 +52,7 @@ describe('injector configuration', () => {
 		expect($injector.getScope('SearchPlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('ExportMfpPlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('ElevationProfilePlugin')).toBe(Injector.SCOPE_SINGLETON);
+		expect($injector.getScope('IframeStatePlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HistoryStatePlugin')).toBe(Injector.SCOPE_SINGLETON);
 
 		// map module

--- a/test/plugins/IframeStatePlugin.test.js
+++ b/test/plugins/IframeStatePlugin.test.js
@@ -1,0 +1,178 @@
+import { $injector } from '../../src/injection';
+import { IframeStatePlugin } from '../../src/plugins/IframeStatePlugin';
+import { addLayer } from '../../src/store/layers/layers.action';
+import { layersReducer } from '../../src/store/layers/layers.reducer';
+import { changeCenter, changeRotation, increaseZoom } from '../../src/store/position/position.action';
+import { positionReducer } from '../../src/store/position/position.reducer';
+import { IFRAME_ENCODED_STATE } from '../../src/utils/markup';
+import { TestUtils } from '../test-utils';
+
+describe('IframeState', () => {
+	const shareService = {
+		encodeState() {}
+	};
+	const environmentService = {
+		getWindow: () => {},
+		isEmbedded: () => {}
+	};
+	const mapService = {
+		getMaxZoomLevel: () => 1,
+		getMinZoomLevel: () => 0
+	};
+
+	const mockIframeElement = {
+		setAttribute: () => {}
+	};
+
+	const setup = () => {
+		const state = {
+			position: {
+				zoom: 0,
+				pointerPosition: [0, 0],
+				rotation: 0
+			}
+		};
+
+		const store = TestUtils.setupStoreAndDi(state, {
+			position: positionReducer,
+			layers: layersReducer
+		});
+		$injector
+			.registerSingleton('EnvironmentService', environmentService)
+			.registerSingleton('ShareService', shareService)
+			.registerSingleton('MapService', mapService);
+		return store;
+	};
+
+	it('registers postion.zoom change listeners and updates the iframes data attribute', async () => {
+		const expectedEncodedState = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+
+		increaseZoom();
+
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		await TestUtils.timeout(0);
+	});
+
+	it('registers postion.center change listeners and updates the window history state', async () => {
+		const expectedEncodedState = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+
+		changeCenter([1, 1]);
+
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		await TestUtils.timeout(0);
+	});
+
+	it('registers postion.rotation change listeners and updates the window history state', async () => {
+		const expectedEncodedState = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+
+		changeRotation(1);
+
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		await TestUtils.timeout(0);
+	});
+
+	it('registers layers.active change listeners and updates the window history state', async () => {
+		const expectedEncodedState = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+
+		addLayer('some');
+
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		await TestUtils.timeout(0);
+	});
+
+	it('updates the iframes data attribute in an asynchronous manner after plugin registration is done', async () => {
+		const expectedEncodedState = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+
+		await TestUtils.timeout(0);
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		await TestUtils.timeout(0);
+	});
+
+	it("does nothing when encoded state has'nt changed", async () => {
+		const expectedEncodedState = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+		await TestUtils.timeout(0);
+
+		// Let's trigger one observer multiple times
+		changeCenter([1, 1]);
+		changeCenter([1, 2]);
+		changeCenter([1, 3]);
+		changeCenter([1, 4]);
+
+		// We always return the same encoded state from the ShareService,
+		// so the attribute should be updated only once
+		expect(iframeSpy).toHaveBeenCalledOnceWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		await TestUtils.timeout(0);
+	});
+
+	it("does nothing when we are NOT in 'embed' mode", async () => {
+		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
+		const store = setup();
+		const instanceUnderTest = new IframeStatePlugin();
+		const updateAttributeSpy = spyOn(instanceUnderTest, '_updateAttribute');
+		await instanceUnderTest.register(store);
+
+		await TestUtils.timeout(0);
+		expect(updateAttributeSpy).not.toHaveBeenCalled();
+	});
+
+	describe('_findIframe', () => {
+		it('finds an iframe element by the IFRAME_ENCODED_STATE attribute', async () => {
+			const querySelectorSpy = jasmine.createSpy();
+			const mockWindow = {
+				parent: {
+					document: {
+						querySelector: querySelectorSpy
+					}
+				}
+			};
+			spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+			setup();
+			const instanceUnderTest = new IframeStatePlugin();
+
+			instanceUnderTest._findIframe();
+			expect(querySelectorSpy).toHaveBeenCalledWith(`iframe[${IFRAME_ENCODED_STATE}]`);
+		});
+	});
+});

--- a/test/service/StoreService.test.js
+++ b/test/service/StoreService.test.js
@@ -46,9 +46,6 @@ describe('StoreService', () => {
 		const exportMfpPluginMock = {
 			register: () => {}
 		};
-		const historyStatePluginMock = {
-			register: () => {}
-		};
 		const mainMenuPluginMock = {
 			register() {}
 		};
@@ -60,6 +57,12 @@ describe('StoreService', () => {
 		};
 		const elevationProfilePluginMock = {
 			register() {}
+		};
+		const iframeStatePluginMock = {
+			register: () => {}
+		};
+		const historyStatePluginMock = {
+			register: () => {}
 		};
 
 		const setupInjector = () => {
@@ -82,8 +85,9 @@ describe('StoreService', () => {
 				.registerSingleton('SearchPlugin', searchPluginMock)
 				.registerSingleton('ExportMfpPlugin', exportMfpPluginMock)
 				.registerSingleton('ElevationProfilePlugin', elevationProfilePluginMock)
-				.registerSingleton('HistoryStatePlugin', historyStatePluginMock)
 				.registerSingleton('ChipsPlugin', chipsPlugin)
+				.registerSingleton('IframeStatePlugin', iframeStatePluginMock)
+				.registerSingleton('HistoryStatePlugin', historyStatePluginMock)
 
 				.ready();
 		};
@@ -139,6 +143,7 @@ describe('StoreService', () => {
 			const searchPluginSpy = spyOn(searchPluginMock, 'register');
 			const exportMfpPluginSpy = spyOn(exportMfpPluginMock, 'register');
 			const elevationProfilePluginSpy = spyOn(elevationProfilePluginMock, 'register');
+			const iframeStatePluginSpy = spyOn(iframeStatePluginMock, 'register');
 			const historyStatePluginSpy = spyOn(historyStatePluginMock, 'register');
 			const instanceUnderTest = new StoreService();
 
@@ -164,6 +169,7 @@ describe('StoreService', () => {
 			expect(searchPluginSpy).toHaveBeenCalledWith(store);
 			expect(exportMfpPluginSpy).toHaveBeenCalledWith(store);
 			expect(elevationProfilePluginSpy).toHaveBeenCalledWith(store);
+			expect(iframeStatePluginSpy).toHaveBeenCalledWith(store);
 			expect(historyStatePluginSpy).toHaveBeenCalledWith(store);
 		});
 	});

--- a/test/utils/markup.test.js
+++ b/test/utils/markup.test.js
@@ -5,6 +5,7 @@ import {
 	decodeHtmlEntities,
 	findAllByAttribute,
 	forEachByAttribute,
+	IFRAME_ENCODED_STATE,
 	LOG_LIFECYLE_ATTRIBUTE_NAME,
 	REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME,
 	TEST_ID_ATTRIBUTE_NAME
@@ -88,6 +89,9 @@ describe('markup utils', () => {
 
 		it('provides an attribute name to enable lifecycle logging', () => {
 			expect(LOG_LIFECYLE_ATTRIBUTE_NAME).toBe('data-log-lifecycle');
+		});
+		it('provides an attribute name for iframes to enable exposing the current state of an embedded BA app', () => {
+			expect(IFRAME_ENCODED_STATE).toBe('data-iframe-encoded-state');
 		});
 	});
 


### PR DESCRIPTION
By adding the  `data-iframe-encoded-state` attribute to an iframe element, it will expose the current encoded state of an embedded BA app:
```
<iframe data-iframe-encoded-state src="../embed.html"></iframe>
```
will be updated on state changes, e.g.

```
<iframe data-iframe-encoded-state="http://localhost:8080/embed.html?c=677751,5422939&amp;z=7&amp;l=atkis&amp;t=ba" src="../embed.html"></iframe>
```