### PR TITLE
KML: remove shortcut method

### DIFF
--- a/src/modules/olMap/formats/kml.js
+++ b/src/modules/olMap/formats/kml.js
@@ -114,8 +114,3 @@ export const create = (layer, projection) => {
 	}
 	return kmlString;
 };
-
-export const readFeatures = (kmlString) => {
-	const format = new KML({ writeStyles: true });
-	return format.readFeatures(kmlString);
-};

--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -19,7 +19,7 @@ import MapBrowserEventType from 'ol/MapBrowserEventType';
 import { equals, observe } from '../../../../utils/storeUtils';
 import { setSelectedStyle, setStyle, setType, setGeometryIsValid, setSelection, setDescription } from '../../../../store/draw/draw.action';
 import { unByKey } from 'ol/Observable';
-import { create as createKML, readFeatures } from '../../formats/kml';
+import { create as createKML } from '../../formats/kml';
 import {
 	getModifyOptions,
 	getSelectableFeatures,
@@ -49,6 +49,7 @@ import { isString } from '../../../../utils/checks';
 import { hexToRgb } from '../../../../utils/colors';
 import { KeyActionMapper } from '../../../../utils/KeyActionMapper';
 import { getAttributionForLocallyImportedOrCreatedGeoResource } from '../../../../services/provider/attribution.provider';
+import { KML } from 'ol/format';
 
 export const MAX_SELECTION_SIZE = 1;
 
@@ -173,7 +174,7 @@ export class OlDrawHandler extends OlLayerHandler {
 					 * To preserve the internal logic of this handler, we create a Promise by using 'await' anyway
 					 */
 					const data = await vgr.data;
-					const oldFeatures = readFeatures(data);
+					const oldFeatures = new KML().readFeatures(data);
 					const onFeatureChange = (event) => {
 						const geometry = event.target.getGeometry();
 						setGeometryIsValid(isValidGeometry(geometry));

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -13,7 +13,7 @@ import MapBrowserEventType from 'ol/MapBrowserEventType';
 import { observe } from '../../../../utils/storeUtils';
 import { HelpTooltip } from '../../tooltip/HelpTooltip';
 import { provide as messageProvide } from './tooltipMessage.provider';
-import { create as createKML, readFeatures } from '../../formats/kml';
+import { create as createKML } from '../../formats/kml';
 import { debounced } from '../../../../utils/timer';
 import { VectorGeoResource, VectorSourceType } from '../../../../domain/geoResources';
 import { saveManualOverlayPosition } from '../../overlayStyle/MeasurementOverlayStyle';
@@ -39,6 +39,7 @@ import { setCurrentTool, ToolId } from '../../../../store/tools/tools.action';
 import { setSelection as setDrawSelection } from '../../../../store/draw/draw.action';
 import { KeyActionMapper } from '../../../../utils/KeyActionMapper';
 import { getAttributionForLocallyImportedOrCreatedGeoResource } from '../../../../services/provider/attribution.provider';
+import { KML } from 'ol/format';
 
 const Debounce_Delay = 1000;
 
@@ -145,7 +146,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 					 * To preserve the internal logic of this handler, we create a Promise by using 'await' anyway
 					 */
 					const data = await vgr.data;
-					const oldFeatures = readFeatures(data);
+					const oldFeatures = new KML().readFeatures(data);
 					const onFeatureChange = (event) => {
 						const measureGeometry = this._createMeasureGeometry(event.target);
 						this._styleService.updateStyle(event.target, olMap, { geometry: measureGeometry }, StyleTypes.MEASURE);


### PR DESCRIPTION
fixes #1503

the shortcut method 'readFeature' is not sufficient testable. Replacing the usage with the usage of ol format object.