### PR TITLE
BvvCapabilitiesProvider:  handle exportable property

### DIFF
--- a/src/services/provider/wmsCapabilities.provider.js
+++ b/src/services/provider/wmsCapabilities.provider.js
@@ -31,7 +31,11 @@ export const _determinePreferredFormat = (arr) => {
  */
 export const bvvCapabilitiesProvider = async (url, options) => {
 	const { isAuthenticated } = options;
-	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
+	const {
+		HttpService: httpService,
+		ConfigService: configService,
+		MapService: mapService
+	} = $injector.inject('HttpService', 'ConfigService', 'MapService');
 	const endpoint = configService.getValueAsPath('BACKEND_URL') + 'wms/getCapabilities';
 
 	const getExtraParams = (capabilities) => {
@@ -56,11 +60,12 @@ export const bvvCapabilitiesProvider = async (url, options) => {
 					.setAuthenticationType(getAuthenticationType(options.isAuthenticated))
 					.setQueryable(layer.queryable)
 					.setExtraParams(getExtraParams(capabilities))
+					// WmsGeoResource should be only exportable if capabilities layer supports geodetic SRID
+					.setExportable(layer.referenceSystems.map((refs) => refs.code).includes(mapService.getDefaultGeodeticSrid()))
 			: null;
 	};
 
 	const readCapabilities = (capabilities) => {
-		const { MapService: mapService } = $injector.inject('MapService');
 		const containsSRID = (layer, srid) => layer.referenceSystems.some((srs) => srs.code === srid);
 		return (
 			capabilities.layers

--- a/test/service/provider/wmsCapabilities.provider.test.js
+++ b/test/service/provider/wmsCapabilities.provider.test.js
@@ -37,6 +37,12 @@ const Default_Capabilities_Result = {
 					value: 'EPSG:31467'
 				},
 				{
+					code: 25832,
+					urn: false,
+					axisOrderLatLong: false,
+					value: 'EPSG:25832'
+				},
+				{
 					code: 3857,
 					urn: false,
 					axisOrderLatLong: false,
@@ -147,7 +153,8 @@ describe('bvvCapabilitiesProvider', () => {
 	};
 
 	const mapService = {
-		getSrid: () => 3857
+		getSrid: () => 3857,
+		getDefaultGeodeticSrid: () => 25832
 	};
 
 	const baaCredentialService = {
@@ -265,7 +272,8 @@ describe('bvvCapabilitiesProvider', () => {
 				url: 'https://online.resource/GetMap?',
 				format: 'image/png',
 				queryable: true,
-				authenticationType: null
+				authenticationType: null,
+				exportable: true
 			})
 		);
 		expect(wmsGeoResources[1]).toEqual(
@@ -275,7 +283,8 @@ describe('bvvCapabilitiesProvider', () => {
 				url: 'https://online.resource/GetMap?',
 				format: 'image/png',
 				queryable: false,
-				authenticationType: null
+				authenticationType: null,
+				exportable: false
 			})
 		);
 	});
@@ -307,7 +316,8 @@ describe('bvvCapabilitiesProvider', () => {
 				format: 'image/png',
 				queryable: false,
 				authenticationType: null,
-				layers: layerName
+				layers: layerName,
+				exportable: false
 			})
 		);
 	});
@@ -344,7 +354,8 @@ describe('bvvCapabilitiesProvider', () => {
 				url: 'https://online.resource/GetMap?',
 				format: 'image/png',
 				queryable: true,
-				authenticationType: null
+				authenticationType: null,
+				exportable: true
 			})
 		);
 		expect(wmsGeoResources[1]).toEqual(
@@ -354,7 +365,8 @@ describe('bvvCapabilitiesProvider', () => {
 				url: 'https://online.resource/GetMap?',
 				format: 'image/png',
 				queryable: false,
-				authenticationType: null
+				authenticationType: null,
+				exportable: false
 			})
 		);
 	});


### PR DESCRIPTION
WmsGeoResource should be only exportable if capabilities layer supports geodetic SRID.
