### PR TITLE
ShareService: ignore existing pathname

### DIFF
--- a/src/modules/iframe/components/iframeGenerator/IframeGenerator.js
+++ b/src/modules/iframe/components/iframeGenerator/IframeGenerator.js
@@ -150,7 +150,7 @@ export class IframeGenerator extends MvuElement {
 	}
 
 	_getIFrameContent(width, height) {
-		const iframeSrc = this._shareService.encodeState([], [PathParameters.EMBED]);
+		const iframeSrc = this._shareService.encodeState({}, [PathParameters.EMBED]);
 		return html` <div class="iframe__content">
 			<iframe
 				data-iframe-encoded-state
@@ -167,7 +167,7 @@ export class IframeGenerator extends MvuElement {
 		const translate = (key) => this._translationService.translate(key);
 
 		const getEmbedCode = () => {
-			return `<iframe src=${previewUrl ? previewUrl : this._shareService.encodeState([], [PathParameters.EMBED])} width='${
+			return `<iframe src=${previewUrl ? previewUrl : this._shareService.encodeState({}, [PathParameters.EMBED])} width='${
 				width === Auto_Width ? Auto_Width : width + 'px'
 			}' height='${height + 'px'}' loading='lazy' frameborder='0' style='border:0'></iframe>`;
 		};

--- a/src/plugins/IframeStatePlugin.js
+++ b/src/plugins/IframeStatePlugin.js
@@ -1,3 +1,4 @@
+import { PathParameters } from '../domain/pathParameters';
 import { $injector } from '../injection';
 import { findAllBySelector, IFRAME_ENCODED_STATE } from '../utils/markup';
 import { observe } from '../utils/storeUtils';
@@ -35,7 +36,7 @@ export class IframeStatePlugin extends BaPlugin {
 	}
 
 	_updateAttribute() {
-		const encodedState = this._shareService.encodeState();
+		const encodedState = this._shareService.encodeState({}, [PathParameters.EMBED]);
 		if (this._currentEncodedState !== encodedState) {
 			this._findIframe()?.setAttribute(IFRAME_ENCODED_STATE, encodedState);
 			this._currentEncodedState = encodedState;

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -56,8 +56,8 @@ export class ShareService {
 
 		const searchParams = new URLSearchParams(extractedState);
 		const location = this._environmentService.getWindow().location;
-		const mergedPathParameters = [...location.pathname.split('/'), ...pathParameters].filter((s) => s.length > 0);
-		return `${location.protocol}//${location.host}/${mergedPathParameters.join('/')}` + '?' + decodeURIComponent(searchParams.toString());
+		const mergedPathParameters = pathParameters.length ? ['', ...pathParameters] : [];
+		return `${location.protocol}//${location.host}${mergedPathParameters.join('/')}` + '?' + decodeURIComponent(searchParams.toString());
 	}
 
 	/**

--- a/test/modules/iframe/components/IframeGenerator.test.js
+++ b/test/modules/iframe/components/IframeGenerator.test.js
@@ -1,3 +1,4 @@
+import { PathParameters } from '../../../../src/domain/pathParameters';
 import { $injector } from '../../../../src/injection';
 import { Toggle } from '../../../../src/modules/commons/components/toggle/Toggle';
 import { IframeGenerator } from '../../../../src/modules/iframe/components/iframeGenerator/IframeGenerator';
@@ -13,7 +14,7 @@ describe('IframeGenerator', () => {
 	let store;
 
 	const shareServiceMock = {
-		encodeState: () => 'https://myhost/app/embed.html?param=foo',
+		encodeState: () => {},
 		copyToClipboard() {}
 	};
 
@@ -43,22 +44,28 @@ describe('IframeGenerator', () => {
 		});
 
 		it('specifies correct iframe source', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			const shareServiceSpy = spyOn(shareServiceMock, 'encodeState').and.returnValue(expectedUrl);
 			const element = await setup();
 
 			const iframeElement = element.shadowRoot.querySelector('iframe');
 
-			expect(iframeElement.src).toBe('https://myhost/app/embed.html?param=foo');
+			expect(iframeElement.src).toBe(expectedUrl);
+			expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		});
 
 		it('shows a textarea with a embedable code', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			const shareServiceSpy = spyOn(shareServiceMock, 'encodeState').and.returnValue(expectedUrl);
 			const element = await setup();
 
 			const textAreaElement = element.shadowRoot.querySelector('textarea');
 
 			expect(textAreaElement.readOnly).toBeTrue();
 			expect(textAreaElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
+			expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		});
 
 		it('shows a ba-icon to copy code to clipboard', async () => {
@@ -74,6 +81,8 @@ describe('IframeGenerator', () => {
 
 	describe('when user requests the iframe code', () => {
 		it('copies the example html code to clipboard', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 			const clipboardSpy = spyOn(shareServiceMock, 'copyToClipboard').and.callThrough();
 
@@ -81,7 +90,7 @@ describe('IframeGenerator', () => {
 			buttonElement.click();
 
 			expect(clipboardSpy).toHaveBeenCalledWith(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 		});
 
@@ -111,6 +120,8 @@ describe('IframeGenerator', () => {
 
 	describe('when input values for size changes', () => {
 		it('renders iframe with the changed values', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 			const textElement = element.shadowRoot.querySelector('#iframe_code');
 			const widthInputElement = element.shadowRoot.querySelector('#iframe_width');
@@ -120,7 +131,7 @@ describe('IframeGenerator', () => {
 			// init values
 			expect(iframeElement.width).toBe('800px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing width
@@ -129,7 +140,7 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.width).toBe('42px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='42px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='42px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing height
@@ -138,11 +149,13 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.height).toBe('420px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='42px' height='420px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='42px' height='420px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 		});
 
 		it('renders iframe with the changed slider values', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 			const textElement = element.shadowRoot.querySelector('#iframe_code');
 			const widthInputElement = element.shadowRoot.querySelector('#iframe_slider_width');
@@ -152,7 +165,7 @@ describe('IframeGenerator', () => {
 			// init values
 			expect(iframeElement.width).toBe('800px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing width
@@ -161,7 +174,7 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.width).toBe('210px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='210px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='210px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing height
@@ -170,11 +183,13 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.height).toBe('420px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='210px' height='420px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='210px' height='420px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 		});
 
 		it('renders iframe with the min slider values', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 			const textElement = element.shadowRoot.querySelector('#iframe_code');
 			const widthInputElement = element.shadowRoot.querySelector('#iframe_slider_width');
@@ -184,7 +199,7 @@ describe('IframeGenerator', () => {
 			// init values
 			expect(iframeElement.width).toBe('800px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing width
@@ -193,7 +208,7 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.width).toBe('100px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='100px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='100px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing height
@@ -202,11 +217,13 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.height).toBe('100px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='100px' height='100px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='100px' height='100px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 		});
 
 		it('renders iframe with the max slider values', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 
 			const textElement = element.shadowRoot.querySelector('#iframe_code');
@@ -217,7 +234,7 @@ describe('IframeGenerator', () => {
 			// init values
 			expect(iframeElement.width).toBe('800px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing width
@@ -226,7 +243,7 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.width).toBe('2000px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='2000px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='2000px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			// changing height
@@ -235,11 +252,13 @@ describe('IframeGenerator', () => {
 
 			expect(iframeElement.height).toBe('2000px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='2000px' height='2000px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='2000px' height='2000px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 		});
 
 		it('toggles auto width', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 			const toggle = element.shadowRoot.querySelector('#toggleAutoWidth');
 			const textElement = element.shadowRoot.querySelector('#iframe_code');
@@ -251,7 +270,7 @@ describe('IframeGenerator', () => {
 			expect(widthInputElement.value).toBe('');
 			expect(iframeElement.width).toBe('100%');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='100%' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='100%' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			toggle.click();
@@ -259,20 +278,22 @@ describe('IframeGenerator', () => {
 			expect(widthInputElement.value).toBe('800');
 			expect(iframeElement.width).toBe('800px');
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 		});
 	});
 
 	describe('when iframe source changes by user interaction (drag&zoom)', () => {
 		it('renders iframe with the changed values', async () => {
+			const expectedUrl = 'https://myhost/app/embed.html?param=foo';
+			spyOn(shareServiceMock, 'encodeState').withArgs({}, [PathParameters.EMBED]).and.returnValue(expectedUrl);
 			const element = await setup();
 
 			const textElement = element.shadowRoot.querySelector('#iframe_code');
 			const iframeElement = element.shadowRoot.querySelector('iframe');
 
 			expect(textElement.value).toBe(
-				"<iframe src=https://myhost/app/embed.html?param=foo width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>"
+				`<iframe src=${expectedUrl} width='800px' height='600px' loading='lazy' frameborder='0' style='border:0'></iframe>`
 			);
 
 			iframeElement.setAttribute(IFRAME_ENCODED_STATE, 'foo');

--- a/test/plugins/IframeStatePlugin.test.js
+++ b/test/plugins/IframeStatePlugin.test.js
@@ -1,4 +1,5 @@
 import { html } from 'lit-html';
+import { PathParameters } from '../../src/domain/pathParameters';
 import { $injector } from '../../src/injection';
 import { MvuElement } from '../../src/modules/MvuElement';
 import { IframeStatePlugin } from '../../src/plugins/IframeStatePlugin';
@@ -60,7 +61,7 @@ describe('IframeState', () => {
 	it('registers postion.zoom change listeners and updates the iframes data attribute', async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
 		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
@@ -70,13 +71,14 @@ describe('IframeState', () => {
 		increaseZoom();
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		await TestUtils.timeout(0);
 	});
 
 	it('registers postion.center change listeners and updates the window history state', async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
 		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
@@ -86,13 +88,14 @@ describe('IframeState', () => {
 		changeCenter([1, 1]);
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		await TestUtils.timeout(0);
 	});
 
 	it('registers postion.rotation change listeners and updates the window history state', async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
 		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
@@ -102,13 +105,14 @@ describe('IframeState', () => {
 		changeRotation(1);
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		await TestUtils.timeout(0);
 	});
 
 	it('registers layers.active change listeners and updates the window history state', async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
 		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
@@ -118,13 +122,14 @@ describe('IframeState', () => {
 		addLayer('some');
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		await TestUtils.timeout(0);
 	});
 
 	it('updates the iframes data attribute in an asynchronous manner after plugin registration is done', async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
 		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
@@ -133,13 +138,14 @@ describe('IframeState', () => {
 
 		await TestUtils.timeout(0);
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		await TestUtils.timeout(0);
 	});
 
 	it("does nothing when encoded state has'nt changed", async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
 		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
@@ -156,6 +162,7 @@ describe('IframeState', () => {
 		// We always return the same encoded state from the ShareService,
 		// so the attribute should be updated only once
 		expect(iframeSpy).toHaveBeenCalledOnceWith(IFRAME_ENCODED_STATE, expectedEncodedState);
+		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
 		await TestUtils.timeout(0);
 	});
 

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -253,7 +253,7 @@ describe('ShareService', () => {
 					const encoded = instanceUnderTest.encodeState();
 					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-					expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}?`)).toBeTrue();
+					expect(encoded.startsWith('http://foo.bar?')).toBeTrue();
 					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
@@ -275,7 +275,7 @@ describe('ShareService', () => {
 					const encoded = instanceUnderTest.encodeState(extraParam);
 					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-					expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}?`)).toBeTrue();
+					expect(encoded.startsWith('http://foo.bar?')).toBeTrue();
 					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
@@ -289,7 +289,7 @@ describe('ShareService', () => {
 					const mockWindow = { location: location };
 					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
 					const instanceUnderTest = new ShareService();
-					const pathParameters = ['foo', 'bar'];
+					const pathParameters = ['param0', 'param1'];
 					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
 					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
 					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
@@ -297,7 +297,7 @@ describe('ShareService', () => {
 					const encoded = instanceUnderTest.encodeState({}, pathParameters);
 					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-					expect(encoded.startsWith(`${location.protocol}//${location.host}${location.pathname}foo/bar?`)).toBeTrue();
+					expect(encoded.startsWith('http://foo.bar/param0/param1?')).toBeTrue();
 					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
@@ -305,7 +305,7 @@ describe('ShareService', () => {
 				});
 			});
 
-			describe('for pathname "/some"', () => {
+			describe('for existing pathname', () => {
 				const location = {
 					protocol: 'http:',
 					host: 'foo.bar',
@@ -325,7 +325,7 @@ describe('ShareService', () => {
 					const encoded = instanceUnderTest.encodeState();
 					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-					expect(encoded.startsWith('http://foo.bar/some?')).toBeTrue();
+					expect(encoded.startsWith('http://foo.bar?')).toBeTrue();
 					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
@@ -347,7 +347,7 @@ describe('ShareService', () => {
 					const encoded = instanceUnderTest.encodeState(extraParam);
 					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-					expect(encoded.startsWith('http://foo.bar/some?')).toBeTrue();
+					expect(encoded.startsWith('http://foo.bar?')).toBeTrue();
 					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');
@@ -361,7 +361,7 @@ describe('ShareService', () => {
 					const mockWindow = { location: location };
 					spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
 					const instanceUnderTest = new ShareService();
-					const pathParameters = ['foo', 'bar'];
+					const pathParameters = ['param0', 'param1'];
 					spyOn(instanceUnderTest, '_extractPosition').and.returnValue({ z: 5, c: ['44.123', '88.123'] });
 					spyOn(instanceUnderTest, '_extractLayers').and.returnValue({ l: ['someLayer', 'anotherLayer'] });
 					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
@@ -369,7 +369,7 @@ describe('ShareService', () => {
 					const encoded = instanceUnderTest.encodeState({}, pathParameters);
 					const queryParams = new URLSearchParams(new URL(encoded).search);
 
-					expect(encoded.startsWith('http://foo.bar/some/foo/bar?')).toBeTrue();
+					expect(encoded.startsWith('http://foo.bar/param0/param1?')).toBeTrue();
 					expect(queryParams.get(QueryParameters.LAYER)).toBe('someLayer,anotherLayer');
 					expect(queryParams.get(QueryParameters.ZOOM)).toBe('5');
 					expect(queryParams.get(QueryParameters.CENTER)).toBe('44.123,88.123');


### PR DESCRIPTION
`encodeState()` will ignore an existing pathname from the current location now. If needed it always has to be requested as a path parameter,
e.g.: `shareService.encodeState({}, [PathParameters.EMBED]);`