### PR TITLE
rework state encoding

### DIFF
--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -47,6 +47,7 @@ import { BvvMfp3Encoder } from '../modules/olMap/services/Mfp3Encoder';
 import { ElevationProfilePlugin } from '../plugins/ElevationProfilePlugin';
 import { ElevationService } from '../services/ElevationService';
 import { IframeStatePlugin } from '../plugins/IframeStatePlugin';
+import { ObserveStateForEncodingPlugin } from '../plugins/ObserveStateForEncodingPlugin';
 
 $injector
 	.registerSingleton('ProjectionService', new Proj4JsService())
@@ -96,6 +97,7 @@ $injector
 	.registerSingleton('ElevationProfilePlugin', new ElevationProfilePlugin())
 	.registerSingleton('IframeStatePlugin', new IframeStatePlugin())
 	.registerSingleton('HistoryStatePlugin', new HistoryStatePlugin())
+	.registerSingleton('ObserveStateForEncodingPlugin', new ObserveStateForEncodingPlugin())
 	.registerModule(mapModule)
 	.registerModule(topicsModule)
 	.ready();

--- a/src/plugins/HistoryStatePlugin.js
+++ b/src/plugins/HistoryStatePlugin.js
@@ -12,7 +12,6 @@ export class HistoryStatePlugin extends BaPlugin {
 		const { EnvironmentService: environmentService, ShareService: shareService } = $injector.inject('EnvironmentService', 'ShareService');
 		this._environmentService = environmentService;
 		this._shareService = shareService;
-		this._currentEncodedState = null;
 	}
 
 	/**
@@ -24,19 +23,12 @@ export class HistoryStatePlugin extends BaPlugin {
 				this._updateHistory();
 			};
 
-			observe(store, (state) => state.position.zoom, updateHistory);
-			observe(store, (state) => state.position.center, updateHistory);
-			observe(store, (state) => state.position.rotation, updateHistory);
-			observe(store, (state) => state.layers.active, updateHistory);
-			setTimeout(updateHistory, 0);
+			observe(store, (state) => state.stateForEncoding.changed, updateHistory);
 		}
 	}
 
 	_updateHistory() {
 		const encodedState = this._shareService.encodeState();
-		if (this._currentEncodedState !== encodedState) {
-			this._environmentService.getWindow().history.replaceState(null, '', encodedState);
-			this._currentEncodedState = encodedState;
-		}
+		this._environmentService.getWindow().history.replaceState(null, '', encodedState);
 	}
 }

--- a/src/plugins/IframeStatePlugin.js
+++ b/src/plugins/IframeStatePlugin.js
@@ -15,7 +15,6 @@ export class IframeStatePlugin extends BaPlugin {
 		const { EnvironmentService: environmentService, ShareService: shareService } = $injector.inject('EnvironmentService', 'ShareService');
 		this._environmentService = environmentService;
 		this._shareService = shareService;
-		this._currentEncodedState = null;
 	}
 
 	/**
@@ -27,19 +26,15 @@ export class IframeStatePlugin extends BaPlugin {
 				this._updateAttribute();
 			};
 
-			observe(store, (state) => state.position.zoom, update);
-			observe(store, (state) => state.position.center, update);
-			observe(store, (state) => state.position.rotation, update);
-			observe(store, (state) => state.layers.active, update);
-			setTimeout(update, 0);
+			observe(store, (state) => state.stateForEncoding.changed, update);
 		}
 	}
 
 	_updateAttribute() {
-		const encodedState = this._shareService.encodeState({}, [PathParameters.EMBED]);
-		if (this._currentEncodedState !== encodedState) {
-			this._findIframe()?.setAttribute(IFRAME_ENCODED_STATE, encodedState);
-			this._currentEncodedState = encodedState;
+		const iframeElement = this._findIframe();
+		if (iframeElement) {
+			const encodedState = this._shareService.encodeState({}, [PathParameters.EMBED]);
+			iframeElement.setAttribute(IFRAME_ENCODED_STATE, encodedState);
 		}
 	}
 

--- a/src/plugins/ObserveStateForEncodingPlugin.js
+++ b/src/plugins/ObserveStateForEncodingPlugin.js
@@ -1,0 +1,42 @@
+import { $injector } from '../injection';
+import { indicateChange } from '../store/stateForEncoding/stateForEncoding.action';
+import { observe } from '../utils/storeUtils';
+import { BaPlugin } from './BaPlugin';
+
+/**
+ * Observes all slices-of-state that are relevant for state encoding and indicates their changes.
+ * @class
+ * @author taulinger
+ */
+export class ObserveStateForEncodingPlugin extends BaPlugin {
+	constructor() {
+		super();
+		const { ShareService: shareService } = $injector.inject('ShareService');
+		this._shareService = shareService;
+		this._currentEncodedState = null;
+	}
+
+	/**
+	 * @override
+	 */
+	async register(store) {
+		const updateStore = () => {
+			this._updateStore();
+		};
+
+		observe(store, (state) => state.position.zoom, updateStore);
+		observe(store, (state) => state.position.center, updateStore);
+		observe(store, (state) => state.position.rotation, updateStore);
+		observe(store, (state) => state.layers.active, updateStore);
+		setTimeout(updateStore, 0);
+	}
+
+	_updateStore() {
+		const encodedState = this._shareService.encodeState();
+		if (this._currentEncodedState !== encodedState) {
+			// update store
+			indicateChange();
+			this._currentEncodedState = encodedState;
+		}
+	}
+}

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -40,6 +40,7 @@ export class ShareService {
 
 	/**
 	 * Encodes the current state to a URL.
+	 * The generated URL is based on the `FRONTEND_URL` config parameter.
 	 * @param {object} [extraParams] Additional parameters. Non-existing entries will be added. Existing values will be ignored except for values that are an array.
 	 * In this case, existing values will be concatenated with the additional values.
 	 * @param {array} [pathParameters] Optional path parameters. Will be appended to the current pathname without further checks

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -87,8 +87,9 @@ export class StoreService {
 				SearchPlugin: searchPlugin,
 				ExportMfpPlugin: exportMfpPlugin,
 				ElevationProfilePlugin: elevationProfilePlugin,
-				HistoryStatePlugin: historyStatePlugin,
-				IframeStatePlugin: iframeStatePlugin
+				ObserveStateForEncodingPlugin: observeStateForEncodingPlugin,
+				IframeStatePlugin: iframeStatePlugin,
+				HistoryStatePlugin: historyStatePlugin
 			} = $injector.inject(
 				'TopicsPlugin',
 				'ChipsPlugin',
@@ -106,8 +107,9 @@ export class StoreService {
 				'SearchPlugin',
 				'ExportMfpPlugin',
 				'ElevationProfilePlugin',
+				'IframeStatePlugin',
 				'HistoryStatePlugin',
-				'IframeStatePlugin'
+				'ObserveStateForEncodingPlugin'
 			);
 
 			setTimeout(async () => {
@@ -128,8 +130,10 @@ export class StoreService {
 				await searchPlugin.register(this._store);
 				await exportMfpPlugin.register(this._store);
 				await elevationProfilePlugin.register(this._store);
+				await elevationProfilePlugin.register(this._store);
 				await iframeStatePlugin.register(this._store);
 				await historyStatePlugin.register(this._store); // should be registered as last plugin
+				await observeStateForEncodingPlugin.register(this._store); // should be registered as last plugin
 			});
 		});
 	}

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -132,7 +132,7 @@ export class StoreService {
 				await elevationProfilePlugin.register(this._store);
 				await elevationProfilePlugin.register(this._store);
 				await iframeStatePlugin.register(this._store);
-				await historyStatePlugin.register(this._store); // should be registered as last plugin
+				await historyStatePlugin.register(this._store);
 				await observeStateForEncodingPlugin.register(this._store); // should be registered as last plugin
 			});
 		});

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -25,6 +25,7 @@ import { mfpReducer } from '../store/mfp/mfp.reducer';
 import { bottomSheetReducer } from '../store/bottomSheet/bottomSheet.reducer';
 import { elevationProfileReducer } from '../store/elevationProfile/elevationProfile.reducer';
 import { chipsReducer } from '../store/chips/chips.reducer';
+import { stateForEncodingReducer } from '../store/stateForEncoding/stateForEncoding.reducer';
 
 /**
  * Service which configures, initializes and holds the redux store.
@@ -62,7 +63,8 @@ export class StoreService {
 			mfp: mfpReducer,
 			bottomSheet: bottomSheetReducer,
 			elevationProfile: elevationProfileReducer,
-			chips: chipsReducer
+			chips: chipsReducer,
+			stateForEncoding: stateForEncodingReducer
 		});
 
 		this._store = createStore(rootReducer);

--- a/src/store/stateForEncoding/stateForEncoding.action.js
+++ b/src/store/stateForEncoding/stateForEncoding.action.js
@@ -1,0 +1,22 @@
+/**
+ * @module stateForEncoding/action
+ */
+import { STATE_FORE_ENCODING_CHANGED } from './stateForEncoding.reducer';
+import { $injector } from '../../injection';
+import { EventLike } from '../../utils/storeUtils';
+
+const getStore = () => {
+	const { StoreService: storeService } = $injector.inject('StoreService');
+	return storeService.getStore();
+};
+
+/**
+ * Indicates that the for encoding observed slices-of-state changed.
+ * @function
+ */
+export const indicateChange = () => {
+	getStore().dispatch({
+		type: STATE_FORE_ENCODING_CHANGED,
+		payload: new EventLike(null)
+	});
+};

--- a/src/store/stateForEncoding/stateForEncoding.reducer.js
+++ b/src/store/stateForEncoding/stateForEncoding.reducer.js
@@ -1,0 +1,24 @@
+import { EventLike } from '../../utils/storeUtils';
+
+export const STATE_FORE_ENCODING_CHANGED = 'stateForEncoding/changed';
+
+export const initialState = {
+	/**
+	 * @type {EventLike<string>}
+	 */
+	changed: new EventLike(null)
+};
+
+export const stateForEncodingReducer = (state = initialState, action) => {
+	const { type, payload } = action;
+	switch (type) {
+		case STATE_FORE_ENCODING_CHANGED: {
+			return {
+				...state,
+				changed: payload
+			};
+		}
+	}
+
+	return state;
+};

--- a/test/injection/config.test.js
+++ b/test/injection/config.test.js
@@ -6,7 +6,7 @@ import { Injector } from '../../src/injection/core/injector.js';
 describe('injector configuration', () => {
 	it('registers the expected dependencies', () => {
 		expect($injector.isReady()).toBeTrue();
-		expect($injector.count()).toBe(59);
+		expect($injector.count()).toBe(60);
 
 		expect($injector.getScope('ProjectionService')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HttpService')).toBe(Injector.SCOPE_PERLOOKUP);
@@ -54,6 +54,7 @@ describe('injector configuration', () => {
 		expect($injector.getScope('ElevationProfilePlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('IframeStatePlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HistoryStatePlugin')).toBe(Injector.SCOPE_SINGLETON);
+		expect($injector.getScope('ObserveStateForEncodingPlugin')).toBe(Injector.SCOPE_SINGLETON);
 
 		// map module
 		expect($injector.getScope('StyleService')).toBe(Injector.SCOPE_SINGLETON);

--- a/test/plugins/HistoryStatePlugin.test.js
+++ b/test/plugins/HistoryStatePlugin.test.js
@@ -49,7 +49,8 @@ describe('HistoryState', () => {
 		const updateHistorySpy = spyOn(instanceUnderTest, '_updateHistory');
 		await instanceUnderTest.register(store);
 
-		await TestUtils.timeout(0);
+		indicateChange();
+
 		expect(updateHistorySpy).not.toHaveBeenCalled();
 	});
 });

--- a/test/plugins/HistoryStatePlugin.test.js
+++ b/test/plugins/HistoryStatePlugin.test.js
@@ -1,9 +1,7 @@
 import { $injector } from '../../src/injection';
 import { HistoryStatePlugin } from '../../src/plugins/HistoryStatePlugin';
-import { addLayer } from '../../src/store/layers/layers.action';
-import { layersReducer } from '../../src/store/layers/layers.reducer';
-import { changeCenter, changeRotation, increaseZoom } from '../../src/store/position/position.action';
-import { positionReducer } from '../../src/store/position/position.reducer';
+import { indicateChange } from '../../src/store/stateForEncoding/stateForEncoding.action';
+import { stateForEncodingReducer } from '../../src/store/stateForEncoding/stateForEncoding.reducer';
 import { TestUtils } from '../test-utils';
 
 describe('HistoryState', () => {
@@ -14,33 +12,20 @@ describe('HistoryState', () => {
 		getWindow: () => {},
 		isEmbedded: () => {}
 	};
-	const mapService = {
-		getMaxZoomLevel: () => 1,
-		getMinZoomLevel: () => 0
-	};
 
 	const setup = () => {
-		const state = {
-			position: {
-				zoom: 0,
-				pointerPosition: [0, 0],
-				rotation: 0
+		const store = TestUtils.setupStoreAndDi(
+			{},
+			{
+				stateForEncoding: stateForEncodingReducer
 			}
-		};
-
-		const store = TestUtils.setupStoreAndDi(state, {
-			position: positionReducer,
-			layers: layersReducer
-		});
-		$injector
-			.registerSingleton('EnvironmentService', environmentService)
-			.registerSingleton('ShareService', shareService)
-			.registerSingleton('MapService', mapService);
+		);
+		$injector.registerSingleton('EnvironmentService', environmentService).registerSingleton('ShareService', shareService);
 		return store;
 	};
 
-	it('registers postion.zoom change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
+	it('registers stateForEncoding.changed listeners and updates the window history state', async () => {
+		const expectedEncodedState = 'state';
 		const mockHistory = { replaceState: () => {} };
 		const historySpy = spyOn(mockHistory, 'replaceState');
 		const mockWindow = { history: mockHistory };
@@ -51,104 +36,10 @@ describe('HistoryState', () => {
 		const instanceUnderTest = new HistoryStatePlugin();
 		await instanceUnderTest.register(store);
 
-		increaseZoom();
+		indicateChange();
 
 		expect(historySpy).toHaveBeenCalledWith(null, '', expectedEncodedState);
 		await TestUtils.timeout(0);
-	});
-
-	it('registers postion.center change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
-		const mockHistory = { replaceState: () => {} };
-		const historySpy = spyOn(mockHistory, 'replaceState');
-		const mockWindow = { history: mockHistory };
-		spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new HistoryStatePlugin();
-		await instanceUnderTest.register(store);
-
-		changeCenter([1, 1]);
-
-		expect(historySpy).toHaveBeenCalledWith(null, '', expectedEncodedState);
-		await TestUtils.timeout(0);
-	});
-
-	it('registers postion.rotation change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
-		const mockHistory = { replaceState: () => {} };
-		const historySpy = spyOn(mockHistory, 'replaceState');
-		const mockWindow = { history: mockHistory };
-		spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new HistoryStatePlugin();
-		await instanceUnderTest.register(store);
-
-		changeRotation(1);
-
-		expect(historySpy).toHaveBeenCalledWith(null, '', expectedEncodedState);
-		await TestUtils.timeout(0);
-	});
-
-	it('registers layers.active change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
-		const mockHistory = { replaceState: () => {} };
-		const historySpy = spyOn(mockHistory, 'replaceState');
-		const mockWindow = { history: mockHistory };
-		spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new HistoryStatePlugin();
-		await instanceUnderTest.register(store);
-
-		addLayer('some');
-
-		expect(historySpy).toHaveBeenCalledWith(null, '', expectedEncodedState);
-		await TestUtils.timeout(0);
-	});
-
-	it('updates the window history state in an asynchronous manner after plugin registration is done', async () => {
-		const expectedEncodedState = 'foo';
-		const mockHistory = { replaceState: () => {} };
-		const historySpy = spyOn(mockHistory, 'replaceState');
-		const mockWindow = { history: mockHistory };
-		spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new HistoryStatePlugin();
-		await instanceUnderTest.register(store);
-
-		await TestUtils.timeout(0);
-		expect(historySpy).toHaveBeenCalledWith(null, '', expectedEncodedState);
-	});
-
-	it("does nothing when encoded state has'nt changed", async () => {
-		const expectedEncodedState = 'foo';
-		const mockHistory = { replaceState: () => {} };
-		const historySpy = spyOn(mockHistory, 'replaceState');
-		const mockWindow = { history: mockHistory };
-		spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
-		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
-		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new HistoryStatePlugin();
-		await instanceUnderTest.register(store);
-		await TestUtils.timeout(0);
-
-		// Let's trigger one observer multiple times
-		changeCenter([1, 1]);
-		changeCenter([1, 2]);
-		changeCenter([1, 3]);
-		changeCenter([1, 4]);
-
-		// We always return the same encoded state from the ShareService,
-		// so the history API should be called only once
-		expect(historySpy).toHaveBeenCalledOnceWith(null, '', expectedEncodedState);
 	});
 
 	it("does nothing when we are in 'embed' mode", async () => {

--- a/test/plugins/IframeStatePlugin.test.js
+++ b/test/plugins/IframeStatePlugin.test.js
@@ -3,10 +3,8 @@ import { PathParameters } from '../../src/domain/pathParameters';
 import { $injector } from '../../src/injection';
 import { MvuElement } from '../../src/modules/MvuElement';
 import { IframeStatePlugin } from '../../src/plugins/IframeStatePlugin';
-import { addLayer } from '../../src/store/layers/layers.action';
-import { layersReducer } from '../../src/store/layers/layers.reducer';
-import { changeCenter, changeRotation, increaseZoom } from '../../src/store/position/position.action';
-import { positionReducer } from '../../src/store/position/position.reducer';
+import { indicateChange } from '../../src/store/stateForEncoding/stateForEncoding.action';
+import { stateForEncodingReducer } from '../../src/store/stateForEncoding/stateForEncoding.reducer';
 import { IFRAME_ENCODED_STATE } from '../../src/utils/markup';
 import { TestUtils } from '../test-utils';
 
@@ -29,36 +27,23 @@ describe('IframeState', () => {
 		getWindow: () => {},
 		isEmbedded: () => {}
 	};
-	const mapService = {
-		getMaxZoomLevel: () => 1,
-		getMinZoomLevel: () => 0
-	};
 
 	const mockIframeElement = {
 		setAttribute: () => {}
 	};
 
 	const setup = () => {
-		const state = {
-			position: {
-				zoom: 0,
-				pointerPosition: [0, 0],
-				rotation: 0
+		const store = TestUtils.setupStoreAndDi(
+			{},
+			{
+				stateForEncoding: stateForEncodingReducer
 			}
-		};
-
-		const store = TestUtils.setupStoreAndDi(state, {
-			position: positionReducer,
-			layers: layersReducer
-		});
-		$injector
-			.registerSingleton('EnvironmentService', environmentService)
-			.registerSingleton('ShareService', shareService)
-			.registerSingleton('MapService', mapService);
+		);
+		$injector.registerSingleton('EnvironmentService', environmentService).registerSingleton('ShareService', shareService);
 		return store;
 	};
 
-	it('registers postion.zoom change listeners and updates the iframes data attribute', async () => {
+	it('registers stateForEncoding.changed listeners and updates the iframes data attribute', async () => {
 		const expectedEncodedState = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
 		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
@@ -68,102 +53,23 @@ describe('IframeState', () => {
 		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
 		await instanceUnderTest.register(store);
 
-		increaseZoom();
+		indicateChange();
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
 		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
-		await TestUtils.timeout(0);
 	});
 
-	it('registers postion.center change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
+	it('does nothing when iframe element is not available', async () => {
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
 		const store = setup();
 		const instanceUnderTest = new IframeStatePlugin();
-		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
-		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(null);
+		const shareServiceSpy = spyOn(shareService, 'encodeState');
 		await instanceUnderTest.register(store);
 
-		changeCenter([1, 1]);
+		indicateChange();
 
-		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
-		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
-		await TestUtils.timeout(0);
-	});
-
-	it('registers postion.rotation change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
-		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new IframeStatePlugin();
-		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
-		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
-		await instanceUnderTest.register(store);
-
-		changeRotation(1);
-
-		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
-		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
-		await TestUtils.timeout(0);
-	});
-
-	it('registers layers.active change listeners and updates the window history state', async () => {
-		const expectedEncodedState = 'foo';
-		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new IframeStatePlugin();
-		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
-		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
-		await instanceUnderTest.register(store);
-
-		addLayer('some');
-
-		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
-		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
-		await TestUtils.timeout(0);
-	});
-
-	it('updates the iframes data attribute in an asynchronous manner after plugin registration is done', async () => {
-		const expectedEncodedState = 'foo';
-		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new IframeStatePlugin();
-		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
-		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
-		await instanceUnderTest.register(store);
-
-		await TestUtils.timeout(0);
-		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_ENCODED_STATE, expectedEncodedState);
-		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
-		await TestUtils.timeout(0);
-	});
-
-	it("does nothing when encoded state has'nt changed", async () => {
-		const expectedEncodedState = 'foo';
-		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
-		const shareServiceSpy = spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
-		const store = setup();
-		const instanceUnderTest = new IframeStatePlugin();
-		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
-		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
-		await instanceUnderTest.register(store);
-		await TestUtils.timeout(0);
-
-		// Let's trigger one observer multiple times
-		changeCenter([1, 1]);
-		changeCenter([1, 2]);
-		changeCenter([1, 3]);
-		changeCenter([1, 4]);
-
-		// We always return the same encoded state from the ShareService,
-		// so the attribute should be updated only once
-		expect(iframeSpy).toHaveBeenCalledOnceWith(IFRAME_ENCODED_STATE, expectedEncodedState);
-		expect(shareServiceSpy).toHaveBeenCalledWith({}, [PathParameters.EMBED]);
-		await TestUtils.timeout(0);
+		expect(shareServiceSpy).not.toHaveBeenCalled();
 	});
 
 	it("does nothing when we are NOT in 'embed' mode", async () => {
@@ -173,7 +79,8 @@ describe('IframeState', () => {
 		const updateAttributeSpy = spyOn(instanceUnderTest, '_updateAttribute');
 		await instanceUnderTest.register(store);
 
-		await TestUtils.timeout(0);
+		indicateChange();
+
 		expect(updateAttributeSpy).not.toHaveBeenCalled();
 	});
 

--- a/test/plugins/ObserveStateForEncodingPlugin.test.js
+++ b/test/plugins/ObserveStateForEncodingPlugin.test.js
@@ -30,7 +30,7 @@ describe('ObserveStateForEncodingPlugin', () => {
 		return store;
 	};
 
-	it('registers postion.zoom change listeners and indictate its changes', async () => {
+	it('registers position.zoom change listeners and indictate its changes', async () => {
 		const store = setup();
 		spyOn(shareService, 'encodeState').and.callFake(() => {
 			// let's return a different state each call
@@ -44,7 +44,7 @@ describe('ObserveStateForEncodingPlugin', () => {
 		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
 	});
 
-	it('registers postion.center change listeners and and indictate its changes', async () => {
+	it('registers position.center change listeners and and indictate its changes', async () => {
 		const store = setup();
 		spyOn(shareService, 'encodeState').and.callFake(() => {
 			// let's return a different state each call
@@ -58,7 +58,7 @@ describe('ObserveStateForEncodingPlugin', () => {
 		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
 	});
 
-	it('registers postion.rotation change listeners and and indictate its changes', async () => {
+	it('registers position.rotation change listeners and and indictate its changes', async () => {
 		const store = setup();
 		spyOn(shareService, 'encodeState').and.callFake(() => {
 			// let's return a different state each call

--- a/test/plugins/ObserveStateForEncodingPlugin.test.js
+++ b/test/plugins/ObserveStateForEncodingPlugin.test.js
@@ -1,0 +1,119 @@
+import { $injector } from '../../src/injection';
+import { ObserveStateForEncodingPlugin } from '../../src/plugins/ObserveStateForEncodingPlugin';
+import { stateForEncodingReducer, initialState } from '../../src/store/stateForEncoding/stateForEncoding.reducer';
+import { addLayer } from '../../src/store/layers/layers.action';
+import { layersReducer } from '../../src/store/layers/layers.reducer';
+import { changeCenter, changeRotation, increaseZoom } from '../../src/store/position/position.action';
+import { positionReducer } from '../../src/store/position/position.reducer';
+import { TestUtils } from '../test-utils';
+
+describe('ObserveStateForEncodingPlugin', () => {
+	const shareService = {
+		encodeState() {}
+	};
+	const mapService = {
+		getMaxZoomLevel: () => 2,
+		getMinZoomLevel: () => 0
+	};
+
+	const setup = () => {
+		const state = {
+			encodedState: initialState
+		};
+
+		const store = TestUtils.setupStoreAndDi(state, {
+			position: positionReducer,
+			layers: layersReducer,
+			encodedState: stateForEncodingReducer
+		});
+		$injector.registerSingleton('ShareService', shareService).registerSingleton('MapService', mapService);
+		return store;
+	};
+
+	it('registers postion.zoom change listeners and indictate its changes', async () => {
+		const store = setup();
+		spyOn(shareService, 'encodeState').and.callFake(() => {
+			// let's return a different state each call
+			return `state_${Math.random()}`;
+		});
+		const instanceUnderTest = new ObserveStateForEncodingPlugin();
+		await instanceUnderTest.register(store);
+
+		increaseZoom();
+
+		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
+	});
+
+	it('registers postion.center change listeners and and indictate its changes', async () => {
+		const store = setup();
+		spyOn(shareService, 'encodeState').and.callFake(() => {
+			// let's return a different state each call
+			return `state_${Math.random()}`;
+		});
+		const instanceUnderTest = new ObserveStateForEncodingPlugin();
+		await instanceUnderTest.register(store);
+
+		changeCenter([1, 1]);
+
+		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
+	});
+
+	it('registers postion.rotation change listeners and and indictate its changes', async () => {
+		const store = setup();
+		spyOn(shareService, 'encodeState').and.callFake(() => {
+			// let's return a different state each call
+			return `state_${Math.random()}`;
+		});
+		const instanceUnderTest = new ObserveStateForEncodingPlugin();
+		await instanceUnderTest.register(store);
+
+		changeRotation(1);
+
+		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
+	});
+
+	it('registers layers.active change listeners and and indictate its changes', async () => {
+		const store = setup();
+		spyOn(shareService, 'encodeState').and.callFake(() => {
+			// let's return a different state each call
+			return `state_${Math.random()}`;
+		});
+		const instanceUnderTest = new ObserveStateForEncodingPlugin();
+		await instanceUnderTest.register(store);
+
+		addLayer('some');
+
+		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
+	});
+
+	it('and indictate its changes in an asynchronous manner after plugin registration is done', async () => {
+		const store = setup();
+		spyOn(shareService, 'encodeState').and.callFake(() => {
+			// let's return a different state each call
+			return `state_${Math.random()}`;
+		});
+		const instanceUnderTest = new ObserveStateForEncodingPlugin();
+		await instanceUnderTest.register(store);
+
+		await TestUtils.timeout(0);
+		expect(store.getState().encodedState.changed).not.toEqual(initialState.changed);
+	});
+
+	it("does nothing when encoded state hasn't changed", async () => {
+		const store = setup();
+		// We always return the same encoded state from the ShareService,
+		spyOn(shareService, 'encodeState').and.returnValue('state');
+		const instanceUnderTest = new ObserveStateForEncodingPlugin();
+		await instanceUnderTest.register(store);
+		await TestUtils.timeout(0);
+
+		// Let's trigger one observer multiple times
+		changeCenter([1, 1]);
+		const changedPropertyAfterFirstMutation = store.getState().encodedState.changed;
+		changeCenter([1, 2]);
+		changeCenter([1, 3]);
+		changeCenter([1, 4]);
+
+		expect(changedPropertyAfterFirstMutation).toEqual(store.getState().encodedState.changed);
+	});
+});

--- a/test/service/StoreService.test.js
+++ b/test/service/StoreService.test.js
@@ -64,6 +64,9 @@ describe('StoreService', () => {
 		const historyStatePluginMock = {
 			register: () => {}
 		};
+		const observeStateForEncodingPluginMock = {
+			register: () => {}
+		};
 
 		const setupInjector = () => {
 			$injector
@@ -88,6 +91,7 @@ describe('StoreService', () => {
 				.registerSingleton('ChipsPlugin', chipsPlugin)
 				.registerSingleton('IframeStatePlugin', iframeStatePluginMock)
 				.registerSingleton('HistoryStatePlugin', historyStatePluginMock)
+				.registerSingleton('ObserveStateForEncodingPlugin', observeStateForEncodingPluginMock)
 
 				.ready();
 		};
@@ -146,6 +150,7 @@ describe('StoreService', () => {
 			const elevationProfilePluginSpy = spyOn(elevationProfilePluginMock, 'register');
 			const iframeStatePluginSpy = spyOn(iframeStatePluginMock, 'register');
 			const historyStatePluginSpy = spyOn(historyStatePluginMock, 'register');
+			const observeStateForEncodingPluginSpy = spyOn(observeStateForEncodingPluginMock, 'register');
 			const instanceUnderTest = new StoreService();
 
 			setupInjector();
@@ -172,6 +177,7 @@ describe('StoreService', () => {
 			expect(elevationProfilePluginSpy).toHaveBeenCalledWith(store);
 			expect(iframeStatePluginSpy).toHaveBeenCalledWith(store);
 			expect(historyStatePluginSpy).toHaveBeenCalledWith(store);
+			expect(observeStateForEncodingPluginSpy).toHaveBeenCalledWith(store);
 		});
 	});
 });

--- a/test/service/StoreService.test.js
+++ b/test/service/StoreService.test.js
@@ -99,7 +99,7 @@ describe('StoreService', () => {
 			expect(store).toBeDefined();
 
 			const reducerKeys = Object.keys(store.getState());
-			expect(reducerKeys.length).toBe(25);
+			expect(reducerKeys.length).toBe(26);
 			expect(reducerKeys.includes('map')).toBeTrue();
 			expect(reducerKeys.includes('pointer')).toBeTrue();
 			expect(reducerKeys.includes('position')).toBeTrue();
@@ -125,6 +125,7 @@ describe('StoreService', () => {
 			expect(reducerKeys.includes('bottomSheet')).toBeTrue();
 			expect(reducerKeys.includes('elevationProfile')).toBeTrue();
 			expect(reducerKeys.includes('chips')).toBeTrue();
+			expect(reducerKeys.includes('stateForEncoding')).toBeTrue();
 		});
 
 		it('registers all plugins', async () => {

--- a/test/store/stateForEncoding/stateForEncoding.reducer.test.js
+++ b/test/store/stateForEncoding/stateForEncoding.reducer.test.js
@@ -1,0 +1,28 @@
+import { indicateChange } from '../../../src/store/stateForEncoding/stateForEncoding.action';
+import { stateForEncodingReducer } from '../../../src/store/stateForEncoding/stateForEncoding.reducer';
+import { EventLike } from '../../../src/utils/storeUtils';
+import { TestUtils } from '../../test-utils';
+
+describe('stateForEncodingReducer', () => {
+	const setup = (state) => {
+		return TestUtils.setupStoreAndDi(state, {
+			stateForEncoding: stateForEncodingReducer
+		});
+	};
+
+	it('initiales the store with default values', () => {
+		const store = setup();
+		expect(store.getState().stateForEncoding.changed.payload).toBeNull;
+		expect(store.getState().stateForEncoding.changed).toBeInstanceOf(EventLike);
+	});
+
+	it('updates the `changed` property', () => {
+		const store = setup();
+		const initialPayload = store.getState().stateForEncoding.changed;
+
+		indicateChange();
+
+		expect(store.getState().stateForEncoding.changed).not.toEqual(initialPayload);
+		expect(store.getState().stateForEncoding.changed).toBeInstanceOf(EventLike);
+	});
+});


### PR DESCRIPTION
Adds a central observer on encoding-relevant parts of our state.
Other modules interested in encoding-relevant state changes just have to observe `stateForEncoding.changed` now.
