### PR TITLE
IframeGeometryIdPlugin

### DIFF
--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -52,6 +52,7 @@ import { SharePlugin } from '../plugins/SharePlugin';
 import { MapFeedbackService } from '../services/MapFeedbackService';
 import { IframeContainerPlugin } from '../plugins/IframeContainerPlugin';
 import { ToolsPlugin } from '../plugins/ToolsPlugin';
+import { IframeGeometryIdPlugin } from '../plugins/IframeGeometryIdPlugin';
 
 $injector
 	.registerSingleton('ProjectionService', new Proj4JsService())
@@ -104,6 +105,7 @@ $injector
 	.registerSingleton('IframeContainerPlugin', new IframeContainerPlugin())
 	.registerSingleton('SharePlugin', new SharePlugin())
 	.registerSingleton('ToolsPlugin', new ToolsPlugin())
+	.registerSingleton('IframeGeometryIdPlugin', new IframeGeometryIdPlugin())
 	.registerSingleton('HistoryStatePlugin', new HistoryStatePlugin())
 	.registerSingleton('ObserveStateForEncodingPlugin', new ObserveStateForEncodingPlugin())
 	.registerModule(mapModule)

--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -17,7 +17,15 @@ import { StyleTypes } from '../../services/StyleService';
 import { StyleSizeTypes } from '../../../../domain/styles';
 import MapBrowserEventType from 'ol/MapBrowserEventType';
 import { equals, observe } from '../../../../utils/storeUtils';
-import { setSelectedStyle, setStyle, setType, setGeometryIsValid, setSelection, setDescription } from '../../../../store/draw/draw.action';
+import {
+	setSelectedStyle,
+	setStyle,
+	setType,
+	setGeometryIsValid,
+	setSelection,
+	setDescription,
+	setFileSaveResult
+} from '../../../../store/draw/draw.action';
 import { unByKey } from 'ol/Observable';
 import { create as createKML } from '../../formats/kml';
 import {
@@ -823,7 +831,8 @@ export class OlDrawHandler extends OlLayerHandler {
 	async _save() {
 		const newContent = createKML(this._vectorLayer, 'EPSG:3857');
 		this._storedContent = newContent;
-		this._storageHandler.store(newContent, FileStorageServiceDataTypes.KML);
+		const fileSaveResult = await this._storageHandler.store(newContent, FileStorageServiceDataTypes.KML);
+		setFileSaveResult({ fileSaveResult, content: newContent });
 	}
 
 	async _saveAndOptionallyConvertToPermanentLayer() {

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -5,7 +5,7 @@ import { unByKey } from 'ol/Observable';
 import { LineString, Polygon } from 'ol/geom';
 import { $injector } from '../../../../injection';
 import { OlLayerHandler } from '../OlLayerHandler';
-import { setStatistic, setMode, setSelection } from '../../../../store/measurement/measurement.action';
+import { setStatistic, setMode, setSelection, setFileSaveResult } from '../../../../store/measurement/measurement.action';
 import { addLayer, removeLayer } from '../../../../store/layers/layers.action';
 import { createSketchStyleFunction, selectStyleFunction } from '../../utils/olStyleUtils';
 import { getStats } from '../../utils/olGeometryUtils';
@@ -658,8 +658,9 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		features.forEach((f) => saveManualOverlayPosition(f));
 
 		const newContent = createKML(this._vectorLayer, 'EPSG:3857');
-		this._storageHandler.store(newContent, FileStorageServiceDataTypes.KML);
 		this._storedContent = newContent;
+		const fileSaveResult = await this._storageHandler.store(newContent, FileStorageServiceDataTypes.KML);
+		setFileSaveResult({ fileSaveResult, content: newContent });
 	}
 
 	async _convertToPermanentLayer() {

--- a/src/modules/olMap/services/InteractionStorageService.js
+++ b/src/modules/olMap/services/InteractionStorageService.js
@@ -7,6 +7,7 @@ const Temp_Session_Id = 'temp_session_id';
  * Facade for FileStorageService and StoreService,
  * to provide interaction-based LayerHandlers a simplified access for storage-functionality
  *
+ * Todo: Let's move the synchronization of the shared slice-of-state to a plugin (e.g. SharePlugin)
  * @class
  * @author thiloSchlemmer
  */
@@ -93,6 +94,7 @@ export class InteractionStorageService {
 				try {
 					const fileSaveResult = await fileStorageService.save(shared.fileSaveResult.adminId, content, type);
 					setSharedFileSaveResult(fileSaveResult);
+					return fileSaveResult;
 				} catch (error) {
 					console.warn('Could not store content:', error);
 				}
@@ -100,6 +102,7 @@ export class InteractionStorageService {
 				try {
 					const fileSaveResult = await fileStorageService.save(null, content, type);
 					setSharedFileSaveResult(fileSaveResult);
+					return fileSaveResult;
 				} catch (error) {
 					console.warn('Could not store content initially:', error);
 					setSharedFileSaveResult(null);
@@ -108,5 +111,6 @@ export class InteractionStorageService {
 		} else {
 			setSharedFileSaveResult(null);
 		}
+		return null;
 	}
 }

--- a/src/plugins/IframeGeometryIdPlugin.js
+++ b/src/plugins/IframeGeometryIdPlugin.js
@@ -5,7 +5,7 @@ import { BaPlugin } from './BaPlugin';
 
 /**
  * Checks if a surrounding iframe exists and contains the {@link IFRAME_GEOMETRY_REFERENCE_ID } data attribute.
- * If so, it updates the value of the attribute on changes of the fileSaveResult property of the draw slice-of-state
+ * If so, it updates the attribute's value on changes in the fileSaveResult property of the draw slice-of-state.
  * @author taulinger
  */
 export class IframeGeometryIdPlugin extends BaPlugin {

--- a/src/plugins/IframeGeometryIdPlugin.js
+++ b/src/plugins/IframeGeometryIdPlugin.js
@@ -4,8 +4,8 @@ import { observe } from '../utils/storeUtils';
 import { BaPlugin } from './BaPlugin';
 
 /**
- * Checks if a surrounding iframe exists and contains the {@link IFRAME_GEOMETRY_REFERENCE_ID } data-attribute.
- * If so, it updates the attributes value on changes of the fileSaveResult property of the draw slice-of-state
+ * Checks if a surrounding iframe exists and contains the {@link IFRAME_GEOMETRY_REFERENCE_ID } data attribute.
+ * If so, it updates the value of the attribute on changes of the fileSaveResult property of the draw slice-of-state
  * @author taulinger
  */
 export class IframeGeometryIdPlugin extends BaPlugin {

--- a/src/plugins/IframeGeometryIdPlugin.js
+++ b/src/plugins/IframeGeometryIdPlugin.js
@@ -1,0 +1,47 @@
+import { $injector } from '../injection';
+import { findAllBySelector, IFRAME_GEOMETRY_REFERENCE_ID } from '../utils/markup';
+import { observe } from '../utils/storeUtils';
+import { BaPlugin } from './BaPlugin';
+
+/**
+ * Checks if a surrounding iframe exists and contains the {@link IFRAME_GEOMETRY_REFERENCE_ID } data-attribute.
+ * If so, it updates the attributes value on changes of the fileSaveResult property of the draw slice-of-state
+ * @author taulinger
+ */
+export class IframeGeometryIdPlugin extends BaPlugin {
+	constructor() {
+		super();
+		const { EnvironmentService: environmentService } = $injector.inject('EnvironmentService');
+		this._environmentService = environmentService;
+	}
+
+	/**
+	 * @override
+	 */
+	async register(store) {
+		if (this._environmentService.isEmbedded()) {
+			const update = (eventLike) => {
+				const {
+					payload: {
+						fileSaveResult: { fileId }
+					}
+				} = eventLike;
+				this._updateAttribute(fileId);
+			};
+
+			observe(store, (state) => state.draw.fileSaveResult, update);
+		}
+	}
+
+	_updateAttribute(fileId) {
+		this._findIframe()?.setAttribute(IFRAME_GEOMETRY_REFERENCE_ID, fileId);
+	}
+
+	_findIframe() {
+		return findAllBySelector(this._getDocument(), `iframe[${IFRAME_GEOMETRY_REFERENCE_ID}]`)[0];
+	}
+
+	_getDocument() {
+		return this._environmentService.getWindow().parent.document;
+	}
+}

--- a/src/plugins/IframeStatePlugin.js
+++ b/src/plugins/IframeStatePlugin.js
@@ -5,8 +5,8 @@ import { observe } from '../utils/storeUtils';
 import { BaPlugin } from './BaPlugin';
 
 /**
- * Checks if a surrounding iframe exists and contains the {@link IFRAME_ENCODED_STATE } data-attribute.
- * If so, it updates the attributes value on state changes.
+ * Checks if a surrounding iframe exists and contains the {@link IFRAME_ENCODED_STATE } data attribute.
+ * If so, it updates the attribute's value on state changes.
  * @author taulinger
  */
 export class IframeStatePlugin extends BaPlugin {

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -89,12 +89,13 @@ export class StoreService {
 				SearchPlugin: searchPlugin,
 				ExportMfpPlugin: exportMfpPlugin,
 				ElevationProfilePlugin: elevationProfilePlugin,
-				ObserveStateForEncodingPlugin: observeStateForEncodingPlugin,
 				IframeStatePlugin: iframeStatePlugin,
 				IframeContainerPlugin: iframeContainerPlugin,
 				SharePlugin: sharePlugin,
 				ToolsPlugin: toolsPlugin,
-				HistoryStatePlugin: historyStatePlugin
+				IframeGeometryIdPlugin: iframeGeometryIdPlugin,
+				HistoryStatePlugin: historyStatePlugin,
+				ObserveStateForEncodingPlugin: observeStateForEncodingPlugin
 			} = $injector.inject(
 				'TopicsPlugin',
 				'ChipsPlugin',
@@ -116,6 +117,7 @@ export class StoreService {
 				'IframeContainerPlugin',
 				'SharePlugin',
 				'ToolsPlugin',
+				'IframeGeometryIdPlugin',
 				'HistoryStatePlugin',
 				'ObserveStateForEncodingPlugin'
 			);
@@ -142,6 +144,7 @@ export class StoreService {
 				await iframeContainerPlugin.register(this._store);
 				await sharePlugin.register(this._store);
 				await toolsPlugin.register(this._store);
+				await iframeGeometryIdPlugin.register(this._store);
 				await historyStatePlugin.register(this._store);
 				await observeStateForEncodingPlugin.register(this._store); // should be registered as last plugin
 			});

--- a/src/store/draw/draw.action.js
+++ b/src/store/draw/draw.action.js
@@ -22,10 +22,10 @@ import { $injector } from '../../injection';
 import { EventLike } from '../../utils/storeUtils';
 
 /**
- * MetaData of a successfully saved drawing (@see {@link FileSaveResult}).
+ * MetaData and content of a successfully saved drawing (@see {@link FileSaveResult}).
  * @typedef {Object} DrawFileSaveResult
- * @property {string} adminId The adminId of the succesfully saved drawing
- * @property {string} fileId The fileId of the succesfully saved drawing
+ * @property {FileSaveResult} fileSaveResult the FileSaveResult
+ * @property {string} content the content (geometry) that was saved
  */
 
 /**
@@ -159,7 +159,7 @@ export const clearText = () => {
 export const setFileSaveResult = (fileSaveResult) => {
 	getStore().dispatch({
 		type: FILE_SAVE_RESULT_CHANGED,
-		payload: fileSaveResult
+		payload: new EventLike(fileSaveResult)
 	});
 };
 

--- a/src/store/draw/draw.reducer.js
+++ b/src/store/draw/draw.reducer.js
@@ -1,3 +1,5 @@
+import { EventLike } from '../../utils/storeUtils';
+
 export const ACTIVE_CHANGED = 'draw/active';
 export const MODE_CHANGED = 'draw/mode';
 export const TYPE_CHANGED = 'draw/type';
@@ -54,9 +56,9 @@ export const initialState = {
 	 */
 	description: null,
 	/**
-	 * @type {DrawFileSaveResult}
+	 * @type {EventLike<DrawFileSaveResult>}
 	 */
-	fileSaveResult: null,
+	fileSaveResult: new EventLike(null),
 	/**
 	 * @type {Array<String>}
 	 */

--- a/src/store/measurement/measurement.action.js
+++ b/src/store/measurement/measurement.action.js
@@ -25,8 +25,8 @@ import { EventLike } from '../../utils/storeUtils';
 /**
  * MetaData of a successfully saved measurement (@see {@link FileSaveResult}).
  * @typedef {Object} MeasureFileSaveResult
- * @property {string} adminId The adminId of the succesfully saved measurement
- * @property {string} fileId The fileId of the succesfully saved measurement
+ * @property {FileSaveResult} fileSaveResult the FileSaveResult
+ * @property {string} content the content (geometry) that was saved
  */
 
 const getStore = () => {
@@ -87,7 +87,7 @@ export const setMode = (mode) => {
 export const setFileSaveResult = (fileSaveResult) => {
 	getStore().dispatch({
 		type: FILE_SAVE_RESULT_CHANGED,
-		payload: fileSaveResult
+		payload: new EventLike(fileSaveResult)
 	});
 };
 

--- a/src/store/measurement/measurement.reducer.js
+++ b/src/store/measurement/measurement.reducer.js
@@ -1,3 +1,5 @@
+import { EventLike } from '../../utils/storeUtils';
+
 export const ACTIVE_CHANGED = 'measurement/active';
 export const STATISTIC_CHANGED = 'measurement/statistic';
 export const MODE_CHANGED = 'measurement/mode';
@@ -23,7 +25,7 @@ export const initialState = {
 	/**
 	 * @type {MeasureFileSaveResult}
 	 */
-	fileSaveResult: null,
+	fileSaveResult: new EventLike(null),
 	/**
 	 * @type {Array<String>}
 	 */

--- a/src/utils/markup.js
+++ b/src/utils/markup.js
@@ -5,6 +5,7 @@ import { MvuElement } from '../modules/MvuElement';
  * An element containing this attribute will be provided with a generated test id.
  */
 export const TEST_ID_ATTRIBUTE_NAME = 'data-test-id';
+
 /**
  * An element containing this attribute registers for taking part in viewport calculation.
  */
@@ -19,6 +20,11 @@ export const LOG_LIFECYLE_ATTRIBUTE_NAME = 'data-log-lifecycle';
  * An iframe element containing this attribute will expose the current encoded state of an embedded BA app.
  */
 export const IFRAME_ENCODED_STATE = 'data-iframe-encoded-state';
+
+/**
+ *An iframe element containing this attribute will expose the reference id of an user-generated geometry.
+ */
+export const IFRAME_GEOMETRY_REFERENCE_ID = 'data-iframe-geometry-reference-id';
 
 /**
  * Sets the value of the `data-test-id` attribute for a MvuElement and all of its children.

--- a/test/injection/config.test.js
+++ b/test/injection/config.test.js
@@ -6,7 +6,7 @@ import { Injector } from '../../src/injection/core/injector.js';
 describe('injector configuration', () => {
 	it('registers the expected dependencies', () => {
 		expect($injector.isReady()).toBeTrue();
-		expect($injector.count()).toBe(64);
+		expect($injector.count()).toBe(65);
 
 		expect($injector.getScope('ProjectionService')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HttpService')).toBe(Injector.SCOPE_PERLOOKUP);
@@ -58,6 +58,7 @@ describe('injector configuration', () => {
 		expect($injector.getScope('IframeContainerPlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('SharePlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('ToolsPlugin')).toBe(Injector.SCOPE_SINGLETON);
+		expect($injector.getScope('IframeGeometryIdPlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HistoryStatePlugin')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('ObserveStateForEncodingPlugin')).toBe(Injector.SCOPE_SINGLETON);
 

--- a/test/modules/olMap/services/InteractionStorageService.test.js
+++ b/test/modules/olMap/services/InteractionStorageService.test.js
@@ -110,26 +110,28 @@ describe('InteractionStorageService', () => {
 	});
 
 	it('stores initial content in the fileStorage', async () => {
+		const fileSaveResult = { fileId: 'fooBarId', adminId: 'barBazId' };
 		const store = setup({ ...initialState, fileSaveResult: null });
 		const content = 'someContent';
-		const saveSpy = spyOn(fileStorageServiceMock, 'save').and.returnValue(Promise.resolve({ fileId: 'fooBarId', adminId: 'barBazId' }));
+		const saveSpy = spyOn(fileStorageServiceMock, 'save').and.resolveTo(fileSaveResult);
 
 		const classUnderTest = new InteractionStorageService();
-		await classUnderTest.store(content, FileStorageServiceDataTypes.KML);
 
+		await expectAsync(classUnderTest.store(content, FileStorageServiceDataTypes.KML)).toBeResolvedTo(fileSaveResult);
 		expect(store.getState().shared.fileSaveResult).toEqual({ fileId: 'fooBarId', adminId: 'barBazId' });
 		expect(saveSpy).toHaveBeenCalledTimes(1);
 		expect(saveSpy).toHaveBeenCalledWith(null, content, FileStorageServiceDataTypes.KML);
 	});
 
 	it('stores new content in the fileStorage', async () => {
+		const fileSaveResult = { fileId: 'fooBarId', adminId: 'barBazId' };
 		const store = setup({ ...initialState, fileSaveResult: { fileId: 'f_someId', adminId: 'a_someId' } });
 		const content = 'someContent';
-		const saveSpy = spyOn(fileStorageServiceMock, 'save').and.returnValue(Promise.resolve({ fileId: 'fooBarId', adminId: 'barBazId' }));
+		const saveSpy = spyOn(fileStorageServiceMock, 'save').and.resolveTo(fileSaveResult);
 
 		const classUnderTest = new InteractionStorageService();
-		await classUnderTest.store(content, FileStorageServiceDataTypes.KML);
 
+		await expectAsync(classUnderTest.store(content, FileStorageServiceDataTypes.KML)).toBeResolvedTo(fileSaveResult);
 		expect(store.getState().shared.fileSaveResult).toEqual({ fileId: 'fooBarId', adminId: 'barBazId' });
 		expect(saveSpy).toHaveBeenCalledTimes(1);
 		expect(saveSpy).toHaveBeenCalledWith('a_someId', content, FileStorageServiceDataTypes.KML);
@@ -140,8 +142,8 @@ describe('InteractionStorageService', () => {
 		const emptyContent = null;
 
 		const classUnderTest = new InteractionStorageService();
-		await classUnderTest.store(emptyContent, FileStorageServiceDataTypes.KML);
 
+		await expectAsync(classUnderTest.store(emptyContent, FileStorageServiceDataTypes.KML)).toBeResolvedTo(null);
 		expect(store.getState().shared.fileSaveResult).toBeNull();
 	});
 

--- a/test/plugins/IframeGeometryIdPlugin.test.js
+++ b/test/plugins/IframeGeometryIdPlugin.test.js
@@ -1,0 +1,94 @@
+import { html } from 'lit-html';
+import { $injector } from '../../src/injection';
+import { MvuElement } from '../../src/modules/MvuElement';
+import { IframeGeometryIdPlugin } from '../../src/plugins/IframeGeometryIdPlugin';
+import { setFileSaveResult } from '../../src/store/draw/draw.action';
+import { drawReducer } from '../../src/store/draw/draw.reducer';
+import { IFRAME_GEOMETRY_REFERENCE_ID } from '../../src/utils/markup';
+import { TestUtils } from '../test-utils';
+
+class MvuElementParent extends MvuElement {
+	createView() {
+		return html` <iframe data-iframe-geometry-reference-id src=""></iframe> `;
+	}
+
+	static get tag() {
+		return 'mvu-element-parent';
+	}
+}
+window.customElements.define(MvuElementParent.tag, MvuElementParent);
+
+describe('IframeGeometryIdPlugin', () => {
+	const environmentService = {
+		getWindow: () => {},
+		isEmbedded: () => {}
+	};
+
+	const mockIframeElement = {
+		setAttribute: () => {}
+	};
+
+	const setup = () => {
+		const store = TestUtils.setupStoreAndDi(
+			{},
+			{
+				draw: drawReducer
+			}
+		);
+		$injector.registerSingleton('EnvironmentService', environmentService);
+		return store;
+	};
+
+	it('registers draw.fileSaveResult listeners and updates the iframes data attribute', async () => {
+		const expectedGeometryId = 'foo';
+		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
+		const store = setup();
+		const instanceUnderTest = new IframeGeometryIdPlugin();
+		const iframeSpy = spyOn(mockIframeElement, 'setAttribute');
+		spyOn(instanceUnderTest, '_findIframe').and.returnValue(mockIframeElement);
+		await instanceUnderTest.register(store);
+
+		setFileSaveResult({ content: 'content', fileSaveResult: { adminId: 'adminId', fileId: expectedGeometryId } });
+
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_GEOMETRY_REFERENCE_ID, expectedGeometryId);
+	});
+
+	it("does nothing when we are NOT in 'embed' mode", async () => {
+		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
+		const store = setup();
+		const instanceUnderTest = new IframeGeometryIdPlugin();
+		const updateAttributeSpy = spyOn(instanceUnderTest, '_updateAttribute');
+		await instanceUnderTest.register(store);
+
+		setFileSaveResult({ content: 'content', fileSaveResult: { adminId: 'adminId', fileId: 'fileId' } });
+
+		expect(updateAttributeSpy).not.toHaveBeenCalled();
+	});
+
+	describe('_findIframe', () => {
+		it('finds an iframe element by the IFRAME_GEOMETRY_REFERENCE_ID attribute', async () => {
+			setup();
+			await TestUtils.render(MvuElementParent.tag);
+			const instanceUnderTest = new IframeGeometryIdPlugin();
+			spyOn(instanceUnderTest, '_getDocument').and.returnValue(document);
+
+			expect(instanceUnderTest._findIframe().tagName).toBe('IFRAME');
+		});
+	});
+
+	describe('_getDocument', () => {
+		it('returns the correct document', async () => {
+			const mock = {};
+			const mockWindow = {
+				parent: {
+					document: mock
+				}
+			};
+			spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+			setup();
+			const instanceUnderTest = new IframeGeometryIdPlugin();
+
+			expect(instanceUnderTest._getDocument()).toEqual(mock);
+		});
+	});
+});

--- a/test/plugins/IframeStatePlugin.test.js
+++ b/test/plugins/IframeStatePlugin.test.js
@@ -19,7 +19,7 @@ class MvuElementParent extends MvuElement {
 }
 window.customElements.define(MvuElementParent.tag, MvuElementParent);
 
-describe('IframeState', () => {
+describe('IframeStatePlugin', () => {
 	const shareService = {
 		encodeState() {}
 	};

--- a/test/service/StoreService.test.js
+++ b/test/service/StoreService.test.js
@@ -70,6 +70,9 @@ describe('StoreService', () => {
 		const toolsPluginMock = {
 			register: () => {}
 		};
+		const iframeGeometryIdPluginMock = {
+			register: () => {}
+		};
 		const historyStatePluginMock = {
 			register: () => {}
 		};
@@ -102,6 +105,7 @@ describe('StoreService', () => {
 				.registerSingleton('IframeContainerPlugin', iframeContainerPluginMock)
 				.registerSingleton('SharePlugin', sharePluginMock)
 				.registerSingleton('ToolsPlugin', toolsPluginMock)
+				.registerSingleton('IframeGeometryIdPlugin', iframeGeometryIdPluginMock)
 				.registerSingleton('HistoryStatePlugin', historyStatePluginMock)
 				.registerSingleton('ObserveStateForEncodingPlugin', observeStateForEncodingPluginMock)
 
@@ -165,6 +169,7 @@ describe('StoreService', () => {
 			const iframeContainerPluginSpy = spyOn(iframeContainerPluginMock, 'register');
 			const sharePluginSpy = spyOn(sharePluginMock, 'register');
 			const toolsPluginSpy = spyOn(toolsPluginMock, 'register');
+			const iframeGeometryIdPluginSpy = spyOn(iframeGeometryIdPluginMock, 'register');
 			const historyStatePluginSpy = spyOn(historyStatePluginMock, 'register');
 			const observeStateForEncodingPluginSpy = spyOn(observeStateForEncodingPluginMock, 'register');
 			const instanceUnderTest = new StoreService();
@@ -195,6 +200,7 @@ describe('StoreService', () => {
 			expect(iframeContainerPluginSpy).toHaveBeenCalledWith(store);
 			expect(sharePluginSpy).toHaveBeenCalledWith(store);
 			expect(toolsPluginSpy).toHaveBeenCalledWith(store);
+			expect(iframeGeometryIdPluginSpy).toHaveBeenCalledWith(store);
 			expect(historyStatePluginSpy).toHaveBeenCalledWith(store);
 			expect(observeStateForEncodingPluginSpy).toHaveBeenCalledWith(store);
 		});

--- a/test/store/draw/draw.reducer.test.js
+++ b/test/store/draw/draw.reducer.test.js
@@ -39,7 +39,7 @@ describe('drawReducer', () => {
 		expect(store.getState().draw.description).toBeNull();
 		expect(store.getState().draw.reset).toBeNull();
 		expect(store.getState().draw.selection).toEqual([]);
-		expect(store.getState().draw.fileSaveResult).toBeNull();
+		expect(store.getState().draw.fileSaveResult.payload).toBeNull();
 		expect(store.getState().draw.validGeometry).toBeFalse();
 	});
 
@@ -127,13 +127,13 @@ describe('drawReducer', () => {
 		expect(store.getState().draw.description).toBeNull();
 	});
 
-	it('updates the fileSaveResult property', () => {
+	it('updates the drawFileSaveResult property', () => {
 		const store = setup();
-		const fileSaveResult = { adminId: 'fooBarId', fileId: 'barBazId' };
+		const drawFileSaveResult = { content: 'content', fileSaveResult: { adminId: 'fooBarId', fileId: 'barBazId' } };
 
-		setFileSaveResult(fileSaveResult);
+		setFileSaveResult(drawFileSaveResult);
 
-		expect(store.getState().draw.fileSaveResult).toEqual({ adminId: 'fooBarId', fileId: 'barBazId' });
+		expect(store.getState().draw.fileSaveResult.payload).toEqual(drawFileSaveResult);
 	});
 
 	it('updates the reset property', () => {

--- a/test/store/measurement/measurement.reducer.test.js
+++ b/test/store/measurement/measurement.reducer.test.js
@@ -26,7 +26,7 @@ describe('measurementReducer', () => {
 		expect(store.getState().measurement.statistic).toEqual({ length: null, area: null });
 		expect(store.getState().measurement.reset).toBeNull();
 		expect(store.getState().measurement.finish).toBeNull();
-		expect(store.getState().measurement.fileSaveResult).toBeNull();
+		expect(store.getState().measurement.fileSaveResult.payload).toBeNull();
 		expect(store.getState().measurement.mode).toBeNull();
 		expect(store.getState().measurement.selection).toEqual([]);
 	});
@@ -54,11 +54,11 @@ describe('measurementReducer', () => {
 
 	it('updates the fileSaveResult property', () => {
 		const store = setup();
-		const fileSaveResult = { adminId: 'fooBarId', fileId: 'barBazId' };
+		const measurementFileSaveResult = { content: 'content', fileSaveResult: { adminId: 'fooBarId', fileId: 'barBazId' } };
 
-		setFileSaveResult(fileSaveResult);
+		setFileSaveResult(measurementFileSaveResult);
 
-		expect(store.getState().measurement.fileSaveResult).toEqual({ adminId: 'fooBarId', fileId: 'barBazId' });
+		expect(store.getState().measurement.fileSaveResult.payload).toEqual(measurementFileSaveResult);
 	});
 
 	it('updates the reset property', () => {

--- a/test/utils/markup.test.js
+++ b/test/utils/markup.test.js
@@ -6,6 +6,7 @@ import {
 	findAllBySelector,
 	forEachBySelector,
 	IFRAME_ENCODED_STATE,
+	IFRAME_GEOMETRY_REFERENCE_ID,
 	LOG_LIFECYLE_ATTRIBUTE_NAME,
 	REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME,
 	TEST_ID_ATTRIBUTE_NAME
@@ -92,6 +93,9 @@ describe('markup utils', () => {
 		});
 		it('provides an attribute name for iframes to enable exposing the current state of an embedded BA app', () => {
 			expect(IFRAME_ENCODED_STATE).toBe('data-iframe-encoded-state');
+		});
+		it('provides an attribute name for iframes to enable exposing the reference id of an user-generated geometry', () => {
+			expect(IFRAME_GEOMETRY_REFERENCE_ID).toBe('data-iframe-geometry-reference-id');
 		});
 	});
 


### PR DESCRIPTION
Checks if a surrounding iframe exists and contains the IFRAME_GEOMETRY_REFERENCE_ID data attribute.
 If so, it updates the attribute's value on changes in the fileSaveResult property of the draw slice-of-state.
