### PR TITLE
allow cloning of stored layer

### DIFF
--- a/src/i18n/global.provider.js
+++ b/src/i18n/global.provider.js
@@ -13,7 +13,6 @@ export const provide = (lang) => {
 				global_import_data_failed: 'Importing data failed',
 				global_import_unsupported_sourceType: 'Source type could not be detected or is not supported',
 				global_import_authenticationModal_title: 'Authentication required',
-				global_default_vector_georesource_name: 'Data',
 				global_locally_imported_dataset_copyright_label: 'Dataset and/or style provided by third party',
 				global_share_unsupported_geoResource_warning: "The following layers won't be shared:",
 				global_privacy_policy_url: 'https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html'
@@ -26,13 +25,12 @@ export const provide = (lang) => {
 				global_mfpService_createJob_exception: 'PDF konnte nicht erstellt werden.',
 				global_featureInfoService_exception: 'FeatureInfo Abfrage schlug fehl',
 				global_geolocation_denied:
-					'Es ist keine Positionsbestimmung möglich, da ihre Browsereinstellungen dies nicht zulassen. Erlauben sie die Positionsbestimmung und deaktivieren Sie den "Privat" Modus des Browsers.',
+					'Es ist keine Positionsbestimmung möglich, da ihre Browsereinstellungen dies nicht zulassen. Erlauben Sie die Positionsbestimmung und deaktivieren Sie den "Privat" Modus des Browsers.',
 				global_geolocation_not_available: 'Es ist keine Positionsbestimmung möglich.',
 				global_import_url_failed: 'URL-Import schlug fehl',
 				global_import_data_failed: 'Import der Daten schlug fehl',
 				global_import_unsupported_sourceType: 'Daten-Typ konnte nicht erkannt werden oder wird nicht unterstützt',
 				global_import_authenticationModal_title: 'Anmeldung erforderlich',
-				global_default_vector_georesource_name: 'Daten',
 				global_locally_imported_dataset_copyright_label: 'Mit Darstellung durch den Anwender',
 				global_share_unsupported_geoResource_warning: 'Folgende Ebenen werden nicht geteilt:',
 				global_privacy_policy_url: 'https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html'

--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -203,7 +203,7 @@ export class LayerItem extends AbstractMvuContentPanel {
 
 		const getMenuItems = () => {
 			return [
-				{ id: 'copy', label: translate('layerManager_to_copy'), icon: cloneSvg, action: cloneLayer, disabled: !layer.constraints?.cloneable },
+				{ id: 'copy', label: translate('layerManager_to_copy'), icon: cloneSvg, action: cloneLayer, disabled: false },
 				{
 					id: 'zoomToExtent',
 					label: translate('layerManager_zoom_to_extent'),

--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -162,7 +162,8 @@ export class OlDrawHandler extends OlLayerHandler {
 		}
 		const getOldLayer = (map) => {
 			const isOldLayer = (layer) => this._storageHandler.isStorageId(layer.get('geoResourceId'));
-			return map.getLayers().getArray().find(isOldLayer);
+			// we iterate over all layers in reverse order, the top-most layer is the one we take source for our drawing layer
+			return map.getLayers().getArray().reverse().find(isOldLayer);
 		};
 
 		const createLayer = () => {

--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -865,7 +865,7 @@ export class OlDrawHandler extends OlLayerHandler {
 
 			// register the stored data as new georesource
 			this._geoResourceService.addOrReplace(vgr);
-			addLayer(id, { constraints: { cloneable: false, metaData: false } });
+			addLayer(id, { constraints: { metaData: false } });
 		}
 	}
 }

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -692,7 +692,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 
 		// register the stored data as new georesource
 		this._geoResourceService.addOrReplace(vgr);
-		addLayer(id, { constraints: { cloneable: false, metaData: false } });
+		addLayer(id, { constraints: { metaData: false } });
 	}
 
 	static get Debounce_Delay() {

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -128,7 +128,8 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		}
 		const getOldLayer = (map) => {
 			const isOldLayer = (layer) => this._storageHandler.isStorageId(layer.get('geoResourceId'));
-			return map.getLayers().getArray().find(isOldLayer);
+			// we iterate over all layers in reverse order, the top-most layer is the one we take source for our drawing layer
+			return map.getLayers().getArray().reverse().find(isOldLayer);
 		};
 
 		const createLayer = () => {

--- a/src/services/provider/fileStorage.provider.js
+++ b/src/services/provider/fileStorage.provider.js
@@ -8,17 +8,14 @@ import { getAttributionForLocallyImportedOrCreatedGeoResource } from './attribut
 
 export const _newLoader = (id) => {
 	return async () => {
-		const { FileStorageService: fileStorageService, TranslationService: translationService } = $injector.inject(
-			'FileStorageService',
-			'TranslationService'
-		);
+		const { FileStorageService: fileStorageService } = $injector.inject('FileStorageService');
 
 		try {
 			const fileId = await fileStorageService.getFileId(id);
 			const { data, type, srid } = await fileStorageService.get(fileId);
 
 			if (type === FileStorageServiceDataTypes.KML) {
-				const vgr = new VectorGeoResource(id, translationService.translate('global_default_vector_georesource_name'), VectorSourceType.KML)
+				const vgr = new VectorGeoResource(id, null /**will be read from the KML */, VectorSourceType.KML)
 					.setSource(data, srid)
 					.setAttributionProvider(getAttributionForLocallyImportedOrCreatedGeoResource);
 				return vgr;

--- a/test/i18n/global.provider.test.js
+++ b/test/i18n/global.provider.test.js
@@ -15,7 +15,6 @@ describe('global i18n', () => {
 		expect(map.global_import_data_failed).toBe('Importing data failed');
 		expect(map.global_import_unsupported_sourceType).toBe('Source type could not be detected or is not supported');
 		expect(map.global_import_authenticationModal_title).toBe('Authentication required');
-		expect(map.global_default_vector_georesource_name).toBe('Data');
 		expect(map.global_locally_imported_dataset_copyright_label).toBe('Dataset and/or style provided by third party');
 		expect(map.global_share_unsupported_geoResource_warning).toBe("The following layers won't be shared:");
 		expect(map.global_privacy_policy_url).toBe('https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html');
@@ -28,21 +27,20 @@ describe('global i18n', () => {
 		expect(map.global_mfpService_createJob_exception).toBe('PDF konnte nicht erstellt werden.');
 		expect(map.global_featureInfoService_exception).toBe('FeatureInfo Abfrage schlug fehl');
 		expect(map.global_geolocation_denied).toBe(
-			'Es ist keine Positionsbestimmung möglich, da ihre Browsereinstellungen dies nicht zulassen. Erlauben sie die Positionsbestimmung und deaktivieren Sie den "Privat" Modus des Browsers.'
+			'Es ist keine Positionsbestimmung möglich, da ihre Browsereinstellungen dies nicht zulassen. Erlauben Sie die Positionsbestimmung und deaktivieren Sie den "Privat" Modus des Browsers.'
 		);
 		expect(map.global_geolocation_not_available).toBe('Es ist keine Positionsbestimmung möglich.');
 		expect(map.global_import_url_failed).toBe('URL-Import schlug fehl');
 		expect(map.global_import_data_failed).toBe('Import der Daten schlug fehl');
 		expect(map.global_import_unsupported_sourceType).toBe('Daten-Typ konnte nicht erkannt werden oder wird nicht unterstützt');
 		expect(map.global_import_authenticationModal_title).toBe('Anmeldung erforderlich');
-		expect(map.global_default_vector_georesource_name).toBe('Daten');
 		expect(map.global_locally_imported_dataset_copyright_label).toBe('Mit Darstellung durch den Anwender');
 		expect(map.global_share_unsupported_geoResource_warning).toBe('Folgende Ebenen werden nicht geteilt:');
 		expect(map.global_privacy_policy_url).toBe('https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 13;
+		const expectedSize = 12;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -324,8 +324,7 @@ describe('LayerItem', () => {
 				visible: true,
 				zIndex: 0,
 				opacity: 1,
-				collapsed: true,
-				constraints: { cloneable: false }
+				collapsed: true
 			};
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new WmsGeoResource('geoResourceId0', 'id0', '', [], ''));
 			const element = await setup(layer);

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -291,32 +291,6 @@ describe('LayerItem', () => {
 			expect(copyMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
 		});
 
-		it('contains a disabled menu-item for copy', async () => {
-			spyOn(geoResourceService, 'byId')
-				.withArgs('geoResourceId0')
-				.and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
-			const layer = {
-				...createDefaultLayerProperties(),
-				id: 'id0',
-				geoResourceId: 'geoResourceId0',
-				visible: true,
-				zIndex: 0,
-				opacity: 1,
-				collapsed: true,
-				constraints: { cloneable: false }
-			};
-			const element = await setup(layer);
-
-			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
-			const copyMenuItem = menu.items.find((item) => item.label === 'layerManager_to_copy');
-
-			expect(copyMenuItem).not.toBeNull();
-			expect(copyMenuItem.label).toEqual('layerManager_to_copy');
-			expect(copyMenuItem.action).toEqual(jasmine.any(Function));
-			expect(copyMenuItem.disabled).toBeTrue();
-			expect(copyMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
-		});
-
 		it('contains a menu-item for zoomToExtent', async () => {
 			spyOn(geoResourceService, 'byId')
 				.withArgs('geoResourceId0')

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -955,7 +955,10 @@ describe('OlDrawHandler', () => {
 			const map = setupMap();
 			const vectorGeoResource = new VectorGeoResource('a_lastId', 'foo', VectorSourceType.KML).setSource(lastData, 4326);
 
-			spyOn(map, 'getLayers').and.returnValue(new Collection([new Layer({ geoResourceId: 'a_lastId' })]));
+			spyOn(map, 'getLayers').and.returnValue(
+				// we add two fileStorage related layers
+				new Collection([new Layer({ geoResourceId: 'a_notWanted' }), new Layer({ geoResourceId: 'a_lastId' })])
+			);
 			spyOn(interactionStorageServiceMock, 'isStorageId').and.callFake(() => true);
 			spyOn(classUnderTest._overlayService, 'add').and.callFake(() => {});
 

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -1226,7 +1226,6 @@ describe('OlDrawHandler', () => {
 			await TestUtils.timeout();
 			expect(store.getState().layers.active.length).toBe(1);
 			expect(store.getState().layers.active[0].id).toBe('f_ooBarId');
-			expect(store.getState().layers.active[0].constraints.cloneable).toBeFalse();
 			expect(store.getState().layers.active[0].constraints.metaData).toBeFalse();
 		});
 

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -729,7 +729,6 @@ describe('OlMeasurementHandler', () => {
 			await TestUtils.timeout();
 			expect(store.getState().layers.active.length).toBe(1);
 			expect(store.getState().layers.active[0].id).toBe('f_ooBarId');
-			expect(store.getState().layers.active[0].constraints.cloneable).toBeFalse();
 			expect(store.getState().layers.active[0].constraints.metaData).toBeFalse();
 		});
 

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -471,7 +471,10 @@ describe('OlMeasurementHandler', () => {
 			const map = setupMap();
 			const vectorGeoResource = new VectorGeoResource('a_lastId', 'foo', VectorSourceType.KML).setSource(lastData, 4326);
 
-			spyOn(map, 'getLayers').and.returnValue(new Collection([new Layer({ geoResourceId: 'a_lastId' })]));
+			spyOn(map, 'getLayers').and.returnValue(
+				// we add two fileStorage related layers
+				new Collection([new Layer({ geoResourceId: 'a_notWanted' }), new Layer({ geoResourceId: 'a_lastId' })])
+			);
 			spyOn(interactionStorageServiceMock, 'isStorageId').and.callFake(() => true);
 			spyOn(classUnderTest._overlayService, 'add').and.callFake(() => {});
 

--- a/test/service/provider/fileStorage.provider.test.js
+++ b/test/service/provider/fileStorage.provider.test.js
@@ -13,7 +13,7 @@ describe('BVV GeoResource provider', () => {
 	};
 
 	beforeEach(() => {
-		$injector.registerSingleton('TranslationService', { translate: (key) => key }).registerSingleton('FileStorageService', fileStorageService);
+		$injector.registerSingleton('FileStorageService', fileStorageService);
 	});
 
 	afterEach(() => {
@@ -83,7 +83,7 @@ describe('BVV GeoResource provider', () => {
 			expect(geoResource._srid).toBe(srid);
 			expect(geoResource._attributionProvider).toBe(getAttributionForLocallyImportedOrCreatedGeoResource);
 			expect(geoResource._sourceType).toBe(VectorSourceType.KML);
-			expect(geoResource.label).toBe('global_default_vector_georesource_name');
+			expect(geoResource.label).toBe('KML');
 		});
 
 		it('throws an error when source type is not supported', async () => {


### PR DESCRIPTION
When more than one "drawing" layer exists and the measurement or drawing tool is activated the topmost "drawing" layer is taken as the source.

Also fixes #1628 and fixes #1627