### PR TITLE
MapFeedback: remove Feedback components from ShowCase

### DIFF
--- a/src/modules/utils/components/showCase/ShowCase.js
+++ b/src/modules/utils/components/showCase/ShowCase.js
@@ -254,11 +254,6 @@ export class ShowCase extends BaElement {
 						<div class="theme-toggle" style="display: flex;justify-content: flex-start;"><ba-theme-toggle></ba-theme-toggle></div>
 					</div>
 
-					<h3>Feedback</h3>
-					<div class="example row">
-						<ba-mvu-togglefeedbackpanel></ba-mvu-togglefeedbackpanel>
-					</div>
-
 					<h3>Profile</h3>
 					<div class="example row">
 						<ba-button id="button1" .label=${'Show/Hide elevation profile'} .type=${'primary'} @click=${onClickOpenProfile}></ba-button>


### PR DESCRIPTION
After it has been successfully placed in the menu, it is no longer needed in the showcase.