### PR TITLE
IframeGeometryIdPlugin: fix updateAttribute to emptyString

### DIFF
--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -830,7 +830,7 @@ export class OlDrawHandler extends OlLayerHandler {
 	}
 
 	/**
-	 * todo: redundant with OlMeasurementHandler, possible responsibility of a statefull _storageHandler
+	 * todo: redundant with OlMeasurementHandler, possible responsibility of a stateful _storageHandler
 	 */
 	async _save() {
 		const newContent = createKML(this._vectorLayer, 'EPSG:3857');

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -655,7 +655,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 	}
 
 	/**
-	 * todo: redundant with OlDrawHandler, possible responsibility of a statefull _storageHandler
+	 * todo: redundant with OlDrawHandler, possible responsibility of a stateful _storageHandler
 	 */
 	async _save() {
 		const features = this._vectorLayer.getSource().getFeatures();

--- a/src/plugins/IframeGeometryIdPlugin.js
+++ b/src/plugins/IframeGeometryIdPlugin.js
@@ -39,7 +39,7 @@ export class IframeGeometryIdPlugin extends BaPlugin {
 	}
 
 	_updateAttribute(fileId) {
-		this._findIframe()?.setAttribute(IFRAME_GEOMETRY_REFERENCE_ID, fileId);
+		this._findIframe()?.setAttribute(IFRAME_GEOMETRY_REFERENCE_ID, fileId ? fileId : '');
 	}
 
 	_findIframe() {

--- a/test/plugins/IframeGeometryIdPlugin.test.js
+++ b/test/plugins/IframeGeometryIdPlugin.test.js
@@ -56,7 +56,7 @@ describe('IframeGeometryIdPlugin', () => {
 		// drawing deleted
 		setFileSaveResult(null);
 
-		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_GEOMETRY_REFERENCE_ID, null);
+		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_GEOMETRY_REFERENCE_ID, '');
 	});
 
 	it("does nothing when we are NOT in 'embed' mode", async () => {


### PR DESCRIPTION
update the behavior of the method '_updateAttribute' to empty string instead of null, du to the behavior of the setAttribute-method of HtmlElements, which
causes an implicit stringify of null-values.
An empty string ('') can be easier evaluated then 'null'.