### PR TITLE
enable type checking in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
 	},
 	"[jsonc]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	}
+	},
+	"js/ts.implicitProjectConfig.checkJs": true
 }


### PR DESCRIPTION
Just a visual aid in VS Code, no checking from CLI

(see also: https://code.visualstudio.com/docs/nodejs/working-with-javascript#_type-checking-javascript)

(Thx to @norbertK, @thiloSchlemmer )