### PR TITLE
rework loading of URL-based VectorGeoResource

### DIFF
--- a/src/services/FeedbackService.js
+++ b/src/services/FeedbackService.js
@@ -15,7 +15,7 @@ import { bvvMapFeedbackCategoriesProvider, bvvFeedbackStorageProvider, bvvMapFee
  * A function that returns a list of categories for a MapFeedback
  * @async
  * @typedef {Function} mapFeedbackCategoriesProvider
- * @returns {Array<String>} available categories
+ * @returns {Promise<Array<String>>} available categories
  */
 /**
  * A function that returns an id of a GeoResource which should be used as a overlay layer of the map

--- a/src/services/GeoResourceService.js
+++ b/src/services/GeoResourceService.js
@@ -17,7 +17,7 @@
  */
 
 import { $injector } from '../injection';
-import {  observable, VTGeoResource, XyzGeoResource } from '../domain/geoResources';
+import { observable, VTGeoResource, XyzGeoResource } from '../domain/geoResources';
 import { loadBvvFileStorageResourceById } from './provider/fileStorage.provider';
 import { loadBvvGeoResourceById, loadBvvGeoResources, loadExternalGeoResource } from './provider/geoResource.provider';
 import { geoResourceChanged } from '../store/layers/layers.action';

--- a/src/services/GeoResourceService.js
+++ b/src/services/GeoResourceService.js
@@ -17,7 +17,7 @@
  */
 
 import { $injector } from '../injection';
-import { observable, VTGeoResource, XyzGeoResource } from '../domain/geoResources';
+import {  observable, VTGeoResource, XyzGeoResource } from '../domain/geoResources';
 import { loadBvvFileStorageResourceById } from './provider/fileStorage.provider';
 import { loadBvvGeoResourceById, loadBvvGeoResources, loadExternalGeoResource } from './provider/geoResource.provider';
 import { geoResourceChanged } from '../store/layers/layers.action';
@@ -44,8 +44,8 @@ export const FALLBACK_GEORESOURCE_LABEL_3 = 'Web Vektor Relief';
 export class GeoResourceService {
 	/**
 	 *
-	 * @param {geoResourceProvider} [geoResourceProvider=loadBvvGeoResources]
-	 * @param {geoResourceByIdProvider} [geoResourceByIdProvider=[loadBvvFileStorageResourceById, loadBvvGeoResourceById]]
+	 * @param {module:services/GeoResourceService~geoResourceProvider} [provider=loadBvvGeoResources]
+	 * @param {module:services/GeoResourceService~geoResourceByIdProvider[]} [byIdProvider=[loadBvvFileStorageResourceById, loadBvvGeoResourceById]]
 	 */
 	constructor(provider = loadBvvGeoResources, byIdProvider = [loadExternalGeoResource, loadBvvFileStorageResourceById, loadBvvGeoResourceById]) {
 		this._provider = provider;

--- a/src/services/provider/feedback.provider.js
+++ b/src/services/provider/feedback.provider.js
@@ -7,8 +7,8 @@ import { MediaType } from '../HttpService';
 
 /**
  * Bvv specific implementation of {@link module:services/FeedbackService~feedbackStorageProvider}
- * @implements {module:services/FeedbackService~feedbackStorageProvider}
  * @function
+ * @type {module:services/FeedbackService~feedbackStorageProvider}
  */
 export const bvvFeedbackStorageProvider = async (mapFeedback) => {
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
@@ -47,9 +47,8 @@ export const bvvFeedbackStorageProvider = async (mapFeedback) => {
 
 /**
  * Bvv specific implementation of {@link module:services/FeedbackService~mapFeedbackCategoriesProvider}
- * @async
- * @implements {module:services/FeedbackService~feedbackCategoriesProvider}
  * @function
+ * @type {module:services/FeedbackService~mapFeedbackCategoriesProvider}
  */
 export const bvvMapFeedbackCategoriesProvider = async () => {
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
@@ -67,6 +66,6 @@ export const bvvMapFeedbackCategoriesProvider = async () => {
 /**
  * Bvv specific implementation of {@link module:services/FeedbackService~mapFeedbackOverlayGeoResourceProvider}
  * @function
- * @implements {module:services/FeedbackService~mapFeedbackOverlayGeoResourceProvider}
+ * @type {module:services/FeedbackService~mapFeedbackOverlayGeoResourceProvider}
  */
 export const bvvMapFeedbackOverlayGeoResourceProvider = () => 'tim';

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -15,10 +15,6 @@ import { $injector } from '../../injection';
 import { isHttpUrl } from '../../utils/checks';
 import { getBvvAttribution } from './attribution.provider';
 
-/**
- * Maps a BVV geoResource definition to a corresponding GeoResource instance
- * @param {object} definition Configuration object for a GeoResource
- */
 export const _definitionToGeoResource = (definition) => {
 	const toGeoResource = (def) => {
 		switch (def.type) {
@@ -81,8 +77,7 @@ export const _definitionToGeoResource = (definition) => {
 /**
  * Uses the BVV endpoint to load geoResources.
  * @function
- * @implements {module:services/GeoResourceService~geoResourceProvider}
- * @returns {Promise<Array<GeoResource>>}
+ * @type {module:services/GeoResourceService~geoResourceProvider}
  */
 export const loadBvvGeoResources = async () => {
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
@@ -109,11 +104,6 @@ export const loadBvvGeoResources = async () => {
 	throw new Error('GeoResources could not be loaded');
 };
 
-/**
- * Helper function to parse BVV attributions.
- * @param {object} definition BVV GeoResource definition
- * @returns  {Array<Attribution>|null} an array of attributions or `null`
- */
 export const _parseBvvAttributionDefinition = (definition) => {
 	if (Array.isArray(definition.extendedAttributions)) {
 		return definition.extendedAttributions.map((extAtt) => ({
@@ -127,8 +117,7 @@ export const _parseBvvAttributionDefinition = (definition) => {
 /**
  * Loads example GeoResources without a backend.
  * @function
- * @implements {module:services/GeoResourceService~geoResourceProvider}
- * @returns {Promise<Array<GeoResource>>}
+ * @type {module:services/GeoResourceService~geoResourceProvider}
  */
 export const loadExampleGeoResources = async () => {
 	const wms0 = new WmsGeoResource(
@@ -158,8 +147,8 @@ export const loadExampleGeoResources = async () => {
 /**
  * Uses the BVV endpoint to load a GeoResource by id
  * @function
- * @implements {module:services/GeoResourceService~geoResourceByIdProvider}
- * @returns {GeoResourceFuture|null}
+ * @param {string} id Id of the requested GeoResource
+ * @type {module:services/GeoResourceService~geoResourceByIdProvider}
  */
 export const loadBvvGeoResourceById = (id) => {
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
@@ -192,8 +181,8 @@ export const loadBvvGeoResourceById = (id) => {
  *
  * WMS: `{url}||{layer}||[{label}]`
  * @function
- * @implements {module:services/GeoResourceService~geoResourceByIdProvider}
- * @returns {GeoResourceFuture|null}
+ * @param {string} urlBasedAsId URL-based ID of the requested GeoResource
+ * @type {module:services/GeoResourceService~geoResourceByIdProvider}
  */
 export const loadExternalGeoResource = (urlBasedAsId) => {
 	const parts = urlBasedAsId.split('||');

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -31,6 +31,9 @@ describe('GeoResource provider', () => {
 	const importWmsService = {
 		async forUrl() {}
 	};
+	const urlService = {
+		proxifyInstant() {}
+	};
 
 	beforeEach(() => {
 		TestUtils.setupStoreAndDi();
@@ -40,7 +43,8 @@ describe('GeoResource provider', () => {
 			.registerSingleton('GeoResourceService', geoResourceService)
 			.registerSingleton('SourceTypeService', sourceTypeService)
 			.registerSingleton('ImportVectorDataService', importVectorDataService)
-			.registerSingleton('ImportWmsService', importWmsService);
+			.registerSingleton('ImportWmsService', importWmsService)
+			.registerSingleton('UrlService', urlService);
 	});
 
 	const basicAttribution = {
@@ -127,7 +131,7 @@ describe('GeoResource provider', () => {
 		...aggregateDefinition
 	};
 
-	const vadlidateGeoResourceProperties = (georesource, definition) => {
+	const validateGeoResourceProperties = (georesource, definition) => {
 		expect(georesource.id).toBe(definition.id);
 		expect(georesource.label).toBe(definition.label);
 		expect(georesource.opacity).toBe(1.0);
@@ -148,7 +152,7 @@ describe('GeoResource provider', () => {
 		it('maps a WMS BVV definition to a corresponding GeoResource instance', () => {
 			const wmsGeoResource = _definitionToGeoResource(wmsDefinition);
 
-			vadlidateGeoResourceProperties(wmsGeoResource, wmsDefinition);
+			validateGeoResourceProperties(wmsGeoResource, wmsDefinition);
 			expect(wmsGeoResource.url).toBe('wmsUrl');
 			expect(wmsGeoResource.layers).toBe(wmsDefinition.layers);
 			expect(wmsGeoResource.format).toBe(wmsDefinition.format);
@@ -171,7 +175,7 @@ describe('GeoResource provider', () => {
 		it('maps a XYZ BVV definition to a corresponding GeoResource instance', () => {
 			const xyzGeoResource = _definitionToGeoResource(xyzDefinition);
 
-			vadlidateGeoResourceProperties(xyzGeoResource, xyzDefinition);
+			validateGeoResourceProperties(xyzGeoResource, xyzDefinition);
 			expect(xyzGeoResource.urls).toBe('xyzUrl');
 			expect(xyzGeoResource._attributionProvider).toBe(getBvvAttribution);
 			expect(xyzGeoResource._attribution).not.toBeNull();
@@ -192,7 +196,7 @@ describe('GeoResource provider', () => {
 		it('maps a VT BVV definition to a corresponding GeoResource instance', () => {
 			const vtGeoResource = _definitionToGeoResource(vtDefinition);
 
-			vadlidateGeoResourceProperties(vtGeoResource, vtDefinition);
+			validateGeoResourceProperties(vtGeoResource, vtDefinition);
 			expect(vtGeoResource.styleUrl).toBe('vtStyleUrl');
 			expect(vtGeoResource._attributionProvider).toBe(getBvvAttribution);
 			expect(vtGeoResource._attribution).not.toBeNull();
@@ -209,18 +213,32 @@ describe('GeoResource provider', () => {
 			expect(vtGeoResource.exportable).toBeFalse();
 		});
 
-		it('maps a VectorFile BVV definition to a corresponding GeoResource instance', () => {
-			const vectorGeoResource = _definitionToGeoResource(vectorDefinition);
+		it('maps a VectorFile BVV definition to a corresponding GeoResource instance', async () => {
+			const data = 'data';
+			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
+			spyOn(httpService, 'get')
+				.withArgs(vectorDefinition.url, { timeout: 5000 })
+				.and.returnValue(Promise.resolve(new Response(data, { status: 200 })));
+			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
-			vadlidateGeoResourceProperties(vectorGeoResource, vectorDefinition);
-			expect(vectorGeoResource.url).toBe('vectorUrl');
+			const vectorGeoResource = await _definitionToGeoResource(vectorDefinition).get();
+
+			validateGeoResourceProperties(vectorGeoResource, vectorDefinition);
+			expect(vectorGeoResource.data).toBe(data);
 			expect(Symbol.keyFor(vectorGeoResource.sourceType)).toBe(vectorDefinition.sourceType);
 			expect(vectorGeoResource._attributionProvider).toBe(getBvvAttribution);
 			expect(vectorGeoResource._attribution).not.toBeNull();
 		});
 
-		it('maps a VectorFile BVV definition with optional properties to a corresponding GeoResource instance', () => {
-			const vectorGeoResource = _definitionToGeoResource(vectorDefinitionOptionalProperties);
+		it('maps a VectorFile BVV definition with optional properties to a corresponding GeoResource instance', async () => {
+			const data = 'data';
+			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinitionOptionalProperties.url);
+			spyOn(httpService, 'get')
+				.withArgs(vectorDefinition.url, { timeout: 5000 })
+				.and.returnValue(Promise.resolve(new Response(data, { status: 200 })));
+			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
+
+			const vectorGeoResource = await _definitionToGeoResource(vectorDefinitionOptionalProperties).get();
 
 			expect(vectorGeoResource.opacity).toBe(0.5);
 			expect(vectorGeoResource.hidden).toBeTrue();
@@ -231,10 +249,22 @@ describe('GeoResource provider', () => {
 			expect(vectorGeoResource.exportable).toBeFalse();
 		});
 
+		it('throws an Error when GeoResourceFuture for a VectorGeoResource cannot be resolved', async () => {
+			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
+			spyOn(httpService, 'get')
+				.withArgs(vectorDefinition.url, { timeout: 5000 })
+				.and.returnValue(Promise.resolve(new Response(null, { status: 404 })));
+			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
+
+			await expectAsync(_definitionToGeoResource(vectorDefinition).get()).toBeRejectedWithError(
+				`GeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
+			);
+		});
+
 		it('maps a aggregate BVV definition to a corresponding GeoResource instance', () => {
 			const aggregateGeoResource = _definitionToGeoResource(aggregateDefinition);
 
-			vadlidateGeoResourceProperties(aggregateGeoResource, aggregateDefinition);
+			validateGeoResourceProperties(aggregateGeoResource, aggregateDefinition);
 			expect(aggregateGeoResource.geoResourceIds).toEqual(aggregateDefinition.geoResourceIds);
 			expect(aggregateGeoResource._attributionProvider).toBe(getBvvAttribution);
 			expect(aggregateGeoResource._attribution).not.toBeNull();
@@ -363,25 +393,25 @@ describe('GeoResource provider', () => {
 				.and.returnValue(backendUrl + '/');
 			const httpServiceSpy = spyOn(httpService, 'get')
 				.withArgs(expectedArgs0, expectedArgs1)
-				.and.returnValue(Promise.resolve(new Response(JSON.stringify([wmsDefinition, xyzDefinition, vectorDefinition, aggregateDefinition]))));
+				.and.returnValue(Promise.resolve(new Response(JSON.stringify([wmsDefinition, xyzDefinition, aggregateDefinition]))));
 
 			const georesources = await loadBvvGeoResources();
 
 			expect(configServiceSpy).toHaveBeenCalled();
 			expect(httpServiceSpy).toHaveBeenCalled();
-			expect(georesources.length).toBe(4);
+			expect(georesources.length).toBe(3);
 
 			const wmsGeoResource = georesources[0];
-			vadlidateGeoResourceProperties(wmsGeoResource, wmsDefinition);
+			validateGeoResourceProperties(wmsGeoResource, wmsDefinition);
 
 			const xyzGeoResource = georesources[1];
-			vadlidateGeoResourceProperties(xyzGeoResource, xyzDefinition);
+			validateGeoResourceProperties(xyzGeoResource, xyzDefinition);
 
-			const vectorGeoResource = georesources[2];
-			vadlidateGeoResourceProperties(vectorGeoResource, vectorDefinition);
+			// const vectorGeoResource = georesources[2];
+			// validateGeoResourceProperties(await vectorGeoResource.get(), vectorDefinition);
 
-			const aggregateGeoResource = georesources[3];
-			vadlidateGeoResourceProperties(aggregateGeoResource, aggregateDefinition);
+			const aggregateGeoResource = georesources[2];
+			validateGeoResourceProperties(aggregateGeoResource, aggregateDefinition);
 		});
 
 		it('logs a warn statement when GeoResource type cannot be resolved', async () => {


### PR DESCRIPTION
All URL-based VectorGeoResource are loaded by a GeoResourceFuture now.

Implicitly fixes #1685 