### PR TITLE
declare globals for assets

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,9 @@
+declare module '*.svg' {
+	const content: any;
+	export default content;
+}
+
+declare module '*.css' {
+	const content: any;
+	export default content;
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"checkJs": true
 	},
-	"exclude": ["**/node_modules/*", "**/test/*"]
+	"exclude": ["**/node_modules/*", "**/test/*"],
+	"files": ["globals.d.ts"]
 }
 // file needed only for vscode type checking


### PR DESCRIPTION
Trying to get rid of type-checking errors for svg and css assets in vs code

Following these sources:

- https://stackoverflow.com/questions/44717164/unable-to-import-svg-files-in-typescript/45887328#45887328
- https://webpack.js.org/guides/typescript/#importing-other-assets

Caveats:

- [This may degrade build performance](https://webpack.js.org/guides/typescript/#build-performance)