### PR TITLE
StyleService: update styling-behavior for features without style

### DIFF
--- a/src/modules/olMap/services/StyleService.js
+++ b/src/modules/olMap/services/StyleService.js
@@ -233,8 +233,12 @@ export class StyleService {
 				return { color: Array.isArray(currentColor) ? rgbToHex(currentColor) : currentColor, scale: currentScale, text: currentText };
 			};
 
+			const fromAttribute = (feature) => {
+				return { text: feature.get('name') };
+			};
+
 			const styles = getStyleArray(olFeature);
-			return styles ? fromStyle(styles[0]) : {};
+			return styles ? fromStyle(styles[0]) : fromAttribute(olFeature);
 		};
 
 		const newStyle = textStyleFunction(getStyleOption());
@@ -255,8 +259,12 @@ export class StyleService {
 				return { symbolSrc: symbolSrc, color: rgbToHex(color), scale: scale, text: text };
 			};
 
+			const fromAttribute = (feature) => {
+				return { text: feature.get('name') };
+			};
+
 			const styles = getStyleArray(feature);
-			return styles ? fromStyle(styles[0]) : {};
+			return styles ? fromStyle(styles[0]) : fromAttribute(olFeature);
 		};
 
 		const newStyle = markerStyleFunction(getStyleOption(olFeature));

--- a/test/modules/olMap/services/StyleService.test.js
+++ b/test/modules/olMap/services/StyleService.test.js
@@ -200,6 +200,34 @@ describe('StyleService', () => {
 			expect(textStyle).toContain(jasmine.any(Style));
 		});
 
+		it('adds text-style to feature without style but attribute', () => {
+			const featureWithoutStyle = new Feature({ geometry: new Point([0, 0]) });
+			featureWithoutStyle.set('name', 'foo-name');
+			featureWithoutStyle.setId('draw_text_noStyle');
+
+			const viewMock = {
+				getResolution() {
+					return 50;
+				},
+				once() {}
+			};
+
+			const mapMock = {
+				getView: () => viewMock,
+				getInteractions() {
+					return { getArray: () => [] };
+				}
+			};
+			const layerMock = {};
+			let textStyle = null;
+
+			const styleSetterNoStyleSpy = spyOn(featureWithoutStyle, 'setStyle').and.callFake((f) => (textStyle = f()));
+			instanceUnderTest.addStyle(featureWithoutStyle, mapMock, layerMock);
+
+			expect(styleSetterNoStyleSpy).toHaveBeenCalledWith(jasmine.any(Function));
+			expect(textStyle[0].getText().getText()).toBe('foo-name');
+		});
+
 		it('adds marker-style to feature', () => {
 			const featureWithStyleArray = new Feature({ geometry: new Point([0, 0]) });
 			const featureWithStyleFunction = new Feature({ geometry: new Point([0, 0]) });
@@ -246,6 +274,34 @@ describe('StyleService', () => {
 			instanceUnderTest.addStyle(featureWithoutStyle, mapMock, layerMock);
 			expect(styleSetterNoStyleSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(markerStyle).toContain(jasmine.any(Style));
+		});
+
+		it('adds marker-style to feature without style but attribute', () => {
+			const featureWithoutStyle = new Feature({ geometry: new Point([0, 0]) });
+			featureWithoutStyle.set('name', 'bar-name');
+			featureWithoutStyle.setId('draw_marker_noStyle');
+
+			const viewMock = {
+				getResolution() {
+					return 50;
+				},
+				once() {}
+			};
+
+			const mapMock = {
+				getView: () => viewMock,
+				getInteractions() {
+					return { getArray: () => [] };
+				}
+			};
+			const layerMock = {};
+			let markerStyle = null;
+
+			const styleSetterNoStyleSpy = spyOn(featureWithoutStyle, 'setStyle').and.callFake((f) => (markerStyle = f()));
+			instanceUnderTest.addStyle(featureWithoutStyle, mapMock, layerMock);
+
+			expect(styleSetterNoStyleSpy).toHaveBeenCalledWith(jasmine.any(Function));
+			expect(markerStyle[0].getText().getText()).toBe('bar-name');
 		});
 
 		it('adds NO style to feature with style-type of LINE or POLYGON', () => {


### PR DESCRIPTION
Updating StyleService for added features without existing style but id and attribute leading to style-information about marker- or text-styles.

This use case can occur when a feature is imported from a geojson resource.