### PR TITLE
make highlight features selectable

### DIFF
--- a/src/i18n/global.provider.js
+++ b/src/i18n/global.provider.js
@@ -15,7 +15,9 @@ export const provide = (lang) => {
 				global_import_authenticationModal_title: 'Authentication required',
 				global_locally_imported_dataset_copyright_label: 'Dataset and/or style provided by third party',
 				global_share_unsupported_geoResource_warning: "The following layers won't be shared:",
-				global_privacy_policy_url: 'https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html'
+				global_privacy_policy_url: 'https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html',
+				global_marker_symbol_label: 'Marker',
+				global_featureInfo_not_available: 'FeatureInfo is not available'
 			};
 
 		case 'de':
@@ -33,7 +35,9 @@ export const provide = (lang) => {
 				global_import_authenticationModal_title: 'Anmeldung erforderlich',
 				global_locally_imported_dataset_copyright_label: 'Mit Darstellung durch den Anwender',
 				global_share_unsupported_geoResource_warning: 'Folgende Ebenen werden nicht geteilt:',
-				global_privacy_policy_url: 'https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html'
+				global_privacy_policy_url: 'https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html',
+				global_marker_symbol_label: 'Markierung',
+				global_featureInfo_not_available: 'FeatureInfo ist nicht verfügbar'
 			};
 
 		default:

--- a/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -68,7 +68,7 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 		};
 
 		//use only visible and unhidden layers
-		const layerFilter = (layerProperties) => layerProperties.visible && !layerProperties.constraints.hidden;
+		const layerFilter = (layerProperties) => layerProperties.visible;
 
 		observe(
 			this._storeService.getStore(),
@@ -86,10 +86,18 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 					})
 					//map olLayer to olFeature (wrapper)
 					.map((olLayerContainer) => {
-						const { layerProperties: layerProperties, olLayer } = olLayerContainer;
+						const { layerProperties, olLayer } = olLayerContainer;
 						return { olFeature: findOlFeature(map, map.getPixelFromCoordinate(coordinate.payload), olLayer), layerProperties: layerProperties };
 					})
 					.filter((olFeatureContainer) => !!olFeatureContainer.olFeature)
+					.filter((olFeatureContainer) => {
+						const { layerProperties, olFeature } = olFeatureContainer;
+						//only features containing a name are allowed to be selected for hidden layers!
+						if (layerProperties.constraints.hidden) {
+							return !!olFeature.get('name');
+						}
+						return olFeature;
+					})
 					//map olFeature to FeatureInfo item
 					.map((olFeatureContainer) => this._featureInfoProvider(olFeatureContainer.olFeature, olFeatureContainer.layerProperties))
 					// .filter(featureInfo => !!featureInfo)

--- a/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -68,7 +68,7 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 		};
 
 		//use only visible and unhidden layers
-		const layerFilter = (layerProperties) => layerProperties.visible;
+		const layerFilter = (layerProperties) => layerProperties.visible && !layerProperties.constraints.hidden;
 
 		observe(
 			this._storeService.getStore(),

--- a/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -90,8 +90,6 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 						return { olFeature: findOlFeature(map, map.getPixelFromCoordinate(coordinate.payload), olLayer), layerProperties: layerProperties };
 					})
 					.filter((olFeatureContainer) => !!olFeatureContainer.olFeature)
-					//only features containing a name are allowed to be selected!
-					.filter((olFeatureContainer) => !!olFeatureContainer.olFeature.get('name'))
 					//map olFeature to FeatureInfo item
 					.map((olFeatureContainer) => this._featureInfoProvider(olFeatureContainer.olFeature, olFeatureContainer.layerProperties))
 					// .filter(featureInfo => !!featureInfo)

--- a/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -68,7 +68,7 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 		};
 
 		//use only visible and unhidden layers
-		const layerFilter = (layerProperties) => layerProperties.visible && !layerProperties.constraints.hidden;
+		const layerFilter = (layerProperties) => layerProperties.visible;
 
 		observe(
 			this._storeService.getStore(),

--- a/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -93,7 +93,7 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 					//map olFeature to FeatureInfo item
 					.map((olFeatureContainer) => this._featureInfoProvider(olFeatureContainer.olFeature, olFeatureContainer.layerProperties))
 					// .filter(featureInfo => !!featureInfo)
-					.map((featureInfo) => (featureInfo ? featureInfo : { title: translate('olMap_handler_featureInfo_not_available'), content: '' }))
+					.map((featureInfo) => (featureInfo ? featureInfo : { title: translate('global_featureInfo_not_available'), content: '' }))
 					//display FeatureInfo items in the same order as layers
 					.reverse();
 

--- a/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -90,6 +90,8 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 						return { olFeature: findOlFeature(map, map.getPixelFromCoordinate(coordinate.payload), olLayer), layerProperties: layerProperties };
 					})
 					.filter((olFeatureContainer) => !!olFeatureContainer.olFeature)
+					//only features containing a name are allowed to be selected!
+					.filter((olFeatureContainer) => !!olFeatureContainer.olFeature.get('name'))
 					//map olFeature to FeatureInfo item
 					.map((olFeatureContainer) => this._featureInfoProvider(olFeatureContainer.olFeature, olFeatureContainer.layerProperties))
 					// .filter(featureInfo => !!featureInfo)

--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -62,7 +62,11 @@ export const getBvvFeatureInfo = (olFeature, layerProperties) => {
 	};
 
 	const geoRes = geoResourceService.byId(layerProperties.geoResourceId);
-	const name = olFeature.get('name') ? `${securityService.sanitizeHtml(olFeature.get('name'))} - ${geoRes.label}` : `${geoRes.label}`;
+	const name = geoRes
+		? olFeature.get('name')
+			? `${securityService.sanitizeHtml(olFeature.get('name'))} - ${geoRes.label}`
+			: `${geoRes.label}`
+		: `${securityService.sanitizeHtml(olFeature.get('name') ?? '')}`;
 	const content = getContent();
 	const geometry = { data: new GeoJSON().writeGeometry(olFeature.getGeometry()), geometryType: FeatureInfoGeometryTypes.GEOJSON };
 	return { title: name, content: content, geometry: geometry };

--- a/src/modules/olMap/handler/highlight/OlHighlightLayerHandler.js
+++ b/src/modules/olMap/handler/highlight/OlHighlightLayerHandler.js
@@ -66,19 +66,24 @@ export class OlHighlightLayerHandler extends OlLayerHandler {
 	}
 
 	_toOlFeature(feature) {
-		const { data } = feature;
+		const { data, label } = feature;
+
+		const addLabel = (olFeature) => {
+			olFeature.set('name', label);
+			return olFeature;
+		};
 
 		//we have a HighlightCoordinate
 		if (data.coordinate) {
-			return this._appendStyle(feature, new Feature(new Point(data.coordinate)));
+			return this._appendStyle(feature, addLabel(new Feature(new Point(data.coordinate))));
 		}
 
 		//we have a HighlightGeometry
 		switch (data.geometryType) {
 			case HighlightGeometryType.WKT:
-				return this._appendStyle(feature, new WKT().readFeature(data.geometry));
+				return this._appendStyle(feature, addLabel(new WKT().readFeature(data.geometry)));
 			case HighlightGeometryType.GEOJSON:
-				return this._appendStyle(feature, new GeoJSON().readFeature(data.geometry));
+				return this._appendStyle(feature, addLabel(new GeoJSON().readFeature(data.geometry)));
 		}
 		return null;
 	}

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -37,12 +37,18 @@ export const SEARCH_RESULT_TEMPORARY_HIGHLIGHT_FEATURE_ID = 'searchResultTempora
  * @author taulinger
  */
 export class HighlightPlugin extends BaPlugin {
+	constructor() {
+		super();
+		const { TranslationService: translationService } = $injector.inject('TranslationService');
+		this._translationService = translationService;
+	}
 	/**
 	 * @override
 	 * @param {Store} store
 	 */
 	async register(store) {
 		const highlightFeatureId = createUniqueId();
+		const translate = (key) => this._translationService.translate(key);
 
 		const onChange = (active) => {
 			if (active) {
@@ -93,7 +99,12 @@ export class HighlightPlugin extends BaPlugin {
 
 		if (crosshair) {
 			setTimeout(() => {
-				addHighlightFeatures({ id: createUniqueId(), data: { coordinate: store.getState().position.center }, type: HighlightFeatureType.DEFAULT });
+				addHighlightFeatures({
+					id: createUniqueId(),
+					label: translate('global_marker_symbol_label'),
+					data: { coordinate: store.getState().position.center },
+					type: HighlightFeatureType.DEFAULT
+				});
 			});
 		}
 

--- a/test/i18n/global.provider.test.js
+++ b/test/i18n/global.provider.test.js
@@ -18,6 +18,8 @@ describe('global i18n', () => {
 		expect(map.global_locally_imported_dataset_copyright_label).toBe('Dataset and/or style provided by third party');
 		expect(map.global_share_unsupported_geoResource_warning).toBe("The following layers won't be shared:");
 		expect(map.global_privacy_policy_url).toBe('https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html');
+		expect(map.global_marker_symbol_label).toBe('Marker');
+		expect(map.global_featureInfo_not_available).toBe('FeatureInfo is not available');
 	});
 
 	it('provides translation for de', () => {
@@ -37,10 +39,12 @@ describe('global i18n', () => {
 		expect(map.global_locally_imported_dataset_copyright_label).toBe('Mit Darstellung durch den Anwender');
 		expect(map.global_share_unsupported_geoResource_warning).toBe('Folgende Ebenen werden nicht geteilt:');
 		expect(map.global_privacy_policy_url).toBe('https://geoportal.bayern.de/geoportalbayern/seiten/datenschutz.html');
+		expect(map.global_marker_symbol_label).toBe('Markierung');
+		expect(map.global_featureInfo_not_available).toBe('FeatureInfo ist nicht verfügbar');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 12;
+		const expectedSize = 14;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -280,6 +280,15 @@ describe('OlFeatureInfoHandler', () => {
 			await TestUtils.timeout(TestDelay);
 			expect(store.getState().featureInfo.current).toHaveSize(1);
 			expect(store.getState().highlight.features).toHaveSize(1);
+
+			//we modify the second layer so that it is not queryable anymore
+			modifyLayer(layerId1, { constraints: { hidden: true } });
+			abortOrReset();
+			startRequest(matchingCoordinate);
+
+			await TestUtils.timeout(TestDelay);
+			expect(store.getState().featureInfo.current).toHaveSize(0);
+			expect(store.getState().highlight.features).toHaveSize(0);
 		});
 
 		it('ignores a clustered feature containing more than one features', async () => {

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -280,6 +280,15 @@ describe('OlFeatureInfoHandler', () => {
 			await TestUtils.timeout(TestDelay);
 			expect(store.getState().featureInfo.current).toHaveSize(1);
 			expect(store.getState().highlight.features).toHaveSize(1);
+
+			// we modify the feature1 by re-setting its name property
+			feature1.set('name', undefined);
+			abortOrReset();
+			startRequest(matchingCoordinate);
+
+			await TestUtils.timeout(TestDelay);
+			expect(store.getState().featureInfo.current).toHaveSize(0);
+			expect(store.getState().highlight.features).toHaveSize(0);
 		});
 
 		it('ignores a clustered feature containing more than one features', async () => {
@@ -333,6 +342,7 @@ describe('OlFeatureInfoHandler', () => {
 			const geometry = new Point(matchingCoordinate);
 			const olVectorSource0 = new VectorSource();
 			const feature0 = new Feature({ geometry: geometry });
+			feature0.set('name', 'name0');
 
 			olVectorSource0.addFeature(feature0);
 			vectorLayer0.setSource(olVectorSource0);
@@ -340,6 +350,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			const olVectorSource1 = new VectorSource();
 			const feature1 = new Feature({ geometry: geometry });
+			feature1.set('name', 'name1');
 
 			olVectorSource1.addFeature(feature1);
 			vectorLayer1.setSource(olVectorSource1);

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -280,15 +280,6 @@ describe('OlFeatureInfoHandler', () => {
 			await TestUtils.timeout(TestDelay);
 			expect(store.getState().featureInfo.current).toHaveSize(1);
 			expect(store.getState().highlight.features).toHaveSize(1);
-
-			// we modify the feature1 by re-setting its name property
-			feature1.set('name', undefined);
-			abortOrReset();
-			startRequest(matchingCoordinate);
-
-			await TestUtils.timeout(TestDelay);
-			expect(store.getState().featureInfo.current).toHaveSize(0);
-			expect(store.getState().highlight.features).toHaveSize(0);
 		});
 
 		it('ignores a clustered feature containing more than one features', async () => {
@@ -342,7 +333,6 @@ describe('OlFeatureInfoHandler', () => {
 			const geometry = new Point(matchingCoordinate);
 			const olVectorSource0 = new VectorSource();
 			const feature0 = new Feature({ geometry: geometry });
-			feature0.set('name', 'name0');
 
 			olVectorSource0.addFeature(feature0);
 			vectorLayer0.setSource(olVectorSource0);
@@ -350,7 +340,6 @@ describe('OlFeatureInfoHandler', () => {
 
 			const olVectorSource1 = new VectorSource();
 			const feature1 = new Feature({ geometry: geometry });
-			feature1.set('name', 'name1');
 
 			olVectorSource1.addFeature(feature1);
 			vectorLayer1.setSource(olVectorSource1);

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -281,8 +281,17 @@ describe('OlFeatureInfoHandler', () => {
 			expect(store.getState().featureInfo.current).toHaveSize(1);
 			expect(store.getState().highlight.features).toHaveSize(1);
 
-			//we modify the second layer so that it is not queryable anymore
+			//we modify the second layer so that it is not queryable anymore, but the feature1 has a name property
 			modifyLayer(layerId1, { constraints: { hidden: true } });
+			abortOrReset();
+			startRequest(matchingCoordinate);
+
+			await TestUtils.timeout(TestDelay);
+			expect(store.getState().featureInfo.current).toHaveSize(1);
+			expect(store.getState().highlight.features).toHaveSize(1);
+
+			//we modify feature1 by setting the name property to undefined
+			feature1.set('name', undefined);
 			abortOrReset();
 			startRequest(matchingCoordinate);
 

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -280,15 +280,6 @@ describe('OlFeatureInfoHandler', () => {
 			await TestUtils.timeout(TestDelay);
 			expect(store.getState().featureInfo.current).toHaveSize(1);
 			expect(store.getState().highlight.features).toHaveSize(1);
-
-			//we modify the second layer so that it is not queryable anymore
-			modifyLayer(layerId1, { constraints: { hidden: true } });
-			abortOrReset();
-			startRequest(matchingCoordinate);
-
-			await TestUtils.timeout(TestDelay);
-			expect(store.getState().featureInfo.current).toHaveSize(0);
-			expect(store.getState().highlight.features).toHaveSize(0);
 		});
 
 		it('ignores a clustered feature containing more than one features', async () => {

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -361,8 +361,8 @@ describe('OlFeatureInfoHandler', () => {
 			startRequest(matchingCoordinate);
 
 			expect(store.getState().featureInfo.current).toHaveSize(2);
-			expect(store.getState().featureInfo.current[0]).toEqual({ title: 'olMap_handler_featureInfo_not_available', content: '' });
-			expect(store.getState().featureInfo.current[1]).toEqual({ title: 'olMap_handler_featureInfo_not_available', content: '' });
+			expect(store.getState().featureInfo.current[0]).toEqual({ title: 'global_featureInfo_not_available', content: '' });
+			expect(store.getState().featureInfo.current[1]).toEqual({ title: 'global_featureInfo_not_available', content: '' });
 			expect(store.getState().highlight.features).toHaveSize(0);
 		});
 	});

--- a/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
+++ b/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
@@ -69,96 +69,159 @@ describe('FeatureInfo provider', () => {
 		});
 
 		describe('and suitable properties are available', () => {
-			it('returns a LayerInfo item', () => {
-				const target = document.createElement('div');
-				const geoResourceId = 'geoResourceId';
-				spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue({ label: 'foo' } /*fake GeoResource */);
-				const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
-				const geometry = new Point(coordinate);
-				let feature = new Feature({ geometry: geometry });
-				feature.set('name', 'name');
-				const expectedFeatureInfoGeometry = {
-					data: new GeoJSON().writeGeometry(geometry),
-					geometryType: FeatureInfoGeometryTypes.GEOJSON
-				};
+			describe('and a GeoResource is available', () => {
+				it('returns a LayerInfo item', () => {
+					const target = document.createElement('div');
+					const geoResourceId = 'geoResourceId';
+					spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue({ label: 'foo' } /*fake GeoResource */);
+					const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
+					const geometry = new Point(coordinate);
+					let feature = new Feature({ geometry: geometry });
+					feature.set('name', 'name');
+					const expectedFeatureInfoGeometry = {
+						data: new GeoJSON().writeGeometry(geometry),
+						geometryType: FeatureInfoGeometryTypes.GEOJSON
+					};
 
-				let featureInfo = getBvvFeatureInfo(feature, layerProperties);
-				render(featureInfo.content, target);
+					let featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
 
-				expect(featureInfo).toEqual({
-					title: 'name - foo',
-					content: jasmine.any(Object),
-					geometry: expectedFeatureInfoGeometry
+					expect(featureInfo).toEqual({
+						title: 'name - foo',
+						content: jasmine.any(Object),
+						geometry: expectedFeatureInfoGeometry
+					});
+					expect(target.innerText.trim()).toBe('');
+					expect(target.querySelector('ba-geometry-info')).toBeTruthy();
+					expect(target.querySelector('ba-profile-chip')).toBeTruthy();
+					expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
+
+					//no name property, but description property
+					feature = new Feature({ geometry: new Point(coordinate) });
+					feature.set('description', 'description');
+
+					featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
+
+					expect(featureInfo).toEqual({
+						title: 'foo',
+						content: jasmine.any(Object),
+						geometry: expectedFeatureInfoGeometry
+					});
+					expect(target.querySelector('.content').innerText).toBe('description');
+					expect(target.querySelector('ba-geometry-info')).toBeTruthy();
+					expect(target.querySelector('ba-profile-chip')).toBeTruthy();
+					expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
+
+					//no name property, but desc property
+					feature = new Feature({ geometry: new Point(coordinate) });
+					feature.set('desc', 'desc');
+
+					featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
+
+					expect(featureInfo).toEqual({
+						title: 'foo',
+						content: jasmine.any(Object),
+						geometry: expectedFeatureInfoGeometry
+					});
+					expect(target.querySelector('.content').innerText).toBe('desc');
+					expect(target.querySelector('ba-geometry-info')).toBeTruthy();
+					expect(target.querySelector('ba-profile-chip')).toBeTruthy();
+					expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
 				});
-				expect(target.innerText.trim()).toBe('');
-				expect(target.querySelector('ba-geometry-info')).toBeTruthy();
-				expect(target.querySelector('ba-profile-chip')).toBeTruthy();
 
-				//no name property, but description property
-				feature = new Feature({ geometry: new Point(coordinate) });
-				feature.set('description', 'description');
+				it('should sanitize description content', () => {
+					const target = document.createElement('div');
+					const geoResourceId = 'geoResourceId';
+					spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue({ label: 'foo' } /*fake GeoResource */);
+					const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
+					const geometry = new Point(coordinate);
+					let feature = new Feature({ geometry: geometry });
+					feature = new Feature({ geometry: new Point(coordinate) });
+					feature.set('description', 'description');
+					const sanitizeSpy = spyOn(securityServiceMock, 'sanitizeHtml').withArgs('description').and.callThrough();
+					const featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
 
-				featureInfo = getBvvFeatureInfo(feature, layerProperties);
-				render(featureInfo.content, target);
-
-				expect(featureInfo).toEqual({
-					title: 'foo',
-					content: jasmine.any(Object),
-					geometry: expectedFeatureInfoGeometry
+					expect(sanitizeSpy).toHaveBeenCalledOnceWith('description');
 				});
-				expect(target.querySelector('.content').innerText).toBe('description');
-				expect(target.querySelector('ba-geometry-info')).toBeTruthy();
-				expect(target.querySelector('ba-profile-chip')).toBeTruthy();
-				expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
 
-				//no name property, but desc property
-				feature = new Feature({ geometry: new Point(coordinate) });
-				feature.set('desc', 'desc');
+				it('should sanitize name content', () => {
+					const target = document.createElement('div');
+					const geoResourceId = 'geoResourceId';
+					spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue({ label: 'foo' } /*fake GeoResource */);
+					const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
+					const geometry = new Point(coordinate);
+					let feature = new Feature({ geometry: geometry });
+					feature = new Feature({ geometry: new Point(coordinate) });
+					feature.set('name', 'name');
+					const sanitizeSpy = spyOn(securityServiceMock, 'sanitizeHtml').withArgs('name').and.callThrough();
+					const featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
 
-				featureInfo = getBvvFeatureInfo(feature, layerProperties);
-				render(featureInfo.content, target);
-
-				expect(featureInfo).toEqual({
-					title: 'foo',
-					content: jasmine.any(Object),
-					geometry: expectedFeatureInfoGeometry
+					expect(sanitizeSpy).toHaveBeenCalledOnceWith('name');
 				});
-				expect(target.querySelector('.content').innerText).toBe('desc');
-				expect(target.querySelector('ba-geometry-info')).toBeTruthy();
-				expect(target.querySelector('ba-profile-chip')).toBeTruthy();
-				expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
 			});
 
-			it('should sanitize description content', () => {
-				const target = document.createElement('div');
-				const geoResourceId = 'geoResourceId';
-				spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue({ label: 'foo' } /*fake GeoResource */);
-				const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
-				const geometry = new Point(coordinate);
-				let feature = new Feature({ geometry: geometry });
-				feature = new Feature({ geometry: new Point(coordinate) });
-				feature.set('description', 'description');
-				const sanitizeSpy = spyOn(securityServiceMock, 'sanitizeHtml').withArgs('description').and.callThrough();
-				const featureInfo = getBvvFeatureInfo(feature, layerProperties);
-				render(featureInfo.content, target);
+			describe('and a GeoResource is NOT available', () => {
+				it('returns a LayerInfo item', () => {
+					const target = document.createElement('div');
+					const geoResourceId = 'geoResourceId';
+					spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue(null);
+					const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
+					const geometry = new Point(coordinate);
+					let feature = new Feature({ geometry: geometry });
+					feature.set('name', 'name');
+					const expectedFeatureInfoGeometry = {
+						data: new GeoJSON().writeGeometry(geometry),
+						geometryType: FeatureInfoGeometryTypes.GEOJSON
+					};
 
-				expect(sanitizeSpy).toHaveBeenCalled();
-			});
+					let featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
 
-			it('should sanitize name content', () => {
-				const target = document.createElement('div');
-				const geoResourceId = 'geoResourceId';
-				spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue({ label: 'foo' } /*fake GeoResource */);
-				const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
-				const geometry = new Point(coordinate);
-				let feature = new Feature({ geometry: geometry });
-				feature = new Feature({ geometry: new Point(coordinate) });
-				feature.set('name', 'name');
-				const sanitizeSpy = spyOn(securityServiceMock, 'sanitizeHtml').withArgs('name').and.callThrough();
-				const featureInfo = getBvvFeatureInfo(feature, layerProperties);
-				render(featureInfo.content, target);
+					expect(featureInfo).toEqual({
+						title: 'name',
+						content: jasmine.any(Object),
+						geometry: expectedFeatureInfoGeometry
+					});
+					expect(target.innerText.trim()).toBe('');
+					expect(target.querySelector('ba-geometry-info')).toBeTruthy();
+					expect(target.querySelector('ba-profile-chip')).toBeTruthy();
+					expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
 
-				expect(sanitizeSpy).toHaveBeenCalled();
+					//no name property
+					feature = new Feature({ geometry: new Point(coordinate) });
+
+					featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
+
+					expect(featureInfo).toEqual({
+						title: '',
+						content: jasmine.any(Object),
+						geometry: expectedFeatureInfoGeometry
+					});
+					expect(target.querySelector('ba-geometry-info')).toBeTruthy();
+					expect(target.querySelector('ba-profile-chip')).toBeTruthy();
+					expect(target.querySelector('ba-export-vector-data-chip')).toBeTruthy();
+				});
+
+				it('should sanitize name content', () => {
+					const sanitizeSpy = spyOn(securityServiceMock, 'sanitizeHtml').withArgs('name').and.callThrough();
+					const target = document.createElement('div');
+					const geoResourceId = 'geoResourceId';
+					spyOn(geoResourceServiceMock, 'byId').withArgs(geoResourceId).and.returnValue(null);
+					const layerProperties = { ...createDefaultLayerProperties(), geoResourceId: geoResourceId };
+					const geometry = new Point(coordinate);
+					const feature = new Feature({ geometry: geometry });
+					feature.set('name', 'name');
+
+					const featureInfo = getBvvFeatureInfo(feature, layerProperties);
+					render(featureInfo.content, target);
+
+					expect(sanitizeSpy).toHaveBeenCalledOnceWith('name');
+				});
 			});
 
 			it('should supply exportVectorDataChip with exportData as KML', () => {

--- a/test/modules/olMap/handler/highlight/OlHighlightLayerHandler.test.js
+++ b/test/modules/olMap/handler/highlight/OlHighlightLayerHandler.test.js
@@ -159,7 +159,7 @@ describe('OlHighlightLayerHandler', () => {
 			expect(handler._olLayer).toBeNull();
 		});
 
-		it('unregisters observer', () => {
+		it('un-registers observer', () => {
 			const map = setupMap();
 			setup();
 			const handler = new OlHighlightLayerHandler();
@@ -177,9 +177,12 @@ describe('OlHighlightLayerHandler', () => {
 			setup();
 			const handler = new OlHighlightLayerHandler();
 			const appendStyleSpy = spyOn(handler, '_appendStyle').withArgs(jasmine.anything(), jasmine.any(Feature)).and.callThrough();
-			const highlightCoordinateFeature = { data: { coordinate: [1, 0] } };
+			const highlightCoordinateFeature = { data: { coordinate: [1, 0] }, label: 'label' };
 
-			expect(handler._toOlFeature(highlightCoordinateFeature).getGeometry().getCoordinates()).toEqual(highlightCoordinateFeature.data.coordinate);
+			const olFeature = handler._toOlFeature(highlightCoordinateFeature);
+
+			expect(olFeature.getGeometry().getCoordinates()).toEqual(highlightCoordinateFeature.data.coordinate);
+			expect(olFeature.get('name')).toBe('label');
 			expect(appendStyleSpy).toHaveBeenCalledTimes(1);
 		});
 
@@ -188,14 +191,21 @@ describe('OlHighlightLayerHandler', () => {
 			const handler = new OlHighlightLayerHandler();
 			const appendStyleSpy = spyOn(handler, '_appendStyle').withArgs(jasmine.anything(), jasmine.any(Feature)).and.callThrough();
 			const highlightGeometryWktFeature = {
-				data: { geometry: new WKT().writeGeometry(new Point([21, 42])), geometryType: HighlightGeometryType.WKT }
+				data: { geometry: new WKT().writeGeometry(new Point([21, 42])), geometryType: HighlightGeometryType.WKT },
+				label: 'WKT'
 			};
 			const highlightGeometryGeoJsonFeature = {
-				data: { geometry: new GeoJSON().writeGeometry(new Point([5, 10])), geometryType: HighlightGeometryType.GEOJSON }
+				data: { geometry: new GeoJSON().writeGeometry(new Point([5, 10])), geometryType: HighlightGeometryType.GEOJSON },
+				label: 'GeoJSON'
 			};
 
-			expect(handler._toOlFeature(highlightGeometryWktFeature).getGeometry().getCoordinates()).toEqual([21, 42]);
-			expect(handler._toOlFeature(highlightGeometryGeoJsonFeature).getGeometry().getCoordinates()).toEqual([5, 10]);
+			const olFeature0 = handler._toOlFeature(highlightGeometryWktFeature);
+			const olFeature1 = handler._toOlFeature(highlightGeometryGeoJsonFeature);
+
+			expect(olFeature0.getGeometry().getCoordinates()).toEqual([21, 42]);
+			expect(olFeature0.get('name')).toBe('WKT');
+			expect(olFeature1.getGeometry().getCoordinates()).toEqual([5, 10]);
+			expect(olFeature1.get('name')).toBe('GeoJSON');
 			expect(appendStyleSpy).toHaveBeenCalledTimes(2);
 		});
 

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -33,6 +33,10 @@ describe('HighlightPlugin', () => {
 		}
 	};
 
+	const translationService = {
+		translate: (key) => key
+	};
+
 	const setup = (state) => {
 		const initialState = {
 			mainMenu: {
@@ -54,7 +58,7 @@ describe('HighlightPlugin', () => {
 			featureInfo: featureInfoReducer,
 			search: searchReducer
 		});
-		$injector.registerSingleton('EnvironmentService', { getWindow: () => windowMock });
+		$injector.registerSingleton('EnvironmentService', { getWindow: () => windowMock }).registerSingleton('TranslationService', translationService);
 		return store;
 	};
 
@@ -278,6 +282,7 @@ describe('HighlightPlugin', () => {
 
 			expect(store.getState().highlight.features).toHaveSize(1);
 			expect(store.getState().highlight.features[0].data.coordinate).toEqual(coordinate);
+			expect(store.getState().highlight.features[0].label).toBe('global_marker_symbol_label');
 			expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.DEFAULT);
 		});
 	});


### PR DESCRIPTION
Features of hidden layers are selectable if they contain a `name` property.

![grafik](https://github.com/ldbv-by/bav4/assets/49945713/0dd2e3f1-bdab-4cdb-b7ce-a02d74832cdb)

