### PR TITLE
add maplibre-gl as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 				"dompurify": "3.0.3",
 				"geographiclib-geodesic": "^2.0.0",
 				"lit-html": "2.7.4",
-				"ol": "7.4.0",
+				"maplibre-gl": "^3.1.0",
+				"ol": "^7.4.0",
 				"proj4": "2.9.0",
 				"redux": "4.2.1",
 				"vanilla-swipe": "2.4.1"
@@ -839,7 +840,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
 			"integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-			"peer": true,
 			"dependencies": {
 				"get-stream": "^6.0.1",
 				"minimist": "^1.2.6"
@@ -877,22 +877,15 @@
 				"gl-style-validate": "bin/gl-style-validate.js"
 			}
 		},
-		"node_modules/@mapbox/mapbox-gl-supported": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-			"integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==",
-			"peer": true
-		},
 		"node_modules/@mapbox/point-geometry": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
 			"integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
 		},
 		"node_modules/@mapbox/tiny-sdf": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-			"integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw==",
-			"peer": true
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+			"integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
 		},
 		"node_modules/@mapbox/unitbezier": {
 			"version": "0.0.0",
@@ -903,7 +896,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
 			"integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-			"peer": true,
 			"dependencies": {
 				"@mapbox/point-geometry": "~0.1.0"
 			}
@@ -912,9 +904,70 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
 			"integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@maplibre/maplibre-gl-style-spec": {
+			"version": "19.2.1",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.2.1.tgz",
+			"integrity": "sha512-ZVT5QlkVhlxlPav+ca0NO3Moc7EzbHDO2FXW4ic3Q0Vm+TDUw9I8A2EBws7xUUQZf7HQB3kQ+3Jsh5mFLRD4GQ==",
+			"dependencies": {
+				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
+				"@mapbox/point-geometry": "^0.1.0",
+				"@mapbox/unitbezier": "^0.0.1",
+				"@types/mapbox__point-geometry": "^0.1.2",
+				"json-stringify-pretty-compact": "^3.0.0",
+				"minimist": "^1.2.8",
+				"rw": "^1.3.3",
+				"sort-object": "^3.0.3"
+			},
+			"bin": {
+				"gl-style-format": "dist/gl-style-format.mjs",
+				"gl-style-migrate": "dist/gl-style-migrate.mjs",
+				"gl-style-validate": "dist/gl-style-validate.mjs"
+			}
+		},
+		"node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+			"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
+		},
+		"node_modules/@maplibre/maplibre-gl-style-spec/node_modules/json-stringify-pretty-compact": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+			"integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+		},
+		"node_modules/@maplibre/maplibre-gl-style-spec/node_modules/sort-asc": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+			"integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@maplibre/maplibre-gl-style-spec/node_modules/sort-desc": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+			"integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@maplibre/maplibre-gl-style-spec/node_modules/sort-object": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+			"integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+			"dependencies": {
+				"bytewise": "^1.1.0",
+				"get-value": "^2.0.2",
+				"is-extendable": "^0.1.1",
+				"sort-asc": "^0.2.0",
+				"sort-desc": "^0.2.0",
+				"union-value": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1109,8 +1162,7 @@
 		"node_modules/@types/geojson": {
 			"version": "7946.0.10",
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-			"integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
-			"peer": true
+			"integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
 		},
 		"node_modules/@types/html-minifier-terser": {
 			"version": "6.0.0",
@@ -1148,14 +1200,12 @@
 		"node_modules/@types/mapbox__point-geometry": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-			"integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
-			"peer": true
+			"integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
 		},
 		"node_modules/@types/mapbox__vector-tile": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
 			"integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
-			"peer": true,
 			"dependencies": {
 				"@types/geojson": "*",
 				"@types/mapbox__point-geometry": "*",
@@ -1205,8 +1255,7 @@
 		"node_modules/@types/pbf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-			"integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
-			"peer": true
+			"integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.7",
@@ -1638,6 +1687,14 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/array-flatten": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -1722,6 +1779,14 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1913,6 +1978,23 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/bytewise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+			"dependencies": {
+				"bytewise-core": "^1.2.2",
+				"typewise": "^1.0.3"
+			}
+		},
+		"node_modules/bytewise-core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+			"dependencies": {
+				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -3900,6 +3982,17 @@
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
 		},
+		"node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4305,8 +4398,7 @@
 		"node_modules/geojson-vt": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-			"integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-			"peer": true
+			"integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
 		},
 		"node_modules/geotiff": {
 			"version": "2.0.7",
@@ -4384,6 +4476,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/gh-pages": {
@@ -4483,8 +4583,7 @@
 		"node_modules/gl-matrix": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-			"integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
-			"peer": true
+			"integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
 		},
 		"node_modules/glob": {
 			"version": "7.1.6",
@@ -5252,6 +5351,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5343,7 +5450,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"dependencies": {
 				"isobject": "^3.0.1"
 			},
@@ -5491,7 +5597,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6223,10 +6328,9 @@
 			}
 		},
 		"node_modules/kdbush": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-			"integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-			"peer": true
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+			"integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
 		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
@@ -6451,43 +6555,47 @@
 			"integrity": "sha512-f+NBjJJY4T3dHtlEz1wCG7YFlkODEjFIYlxDdLIDMNpkSksqTt+l/d4rjuwItxuzkuMFvPyrjzV2lxRM4ePcIA=="
 		},
 		"node_modules/maplibre-gl": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.4.0.tgz",
-			"integrity": "sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==",
-			"hasInstallScript": true,
-			"peer": true,
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.1.0.tgz",
+			"integrity": "sha512-KFarVUUszCEucPwnGsFJtPMQBg/F6lg+SPDmTztKUD/n0YShETjIOdNmm5jpxacEX3+dq50MzlqDr6VH+RtDDA==",
 			"dependencies": {
 				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
-				"@mapbox/mapbox-gl-supported": "^2.0.1",
 				"@mapbox/point-geometry": "^0.1.0",
-				"@mapbox/tiny-sdf": "^2.0.5",
+				"@mapbox/tiny-sdf": "^2.0.6",
 				"@mapbox/unitbezier": "^0.0.1",
 				"@mapbox/vector-tile": "^1.3.1",
 				"@mapbox/whoots-js": "^3.1.0",
+				"@maplibre/maplibre-gl-style-spec": "^19.2.1",
 				"@types/geojson": "^7946.0.10",
 				"@types/mapbox__point-geometry": "^0.1.2",
 				"@types/mapbox__vector-tile": "^1.3.0",
 				"@types/pbf": "^3.0.2",
-				"csscolorparser": "~1.0.3",
 				"earcut": "^2.2.4",
 				"geojson-vt": "^3.2.1",
 				"gl-matrix": "^3.4.3",
 				"global-prefix": "^3.0.0",
+				"kdbush": "^4.0.2",
 				"murmurhash-js": "^1.0.0",
 				"pbf": "^3.2.1",
-				"potpack": "^1.0.2",
+				"potpack": "^2.0.0",
 				"quickselect": "^2.0.0",
-				"supercluster": "^7.1.5",
+				"supercluster": "^8.0.1",
 				"tinyqueue": "^2.0.3",
 				"vt-pbf": "^3.1.3"
+			},
+			"engines": {
+				"node": ">=16.14.0",
+				"npm": ">=8.1.0"
+			},
+			"funding": {
+				"url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
 			}
 		},
 		"node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-			"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-			"peer": true
+			"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
 		},
 		"node_modules/markdown-it": {
 			"version": "12.3.2",
@@ -6744,9 +6852,12 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minimist-options": {
 			"version": "4.1.0",
@@ -6814,8 +6925,7 @@
 		"node_modules/murmurhash-js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-			"peer": true
+			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.6",
@@ -7613,10 +7723,9 @@
 			"dev": true
 		},
 		"node_modules/potpack": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-			"integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-			"peer": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+			"integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -8417,6 +8526,20 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8739,6 +8862,40 @@
 				"wbuf": "^1.7.3"
 			}
 		},
+		"node_modules/split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dependencies": {
+				"extend-shallow": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/split-string/node_modules/extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+			"dependencies": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/split-string/node_modules/is-extendable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+			"dependencies": {
+				"is-plain-object": "^2.0.4"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -9040,12 +9197,11 @@
 			}
 		},
 		"node_modules/supercluster": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-			"integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
-			"peer": true,
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+			"integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
 			"dependencies": {
-				"kdbush": "^3.0.0"
+				"kdbush": "^4.0.2"
 			}
 		},
 		"node_modules/supports-color": {
@@ -9238,8 +9394,7 @@
 		"node_modules/tinyqueue": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-			"peer": true
+			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
 		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
@@ -9385,6 +9540,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/typewise": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+			"dependencies": {
+				"typewise-core": "^1.2.0"
+			}
+		},
+		"node_modules/typewise-core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
+		},
 		"node_modules/ua-parser-js": {
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
@@ -9430,6 +9598,20 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
 			"integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
 			"dev": true
+		},
+		"node_modules/union-value": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"dependencies": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/universalify": {
 			"version": "2.0.0",
@@ -9531,7 +9713,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
 			"integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
-			"peer": true,
 			"dependencies": {
 				"@mapbox/point-geometry": "0.1.0",
 				"@mapbox/vector-tile": "^1.3.1",
@@ -10946,7 +11127,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
 			"integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-			"peer": true,
 			"requires": {
 				"get-stream": "^6.0.1",
 				"minimist": "^1.2.6"
@@ -10972,22 +11152,15 @@
 				"sort-object": "^0.3.2"
 			}
 		},
-		"@mapbox/mapbox-gl-supported": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-			"integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==",
-			"peer": true
-		},
 		"@mapbox/point-geometry": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
 			"integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
 		},
 		"@mapbox/tiny-sdf": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-			"integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw==",
-			"peer": true
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+			"integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
 		},
 		"@mapbox/unitbezier": {
 			"version": "0.0.0",
@@ -10998,7 +11171,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
 			"integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-			"peer": true,
 			"requires": {
 				"@mapbox/point-geometry": "~0.1.0"
 			}
@@ -11006,8 +11178,57 @@
 		"@mapbox/whoots-js": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-			"integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-			"peer": true
+			"integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+		},
+		"@maplibre/maplibre-gl-style-spec": {
+			"version": "19.2.1",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.2.1.tgz",
+			"integrity": "sha512-ZVT5QlkVhlxlPav+ca0NO3Moc7EzbHDO2FXW4ic3Q0Vm+TDUw9I8A2EBws7xUUQZf7HQB3kQ+3Jsh5mFLRD4GQ==",
+			"requires": {
+				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
+				"@mapbox/point-geometry": "^0.1.0",
+				"@mapbox/unitbezier": "^0.0.1",
+				"@types/mapbox__point-geometry": "^0.1.2",
+				"json-stringify-pretty-compact": "^3.0.0",
+				"minimist": "^1.2.8",
+				"rw": "^1.3.3",
+				"sort-object": "^3.0.3"
+			},
+			"dependencies": {
+				"@mapbox/unitbezier": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+					"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
+				},
+				"json-stringify-pretty-compact": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+					"integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+				},
+				"sort-asc": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+					"integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA=="
+				},
+				"sort-desc": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+					"integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w=="
+				},
+				"sort-object": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+					"integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+					"requires": {
+						"bytewise": "^1.1.0",
+						"get-value": "^2.0.2",
+						"is-extendable": "^0.1.1",
+						"sort-asc": "^0.2.0",
+						"sort-desc": "^0.2.0",
+						"union-value": "^1.0.1"
+					}
+				}
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -11178,8 +11399,7 @@
 		"@types/geojson": {
 			"version": "7946.0.10",
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-			"integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
-			"peer": true
+			"integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
 		},
 		"@types/html-minifier-terser": {
 			"version": "6.0.0",
@@ -11217,14 +11437,12 @@
 		"@types/mapbox__point-geometry": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-			"integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
-			"peer": true
+			"integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
 		},
 		"@types/mapbox__vector-tile": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
 			"integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
-			"peer": true,
 			"requires": {
 				"@types/geojson": "*",
 				"@types/mapbox__point-geometry": "*",
@@ -11274,8 +11492,7 @@
 		"@types/pbf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-			"integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
-			"peer": true
+			"integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
 		},
 		"@types/qs": {
 			"version": "6.9.7",
@@ -11637,6 +11854,11 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="
+		},
 		"array-flatten": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -11697,6 +11919,11 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
 		},
 		"astral-regex": {
 			"version": "2.0.0",
@@ -11851,6 +12078,23 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
 			"dev": true
+		},
+		"bytewise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+			"requires": {
+				"bytewise-core": "^1.2.2",
+				"typewise": "^1.0.3"
+			}
+		},
+		"bytewise-core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+			"requires": {
+				"typewise-core": "^1.2"
+			}
 		},
 		"call-bind": {
 			"version": "1.0.2",
@@ -13366,6 +13610,14 @@
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
 		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"requires": {
+				"is-extendable": "^0.1.0"
+			}
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -13674,8 +13926,7 @@
 		"geojson-vt": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-			"integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-			"peer": true
+			"integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
 		},
 		"geotiff": {
 			"version": "2.0.7",
@@ -13729,6 +13980,11 @@
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
 			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA=="
 		},
 		"gh-pages": {
 			"version": "5.0.0",
@@ -13810,8 +14066,7 @@
 		"gl-matrix": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-			"integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
-			"peer": true
+			"integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -14350,6 +14605,11 @@
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"dev": true
 		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -14408,7 +14668,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -14507,8 +14766,7 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-			"dev": true
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -15067,10 +15325,9 @@
 			}
 		},
 		"kdbush": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-			"integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-			"peer": true
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+			"integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -15264,33 +15521,32 @@
 			"integrity": "sha512-f+NBjJJY4T3dHtlEz1wCG7YFlkODEjFIYlxDdLIDMNpkSksqTt+l/d4rjuwItxuzkuMFvPyrjzV2lxRM4ePcIA=="
 		},
 		"maplibre-gl": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-2.4.0.tgz",
-			"integrity": "sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==",
-			"peer": true,
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.1.0.tgz",
+			"integrity": "sha512-KFarVUUszCEucPwnGsFJtPMQBg/F6lg+SPDmTztKUD/n0YShETjIOdNmm5jpxacEX3+dq50MzlqDr6VH+RtDDA==",
 			"requires": {
 				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
-				"@mapbox/mapbox-gl-supported": "^2.0.1",
 				"@mapbox/point-geometry": "^0.1.0",
-				"@mapbox/tiny-sdf": "^2.0.5",
+				"@mapbox/tiny-sdf": "^2.0.6",
 				"@mapbox/unitbezier": "^0.0.1",
 				"@mapbox/vector-tile": "^1.3.1",
 				"@mapbox/whoots-js": "^3.1.0",
+				"@maplibre/maplibre-gl-style-spec": "^19.2.1",
 				"@types/geojson": "^7946.0.10",
 				"@types/mapbox__point-geometry": "^0.1.2",
 				"@types/mapbox__vector-tile": "^1.3.0",
 				"@types/pbf": "^3.0.2",
-				"csscolorparser": "~1.0.3",
 				"earcut": "^2.2.4",
 				"geojson-vt": "^3.2.1",
 				"gl-matrix": "^3.4.3",
 				"global-prefix": "^3.0.0",
+				"kdbush": "^4.0.2",
 				"murmurhash-js": "^1.0.0",
 				"pbf": "^3.2.1",
-				"potpack": "^1.0.2",
+				"potpack": "^2.0.0",
 				"quickselect": "^2.0.0",
-				"supercluster": "^7.1.5",
+				"supercluster": "^8.0.1",
 				"tinyqueue": "^2.0.3",
 				"vt-pbf": "^3.1.3"
 			},
@@ -15298,8 +15554,7 @@
 				"@mapbox/unitbezier": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-					"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-					"peer": true
+					"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
 				}
 			}
 		},
@@ -15495,9 +15750,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -15552,8 +15807,7 @@
 		"murmurhash-js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-			"peer": true
+			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
 		},
 		"nanoid": {
 			"version": "3.3.6",
@@ -16136,10 +16390,9 @@
 			"dev": true
 		},
 		"potpack": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-			"integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-			"peer": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+			"integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -16762,6 +17015,17 @@
 				"send": "0.17.2"
 			}
 		},
+		"set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			}
+		},
 		"setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -17028,6 +17292,33 @@
 				"wbuf": "^1.7.3"
 			}
 		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					}
+				},
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -17252,12 +17543,11 @@
 			"requires": {}
 		},
 		"supercluster": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-			"integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
-			"peer": true,
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+			"integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
 			"requires": {
-				"kdbush": "^3.0.0"
+				"kdbush": "^4.0.2"
 			}
 		},
 		"supports-color": {
@@ -17401,8 +17691,7 @@
 		"tinyqueue": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-			"peer": true
+			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -17515,6 +17804,19 @@
 				"is-typed-array": "^1.1.9"
 			}
 		},
+		"typewise": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+			"requires": {
+				"typewise-core": "^1.2.0"
+			}
+		},
+		"typewise-core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
+		},
 		"ua-parser-js": {
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
@@ -17544,6 +17846,17 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
 			"integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
 			"dev": true
+		},
+		"union-value": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^2.0.1"
+			}
 		},
 		"universalify": {
 			"version": "2.0.0",
@@ -17627,7 +17940,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
 			"integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
-			"peer": true,
 			"requires": {
 				"@mapbox/point-geometry": "0.1.0",
 				"@mapbox/vector-tile": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
 				"karma-script-launcher": "1.0.0",
 				"karma-webkit-launcher": "2.1.0",
 				"karma-webpack": "5.0.0",
+				"mapbox-gl-supported": "^1.2.0",
 				"playwright": "1.34.3",
 				"portfinder-sync": "0.0.2",
 				"prettier": "2.8.8",
@@ -6548,6 +6549,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/mapbox-gl-supported": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz",
+			"integrity": "sha512-U9ZbBcQxX1WnEHHwO4mFHo+dlG9/6HPAFbF9lY6hF6+oAt5p5VXTiHl8hPbUbr5m+D2RLzRgp0uq6wKeVk0P8A==",
+			"deprecated": "This package has been moved to @mapbox/mapbox-gl-supported",
+			"dev": true
 		},
 		"node_modules/mapbox-to-css-font": {
 			"version": "2.4.2",
@@ -15513,6 +15521,12 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+			"dev": true
+		},
+		"mapbox-gl-supported": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz",
+			"integrity": "sha512-U9ZbBcQxX1WnEHHwO4mFHo+dlG9/6HPAFbF9lY6hF6+oAt5p5VXTiHl8hPbUbr5m+D2RLzRgp0uq6wKeVk0P8A==",
 			"dev": true
 		},
 		"mapbox-to-css-font": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"karma-script-launcher": "1.0.0",
 		"karma-webkit-launcher": "2.1.0",
 		"karma-webpack": "5.0.0",
+		"mapbox-gl-supported": "^1.2.0",
 		"playwright": "1.34.3",
 		"portfinder-sync": "0.0.2",
 		"prettier": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 		"dompurify": "3.0.3",
 		"geographiclib-geodesic": "^2.0.0",
 		"lit-html": "2.7.4",
-		"ol": "7.4.0",
+		"maplibre-gl": "^3.1.0",
+		"ol": "^7.4.0",
 		"proj4": "2.9.0",
 		"redux": "4.2.1",
 		"vanilla-swipe": "2.4.1"

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -15,7 +15,6 @@ import VectorLayer from 'ol/layer/Vector';
 import { TestUtils } from '../../../test-utils';
 import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/baaImageLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
-import maplibregl from 'maplibre-gl';
 import { createXYZ } from 'ol/tilegrid';
 import { AdvWmtsTileGrid } from '../../../../src/modules/olMap/ol/tileGrid/AdvWmtsTileGrid';
 
@@ -271,43 +270,35 @@ describe('LayerService', () => {
 
 		describe('VTGeoresource', () => {
 			it('converts a VTGeoresource to a olLayer', () => {
-				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
-				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
-				if (maplibregl.supported()) {
-					const instanceUnderTest = setup();
-					const id = 'id';
-					const geoResourceId = 'geoResourceId';
-					const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null);
+				const instanceUnderTest = setup();
+				const id = 'id';
+				const geoResourceId = 'geoResourceId';
+				const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null);
 
-					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
+				const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
 
-					expect(vtOlLayer.get('id')).toBe(id);
-					expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
-					expect(vtOlLayer.getMinZoom()).toBeNegativeInfinity();
-					expect(vtOlLayer.getMaxZoom()).toBePositiveInfinity();
-					// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
-					expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
-				}
+				expect(vtOlLayer.get('id')).toBe(id);
+				expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
+				expect(vtOlLayer.getMinZoom()).toBeNegativeInfinity();
+				expect(vtOlLayer.getMaxZoom()).toBePositiveInfinity();
+				// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
+				expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
 			});
 
 			it('converts a VTGeoresource containing optional properties to a olLayer', () => {
-				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
-				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
-				if (maplibregl.supported()) {
-					const instanceUnderTest = setup();
-					const id = 'id';
-					const geoResourceId = 'geoResourceId';
-					const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null).setOpacity(0.5).setMinZoom(5).setMaxZoom(19);
+				const instanceUnderTest = setup();
+				const id = 'id';
+				const geoResourceId = 'geoResourceId';
+				const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null).setOpacity(0.5).setMinZoom(5).setMaxZoom(19);
 
-					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
-					expect(vtOlLayer.get('id')).toBe(id);
-					expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
-					expect(vtOlLayer.getOpacity()).toBe(0.5);
-					expect(vtOlLayer.getMinZoom()).toBe(5);
-					expect(vtOlLayer.getMaxZoom()).toBe(19);
-					// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
-					expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
-				}
+				const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
+				expect(vtOlLayer.get('id')).toBe(id);
+				expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
+				expect(vtOlLayer.getOpacity()).toBe(0.5);
+				expect(vtOlLayer.getMinZoom()).toBe(5);
+				expect(vtOlLayer.getMaxZoom()).toBe(19);
+				// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
+				expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
 			});
 		});
 

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -15,9 +15,9 @@ import VectorLayer from 'ol/layer/Vector';
 import { TestUtils } from '../../../test-utils';
 import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/baaImageLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
-import maplibregl from 'maplibre-gl';
 import { createXYZ } from 'ol/tilegrid';
 import { AdvWmtsTileGrid } from '../../../../src/modules/olMap/ol/tileGrid/AdvWmtsTileGrid';
+import supported from 'mapbox-gl-supported';
 
 describe('LayerService', () => {
 	const vectorLayerService = {
@@ -273,7 +273,7 @@ describe('LayerService', () => {
 			it('converts a VTGeoresource to a olLayer', () => {
 				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
 				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
-				if (maplibregl.supported()) {
+				if (supported()) {
 					const instanceUnderTest = setup();
 					const id = 'id';
 					const geoResourceId = 'geoResourceId';
@@ -293,7 +293,7 @@ describe('LayerService', () => {
 			it('converts a VTGeoresource containing optional properties to a olLayer', () => {
 				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
 				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
-				if (maplibregl.supported()) {
+				if (supported()) {
 					const instanceUnderTest = setup();
 					const id = 'id';
 					const geoResourceId = 'geoResourceId';

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -15,6 +15,7 @@ import VectorLayer from 'ol/layer/Vector';
 import { TestUtils } from '../../../test-utils';
 import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/baaImageLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
+import maplibregl from 'maplibre-gl';
 import { createXYZ } from 'ol/tilegrid';
 import { AdvWmtsTileGrid } from '../../../../src/modules/olMap/ol/tileGrid/AdvWmtsTileGrid';
 
@@ -270,35 +271,43 @@ describe('LayerService', () => {
 
 		describe('VTGeoresource', () => {
 			it('converts a VTGeoresource to a olLayer', () => {
-				const instanceUnderTest = setup();
-				const id = 'id';
-				const geoResourceId = 'geoResourceId';
-				const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null);
+				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
+				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
+				if (maplibregl.supported()) {
+					const instanceUnderTest = setup();
+					const id = 'id';
+					const geoResourceId = 'geoResourceId';
+					const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null);
 
-				const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
+					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
 
-				expect(vtOlLayer.get('id')).toBe(id);
-				expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
-				expect(vtOlLayer.getMinZoom()).toBeNegativeInfinity();
-				expect(vtOlLayer.getMaxZoom()).toBePositiveInfinity();
-				// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
-				expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
+					expect(vtOlLayer.get('id')).toBe(id);
+					expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
+					expect(vtOlLayer.getMinZoom()).toBeNegativeInfinity();
+					expect(vtOlLayer.getMaxZoom()).toBePositiveInfinity();
+					// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
+					expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
+				}
 			});
 
 			it('converts a VTGeoresource containing optional properties to a olLayer', () => {
-				const instanceUnderTest = setup();
-				const id = 'id';
-				const geoResourceId = 'geoResourceId';
-				const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null).setOpacity(0.5).setMinZoom(5).setMaxZoom(19);
+				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
+				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
+				if (maplibregl.supported()) {
+					const instanceUnderTest = setup();
+					const id = 'id';
+					const geoResourceId = 'geoResourceId';
+					const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null).setOpacity(0.5).setMinZoom(5).setMaxZoom(19);
 
-				const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
-				expect(vtOlLayer.get('id')).toBe(id);
-				expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
-				expect(vtOlLayer.getOpacity()).toBe(0.5);
-				expect(vtOlLayer.getMinZoom()).toBe(5);
-				expect(vtOlLayer.getMaxZoom()).toBe(19);
-				// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
-				expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
+					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
+					expect(vtOlLayer.get('id')).toBe(id);
+					expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
+					expect(vtOlLayer.getOpacity()).toBe(0.5);
+					expect(vtOlLayer.getMinZoom()).toBe(5);
+					expect(vtOlLayer.getMaxZoom()).toBe(19);
+					// Todo: currently we have no simple possibility to check the correctness of the styleUrl, so we just check for the expected ol layer class
+					expect(vtOlLayer instanceof MapLibreLayer).toBeTrue();
+				}
 			});
 		});
 


### PR DESCRIPTION
`maplibre-gl` comes as a peer dependency from `ol-maplibre-layer`. In order to use its latest version we add it as a direct dependency.