### PR TITLE
synchronize the MapLibre layers's opacity with the layer group's one

### DIFF
--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -132,13 +132,23 @@ export class LayerService {
 			}
 
 			case GeoResourceTypes.AGGREGATE: {
-				return new LayerGroup({
+				const layerGroup = new LayerGroup({
 					id: id,
 					opacity: opacity,
 					layers: geoResource.geoResourceIds.map((id) => this.toOlLayer(id, georesourceService.byId(id))),
 					minZoom: minZoom ?? undefined,
 					maxZoom: maxZoom ?? undefined
 				});
+
+				// synchronizes the MapLibre layers's opacity with the layer group's one
+				layerGroup.on('change:opacity', (evt) =>
+					evt.target.getLayers().forEach((el) => {
+						if (el instanceof MapLibreLayer) {
+							el.setOpacity(evt.target.getOpacity());
+						}
+					})
+				);
+				return layerGroup;
 			}
 		}
 		throw new Error(geoResource.getType() + ' currently not supported');

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -324,7 +324,7 @@ describe('LayerService', () => {
 						return wmsGeoresource;
 				}
 			});
-			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource.id, xyzGeoresource.id]);
+			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource.id, wmsGeoresource.id]);
 
 			const olLayerGroup = instanceUnderTest.toOlLayer(id, aggreggateGeoResource);
 
@@ -334,7 +334,7 @@ describe('LayerService', () => {
 			expect(olLayerGroup.constructor.name).toBe('LayerGroup');
 			const layers = olLayerGroup.getLayers();
 			expect(layers.item(0).get('id')).toBe(xyzGeoresource.id);
-			expect(layers.item(1).get('id')).toBe(xyzGeoresource.id);
+			expect(layers.item(1).get('id')).toBe(wmsGeoresource.id);
 		});
 
 		it('converts a AggregateGeoresource containing optional properties to a olLayer(Group)', () => {
@@ -350,7 +350,7 @@ describe('LayerService', () => {
 						return wmsGeoresource;
 				}
 			});
-			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource.id, xyzGeoresource.id])
+			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource.id, wmsGeoresource.id])
 				.setOpacity(0.5)
 				.setMinZoom(5)
 				.setMaxZoom(19);
@@ -364,10 +364,10 @@ describe('LayerService', () => {
 			expect(olLayerGroup.constructor.name).toBe('LayerGroup');
 			const layers = olLayerGroup.getLayers();
 			expect(layers.item(0).get('id')).toBe(xyzGeoresource.id);
-			expect(layers.item(1).get('id')).toBe(xyzGeoresource.id);
+			expect(layers.item(1).get('id')).toBe(wmsGeoresource.id);
 		});
 
-		it('registers a opacity change listener in order to manually set the opacity for a MapLibreLayer', () => {
+		it('registers an opacity change listener in order to synchronize the opacity of a MapLibreLayer', () => {
 			const instanceUnderTest = setup();
 			const id = 'id';
 			const xyzGeoresource = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -367,6 +367,31 @@ describe('LayerService', () => {
 			expect(layers.item(1).get('id')).toBe(xyzGeoresource.id);
 		});
 
+		it('registers a opacity change listener in order to manually set the opacity for a MapLibreLayer', () => {
+			const instanceUnderTest = setup();
+			const id = 'id';
+			const xyzGeoresource = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+			const vtGeoresource = new VTGeoResource('geoResourceId2', 'label', null);
+			spyOn(georesourceService, 'byId').and.callFake((id) => {
+				switch (id) {
+					case xyzGeoresource.id:
+						return xyzGeoresource;
+					case vtGeoresource.id:
+						return vtGeoresource;
+				}
+			});
+			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource.id, vtGeoresource.id]);
+			const olLayerGroup = instanceUnderTest.toOlLayer(id, aggreggateGeoResource);
+			const layers = olLayerGroup.getLayers();
+			const otherOlLayerSetOpacitySpy = spyOn(layers.item(0), 'setOpacity').and.callThrough();
+			const mapLibreLayerSetOpacitySpy = spyOn(layers.item(1), 'setOpacity').and.callThrough();
+
+			olLayerGroup.setOpacity(0.66);
+
+			expect(mapLibreLayerSetOpacitySpy).toHaveBeenCalledOnceWith(0.66);
+			expect(otherOlLayerSetOpacitySpy).not.toHaveBeenCalled();
+		});
+
 		it('throws an error when georesource type is not supported', () => {
 			const instanceUnderTest = setup();
 			const id = 'id';


### PR DESCRIPTION
When a MapLibre layer is part of an ol.LayerGroup its opacity has to be manually synchronized with the layer group's one.