### PR TITLE
 drawing of symbol not possible after style color is changed

### DIFF
--- a/src/services/IconService.js
+++ b/src/services/IconService.js
@@ -35,7 +35,7 @@ export class IconService {
 			return (color) => {
 				try {
 					const url = configService.getValueAsPath('BACKEND_URL') + 'icons';
-					return `${url}/${color[0]},${color[1]},${color[2]}/${Svg_Marker_Name}`;
+					return `${url}/${color[0]},${color[1]},${color[2]}/${Svg_Marker_Name}.png`;
 				} catch (e) {
 					console.warn('No backend-information available.');
 				}

--- a/test/service/IconService.test.js
+++ b/test/service/IconService.test.js
@@ -158,7 +158,7 @@ describe('IconsService', () => {
 
 			expect(defaultIcon).toBeInstanceOf(IconResult);
 			expect(defaultIcon.id).toBe('marker');
-			expect(defaultIcon.getUrl([1, 2, 3])).toBe('http://some.url/icons/1,2,3/marker');
+			expect(defaultIcon.getUrl([1, 2, 3])).toBe('http://some.url/icons/1,2,3/marker.png');
 		});
 
 		it('provides a default icon, without url', async () => {


### PR DESCRIPTION
bug workflow:
1.  open draw dialog
2.  select "symbol"
3.  open "style" area 
4.  choose another color

result:
-     no drawing of symbol is possible any more
-     there is no icon selected inside "style" area

This pull requests changes the inital value of the marker to "marker.png" as the matcher function of the IconResult class only matches if the URL ends with "/${id}.png"

![Screenshot from 2023-06-28 18-08-45](https://github.com/ldbv-by/bav4/assets/4209805/422567ac-49a8-4467-9912-39bbfc226235)
