### PR TITLE
TestUtils: allow setting of initial properties for a component

### DIFF
--- a/src/modules/MvuElement.js
+++ b/src/modules/MvuElement.js
@@ -127,6 +127,10 @@ export class MvuElement extends HTMLElement {
 	 * @private
 	 */
 	connectedCallback() {
+		// see TestUtils
+		if (window.ba_fireConnectedEvent) {
+			document.dispatchEvent(new CustomEvent('connected', { detail: this, bubbles: true }));
+		}
 		window.addEventListener('load', () => {
 			this.onWindowLoad();
 		});

--- a/test/modules/MvuElement.test.js
+++ b/test/modules/MvuElement.test.js
@@ -479,4 +479,15 @@ describe('MvuElement', () => {
 			expect(errorSpy).toHaveBeenCalledOnceWith("Could not register observer --> 'someUnknowField' is not a field in the Model of MvuElementImpl");
 		});
 	});
+
+	describe('when "window.ba_fireConnectedEvent" property is true', () => {
+		fit('fires a custom event', async () => {
+			const spy = jasmine.createSpy();
+			document.addEventListener('connected', spy);
+
+			const element = await TestUtils.render(MvuElementImpl.tag);
+
+			expect(spy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ detail: element, bubbles: true }));
+		});
+	});
 });

--- a/test/modules/commons/components/Button.test.js
+++ b/test/modules/commons/components/Button.test.js
@@ -133,7 +133,7 @@ describe('Button', () => {
 
 		it('calls the onClick callback via attribute binding', async () => {
 			spyOn(window, 'alert');
-			const element = await TestUtils.render(Button.tag, { onClick: "alert('called')" });
+			const element = await TestUtils.render(Button.tag, {}, { onClick: "alert('called')" });
 
 			element.click();
 
@@ -142,7 +142,7 @@ describe('Button', () => {
 
 		it('does nothing when disabled', async () => {
 			spyOn(window, 'alert');
-			const element = await TestUtils.render(Button.tag, { onClick: "alert('called')" });
+			const element = await TestUtils.render(Button.tag, {}, { onClick: "alert('called')" });
 			element.disabled = true;
 
 			element.onClick = jasmine.createSpy();

--- a/test/modules/commons/components/Checkbox.test.js
+++ b/test/modules/commons/components/Checkbox.test.js
@@ -19,7 +19,7 @@ describe('Checkbox', () => {
 		});
 
 		it('renders the view', async () => {
-			const element = await TestUtils.render(Checkbox.tag, {}, '<span>some</span>');
+			const element = await TestUtils.render(Checkbox.tag, {}, {}, '<span>some</span>');
 
 			//view
 			expect(element.shadowRoot.querySelector('.ba-checkbox')).toBeTruthy();
@@ -109,7 +109,7 @@ describe('Checkbox', () => {
 
 			it('calls the onToggle callback via attribute callback', async () => {
 				spyOn(window, 'alert');
-				const element = await TestUtils.render(Checkbox.tag, { onToggle: "alert('called')" });
+				const element = await TestUtils.render(Checkbox.tag, {}, { onToggle: "alert('called')" });
 
 				element.click();
 
@@ -119,7 +119,7 @@ describe('Checkbox', () => {
 
 			it('does nothing when disabled', async () => {
 				spyOn(window, 'alert');
-				const element = await TestUtils.render(Checkbox.tag, { onToggle: "alert('called')" });
+				const element = await TestUtils.render(Checkbox.tag, {}, { onToggle: "alert('called')" });
 				element.disabled = true;
 				element.onClick = jasmine.createSpy();
 
@@ -173,7 +173,7 @@ describe('Checkbox', () => {
 
 			it('calls the onToggle callback via attribute binding', async () => {
 				spyOn(window, 'alert');
-				const element = await TestUtils.render(Checkbox.tag, { onToggle: "alert('called')" });
+				const element = await TestUtils.render(Checkbox.tag, {}, { onToggle: "alert('called')" });
 				element.onToggle = jasmine.createSpy();
 
 				element.dispatchEvent(event);
@@ -236,7 +236,7 @@ describe('Checkbox', () => {
 
 			it('calls the onToggle callback via attribute callback', async () => {
 				spyOn(window, 'alert');
-				const element = await TestUtils.render(Checkbox.tag, { onToggle: "alert('called')" });
+				const element = await TestUtils.render(Checkbox.tag, {}, { onToggle: "alert('called')" });
 				element.onToggle = jasmine.createSpy();
 
 				element.dispatchEvent(event);

--- a/test/modules/commons/components/Icon.test.js
+++ b/test/modules/commons/components/Icon.test.js
@@ -131,7 +131,7 @@ describe('Icon', () => {
 
 		it('calls the onClick callback via attribute binding', async () => {
 			spyOn(window, 'alert');
-			const element = await TestUtils.render(Icon.tag, { onClick: "alert('called')" });
+			const element = await TestUtils.render(Icon.tag, {}, { onClick: "alert('called')" });
 
 			element.click();
 
@@ -140,7 +140,7 @@ describe('Icon', () => {
 
 		it('does nothing when disabled', async () => {
 			spyOn(window, 'alert');
-			const element = await TestUtils.render(Icon.tag, { onClick: "alert('called')" });
+			const element = await TestUtils.render(Icon.tag, {}, { onClick: "alert('called')" });
 			element.disabled = true;
 			element.onClick = jasmine.createSpy();
 			const anchor = element.shadowRoot.querySelector('.anchor');

--- a/test/modules/commons/components/Toggle.test.js
+++ b/test/modules/commons/components/Toggle.test.js
@@ -19,7 +19,7 @@ describe('Toggle', () => {
 		});
 
 		it('renders the view', async () => {
-			const element = await TestUtils.render(Toggle.tag, {}, '<span>some</span>');
+			const element = await TestUtils.render(Toggle.tag, {}, {}, '<span>some</span>');
 
 			//view
 			expect(element.shadowRoot.querySelector('.switch')).toBeTruthy();
@@ -109,7 +109,7 @@ describe('Toggle', () => {
 
 			it('calls the onToggle callback via attribute callback', async () => {
 				spyOn(window, 'alert');
-				const element = await TestUtils.render(Toggle.tag, { onToggle: "alert('called')" });
+				const element = await TestUtils.render(Toggle.tag, {}, { onToggle: "alert('called')" });
 
 				element.click();
 
@@ -119,7 +119,7 @@ describe('Toggle', () => {
 
 			it('does nothing when disabled', async () => {
 				spyOn(window, 'alert');
-				const element = await TestUtils.render(Toggle.tag, { onToggle: "alert('called')" });
+				const element = await TestUtils.render(Toggle.tag, {}, { onToggle: "alert('called')" });
 				element.disabled = true;
 				element.onClick = jasmine.createSpy();
 

--- a/test/modules/feedback/components/toggleFeedback/ToggleFeedbackPanel.test.js
+++ b/test/modules/feedback/components/toggleFeedback/ToggleFeedbackPanel.test.js
@@ -9,7 +9,7 @@ import { TestUtils } from '../../../../test-utils';
 window.customElements.define(ToggleFeedbackPanel.tag, ToggleFeedbackPanel);
 
 let store;
-const setup = (state = {}) => {
+const setup = (state = {}, properties = {}) => {
 	const initialState = {
 		...state
 	};
@@ -18,7 +18,7 @@ const setup = (state = {}) => {
 
 	$injector.registerSingleton('TranslationService', { translate: (key) => key });
 
-	return TestUtils.renderAndLogLifecycle(ToggleFeedbackPanel.tag);
+	return TestUtils.renderAndLogLifecycle(ToggleFeedbackPanel.tag, properties);
 };
 
 describe('ToggleFeedbackPanel', () => {
@@ -151,9 +151,7 @@ describe('ToggleFeedbackPanel', () => {
 	describe('property "onSubmit"', () => {
 		it('sets the onSubmit callback', async () => {
 			const onSubmbitFn = () => {};
-			const element = await setup();
-
-			element.onSubmit = onSubmbitFn;
+			const element = await setup({}, { onSubmit: onSubmbitFn });
 
 			expect(element._onSubmit).toEqual(onSubmbitFn);
 		});
@@ -161,10 +159,8 @@ describe('ToggleFeedbackPanel', () => {
 
 	describe('property "center"', () => {
 		it('sets the center coordinate and updates the view', async () => {
-			const element = await setup();
+			const element = await setup({}, { center: [21, 42] });
 			element.type = FeedbackType.MAP;
-
-			element.center = [21, 42];
 
 			expect(element.shadowRoot.querySelector(MapFeedbackPanel.tag).center).toEqual([21, 42]);
 		});

--- a/test/modules/iconSelect/components/IconSelect.test.js
+++ b/test/modules/iconSelect/components/IconSelect.test.js
@@ -22,7 +22,7 @@ describe('IconSelect', () => {
 			media: createNoInitialStateMediaReducer()
 		});
 		$injector.registerSingleton('TranslationService', { translate: (key) => key }).registerSingleton('IconService', iconServiceMock);
-		return TestUtils.render(IconSelect.tag, attributes);
+		return TestUtils.render(IconSelect.tag, {}, attributes);
 	};
 
 	describe('when initialized', () => {

--- a/test/modules/topics/components/menu/catalog/CatalogNode.test.js
+++ b/test/modules/topics/components/menu/catalog/CatalogNode.test.js
@@ -39,7 +39,7 @@ describe('CatalogNode', () => {
 		TestUtils.setupStoreAndDi(state);
 
 		if (levelAttribute) {
-			return TestUtils.render(CatalogNode.tag, levelAttribute);
+			return TestUtils.render(CatalogNode.tag, {}, levelAttribute);
 		}
 		return TestUtils.render(CatalogNode.tag);
 	};

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -29,11 +29,22 @@ export class TestUtils {
 	 * and returns a promise which resolves as soon as the
 	 * rendered element becomes available.
 	 * @param {string} tag the tag of the HTMLElement
+	 * @param {object} [properties] initial properties for this element
 	 * @param {object} [attributes]
 	 * @param {object} [slotContent]
 	 * @returns {Promise<HTMLElement>}
 	 */
-	static async render(tag, attributes = {}, slotContent = '') {
+	static async render(tag, properties = {}, attributes = {}, slotContent = '') {
+		window.ba_fireConnectedEvent = true;
+		const connectedListener = (e) => {
+			const element = e.detail;
+			for (const key in properties) {
+				element[key] = properties[key];
+			}
+			window.ba_fireConnectedCallbackEvent = false;
+			document.removeEventListener('connected', this);
+		};
+		document.addEventListener('connected', connectedListener);
 		TestUtils._renderToDocument(tag, attributes, slotContent);
 		return TestUtils._waitForComponentToRender(tag);
 	}
@@ -44,13 +55,14 @@ export class TestUtils {
 	 * rendered element becomes available.
 	 * Additionally enables logging of the elements lifecycle (if available).
 	 * @param {string} tag the tag of the MvuElement
+	 * @param {object} [properties] initial properties for this element
 	 * @param {object} [attributes]
 	 * @param {object} [slotContent]
 	 * @returns {Promise<HTMLElement>}
 	 */
-	static async renderAndLogLifecycle(tag, attributes = {}, slotContent = '') {
+	static async renderAndLogLifecycle(tag, properties = {}, attributes = {}, slotContent = '') {
 		TestUtils._renderToDocument(tag, { [LOG_LIFECYLE_ATTRIBUTE_NAME]: '', ...attributes }, slotContent);
-		return TestUtils._waitForComponentToRender(tag);
+		return TestUtils.render(tag, properties, { [LOG_LIFECYLE_ATTRIBUTE_NAME]: '', ...attributes }, slotContent);
 	}
 
 	/**

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -41,12 +41,13 @@ export class TestUtils {
 			for (const key in properties) {
 				element[key] = properties[key];
 			}
-			window.ba_fireConnectedCallbackEvent = false;
-			document.removeEventListener('connected', this);
 		};
 		document.addEventListener('connected', connectedListener);
 		TestUtils._renderToDocument(tag, attributes, slotContent);
-		return TestUtils._waitForComponentToRender(tag);
+		const element = await TestUtils._waitForComponentToRender(tag);
+		window.ba_fireConnectedCallbackEvent = false;
+		document.removeEventListener('connected', connectedListener);
+		return element;
 	}
 
 	/**
@@ -61,7 +62,6 @@ export class TestUtils {
 	 * @returns {Promise<HTMLElement>}
 	 */
 	static async renderAndLogLifecycle(tag, properties = {}, attributes = {}, slotContent = '') {
-		TestUtils._renderToDocument(tag, { [LOG_LIFECYLE_ATTRIBUTE_NAME]: '', ...attributes }, slotContent);
 		return TestUtils.render(tag, properties, { [LOG_LIFECYLE_ATTRIBUTE_NAME]: '', ...attributes }, slotContent);
 	}
 

--- a/test/utils/markup.test.js
+++ b/test/utils/markup.test.js
@@ -116,7 +116,7 @@ describe('markup utils', () => {
 			it('provides the correct test id for MvuElements', async () => {
 				window.ba_enableTestIds = true;
 				const warnSpy = spyOn(console, 'warn');
-				const element = await TestUtils.render(MvuElementParent.tag, { 'data-test-id': '' });
+				const element = await TestUtils.render(MvuElementParent.tag, {}, { 'data-test-id': '' });
 
 				const divElements = element.shadowRoot.querySelectorAll('div');
 				const mvuChildElements = element.shadowRoot.querySelectorAll(MvuElementChild.tag);
@@ -138,7 +138,7 @@ describe('markup utils', () => {
 			});
 
 			it('does nothing', async () => {
-				const element = await TestUtils.render(MvuElementParent.tag, { 'data-test-id': '' });
+				const element = await TestUtils.render(MvuElementParent.tag, {}, { 'data-test-id': '' });
 
 				const all = [...element.shadowRoot.querySelectorAll('div'), ...element.shadowRoot.querySelectorAll(MvuElementChild.tag)];
 
@@ -153,7 +153,7 @@ describe('markup utils', () => {
 			it('provides the correct test id for MvuElements', async () => {
 				window.ba_enableTestIds = true;
 				const warnSpy = spyOn(console, 'warn');
-				const element = await TestUtils.render(BaElementParent.tag, { 'data-test-id': '' });
+				const element = await TestUtils.render(BaElementParent.tag, {}, { 'data-test-id': '' });
 
 				const divElements = element.shadowRoot.querySelectorAll('div');
 				const baChildElements = element.shadowRoot.querySelectorAll(BaElementChild.tag);
@@ -175,7 +175,7 @@ describe('markup utils', () => {
 			});
 
 			it('does nothing', async () => {
-				const element = await TestUtils.render(BaElementParent.tag, { 'data-test-id': '' });
+				const element = await TestUtils.render(BaElementParent.tag, {}, { 'data-test-id': '' });
 
 				const all = [...element.shadowRoot.querySelectorAll('div'), ...element.shadowRoot.querySelectorAll(BaElementChild.tag)];
 


### PR DESCRIPTION
When a component has one or more public properties a test can set them initially now without using a defined setter.
Example:

```
html`<ba-mvu-togglefeedbackpanel .center=${center}`
```

was tested by something like
```
const element = await TestUtils.render(ToggleFeedbackPanel.tag);
element.center =  : [21, 42] 
```
and will become now
```
const element = await TestUtils.render(ToggleFeedbackPanel.tag, { center: [21, 42] });
```
which reproduces the "real" behavior of the component, because the initial properties are **now available when the component is mounted into the DOM**
