### PR TITLE
add lazy loading/dynamic import of component

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ All redux related files like reducers and actions.
 
 Contains global utilities.
 
+### `src/chunks`
+
+Contains chunk definitions for dynamically loading an MvuElement.
+
 ### Overview
 
 Here's an overview of what project folder structure looks like:

--- a/checkOrApplyDoc.js
+++ b/checkOrApplyDoc.js
@@ -20,7 +20,8 @@ const findInDir = (dir, fileList = []) => {
 		.filter((fp) => fp.endsWith('.js'))
 		.filter((fp) => !excludesFiles.includes(path.basename(fp))) // remove excluded files
 		.filter((fp) => !path.dirname(fp).includes('i18n')) // remove i18n provider
-		.filter((fp) => !fp.includes('reducer')); // remove reducer
+		.filter((fp) => !fp.includes('reducer')) // remove reducer dirs
+		.filter((fp) => !fp.includes('chunks')); // remove lazy dir
 };
 
 findInDir('./src').forEach((fp) => {

--- a/src/chunks/elevation-profile.js
+++ b/src/chunks/elevation-profile.js
@@ -1,0 +1,6 @@
+//This file just defines all dependencies for the chunk "elevation-profile"
+import { ElevationProfile } from '../modules/elevationProfile/components/panel/ElevationProfile';
+
+if (!window.customElements.get(ElevationProfile.tag)) {
+	window.customElements.define(ElevationProfile.tag, ElevationProfile);
+}

--- a/src/chunks/elevation-profile.js
+++ b/src/chunks/elevation-profile.js
@@ -1,4 +1,6 @@
-//This file just defines all dependencies for the chunk "elevation-profile"
+/**
+ * This file just defines all dependencies for the chunk "elevation-profile"
+ */
 import { ElevationProfile } from '../modules/elevationProfile/components/panel/ElevationProfile';
 
 if (!window.customElements.get(ElevationProfile.tag)) {

--- a/src/modules/commons/components/lazy/LazyLoadWrapper.js
+++ b/src/modules/commons/components/lazy/LazyLoadWrapper.js
@@ -10,7 +10,7 @@ const Update_Loaded = 'update_loaded';
  * Uses the webpack dynamic import feature.
  * @class
  * @property {String/TemplateResult} content The (configured) component displayed after its resources are available
- * @property {String} chunkName The chunk name of the js resource which should be dynamically be imported
+ * @property {String} chunkName The chunk name of the js resource which should be dynamically be imported (see `.src/chunks`)
  * @author taulinger
  */
 export class LazyLoadWrapper extends MvuElement {

--- a/src/modules/commons/components/lazy/LazyLoadWrapper.js
+++ b/src/modules/commons/components/lazy/LazyLoadWrapper.js
@@ -7,6 +7,7 @@ const Update_Loaded = 'update_loaded';
 
 /**
  * Wrapper component for a component which resources should be lazily imported.
+ * Uses the webpack dynamic import feature.
  * @class
  * @property {String/TemplateResult} content The (configured) component displayed after its resources are available
  * @property {String} chunkName The chunk name of the js resource which should be dynamically be imported
@@ -40,11 +41,7 @@ export class LazyLoadWrapper extends MvuElement {
 
 	createView(model) {
 		const { loaded } = model;
-		if (!loaded) {
-			return html`<div class="loading">Loading...</div>`;
-		}
-
-		return html`${this.#content}`;
+		return loaded ? html`${this.#content}` : html`<ba-spinner></ba-spinner>`;
 	}
 
 	set content(value) {

--- a/src/modules/commons/components/lazy/LazyLoadWrapper.js
+++ b/src/modules/commons/components/lazy/LazyLoadWrapper.js
@@ -1,0 +1,61 @@
+/**
+ * @module modules/commons/components/lazy/LazyLoad
+ */
+import { html } from 'lit-html';
+import { MvuElement } from '../../../MvuElement';
+const Update_Loaded = 'update_loaded';
+
+/**
+ * Wrapper component for a component which resources should be lazily imported.
+ * @class
+ * @property {String/TemplateResult} content The (configured) component displayed after its resources are available
+ * @property {String} chunkName The chunk name of the js resource which should be dynamically be imported
+ * @author taulinger
+ */
+export class LazyLoadWrapper extends MvuElement {
+	#content;
+	#chunkName;
+	constructor() {
+		super({
+			loaded: false
+		});
+	}
+
+	onInitialize() {
+		if (this.#chunkName) {
+			// see https://webpack.js.org/guides/code-splitting/#dynamic-imports
+			// eslint-disable-next-line promise/prefer-await-to-then
+			import(/* webpackChunkName: "[request]" */ `@chunk/${this.#chunkName}`).then(() => {
+				this.signal(Update_Loaded, true);
+			});
+		}
+	}
+
+	update(type, data, model) {
+		switch (type) {
+			case Update_Loaded:
+				return { ...model, loaded: data };
+		}
+	}
+
+	createView(model) {
+		const { loaded } = model;
+		if (!loaded) {
+			return html`<div class="loading">Loading...</div>`;
+		}
+
+		return html`${this.#content}`;
+	}
+
+	set content(value) {
+		this.#content = value;
+	}
+
+	set chunkName(value) {
+		this.#chunkName = value;
+	}
+
+	static get tag() {
+		return 'ba-lazy-load';
+	}
+}

--- a/src/modules/commons/components/lazy/LazyLoadWrapper.js
+++ b/src/modules/commons/components/lazy/LazyLoadWrapper.js
@@ -1,5 +1,5 @@
 /**
- * @module modules/commons/components/lazy/LazyLoad
+ * @module modules/commons/components/lazy/LazyLoadWrapper
  */
 import { html } from 'lit-html';
 import { MvuElement } from '../../../MvuElement';

--- a/src/modules/commons/components/lazy/index.js
+++ b/src/modules/commons/components/lazy/index.js
@@ -1,0 +1,4 @@
+import { LazyLoadWrapper } from './LazyLoadWrapper';
+if (!window.customElements.get(LazyLoadWrapper.tag)) {
+	window.customElements.define(LazyLoadWrapper.tag, LazyLoadWrapper);
+}

--- a/src/modules/commons/index.js
+++ b/src/modules/commons/index.js
@@ -5,3 +5,4 @@ import './components/checkbox';
 import './components/icon';
 import './components/spinner';
 import './components/overflowMenu';
+import './components/lazy';

--- a/src/modules/elevationProfile/index.js
+++ b/src/modules/elevationProfile/index.js
@@ -3,4 +3,4 @@ import { ElevationProfileChip } from './components/assistChip/ElevationProfileCh
 if (!window.customElements.get(ElevationProfileChip.tag)) {
 	window.customElements.define(ElevationProfileChip.tag, ElevationProfileChip);
 }
-// Note: ElevationProfile is omitted, because the component will be provided by its own chunk (see .src/chunks/elevation-profile.js)
+// Note: ElevationProfile is omitted here, because the component will be provided by its own chunk (see .src/chunks/elevation-profile.js)

--- a/src/modules/elevationProfile/index.js
+++ b/src/modules/elevationProfile/index.js
@@ -1,10 +1,5 @@
 import './i18n';
-import { ElevationProfile } from './components/panel/ElevationProfile';
 import { ElevationProfileChip } from './components/assistChip/ElevationProfileChip';
-
-if (!window.customElements.get(ElevationProfile.tag)) {
-	window.customElements.define(ElevationProfile.tag, ElevationProfile);
-}
 if (!window.customElements.get(ElevationProfileChip.tag)) {
 	window.customElements.define(ElevationProfileChip.tag, ElevationProfileChip);
 }

--- a/src/modules/elevationProfile/index.js
+++ b/src/modules/elevationProfile/index.js
@@ -3,3 +3,4 @@ import { ElevationProfileChip } from './components/assistChip/ElevationProfileCh
 if (!window.customElements.get(ElevationProfileChip.tag)) {
 	window.customElements.define(ElevationProfileChip.tag, ElevationProfileChip);
 }
+// Note: ElevationProfile is omitted, because the component will be provided by its own chunk (see .src/chunks/elevation-profile.js)

--- a/src/plugins/ElevationProfilePlugin.js
+++ b/src/plugins/ElevationProfilePlugin.js
@@ -35,7 +35,9 @@ export class ElevationProfilePlugin extends BaPlugin {
 			this._bottomSheetUnsubscribeFn?.();
 			if (active) {
 				this._bottomSheetUnsubscribeFn = observe(store, (state) => state.bottomSheet.active, onActiveStateChanged);
-				openBottomSheet(html`<ba-elevation-profile></ba-elevation-profile>`);
+				const content = html`<ba-elevation-profile></ba-elevation-profile>`;
+				const chunkName = 'elevation-profile';
+				openBottomSheet(html`<ba-lazy-load .chunkName=${chunkName} .content=${content}></ba-lazy-load>`);
 			} else {
 				closeBottomSheet();
 			}

--- a/test/chunkUtil/mockChunk.js
+++ b/test/chunkUtil/mockChunk.js
@@ -1,0 +1,1 @@
+// Note: Needed for correct testing of .src/modules/commons/components/lazy/LazyLoadWrapper.js

--- a/test/e2e/entryPointsAndChunks.spec.js
+++ b/test/e2e/entryPointsAndChunks.spec.js
@@ -6,13 +6,13 @@ test.describe('entry points', () => {
 	test('should provide the bundle.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/bundle.js`);
 		expect(response.ok()).toBeTruthy();
-		expect((await response.body()).byteLength).toBeCloseTo(15209266, 2);
+		expect((await response.body()).byteLength).toBeCloseTo(15209266, -3);
 	});
 
 	test('should provide the embed.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/embed.js`);
 		expect(response.ok()).toBeTruthy();
-		expect((await response.body()).byteLength).toBeCloseTo(12364167, 2);
+		expect((await response.body()).byteLength).toBeCloseTo(12364167, -3);
 	});
 
 	test('should provide the config.js', async ({ request }) => {

--- a/test/e2e/entryPointsAndChunks.spec.js
+++ b/test/e2e/entryPointsAndChunks.spec.js
@@ -6,13 +6,13 @@ test.describe('entry points', () => {
 	test('should provide the bundle.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/bundle.js`);
 		expect(response.ok()).toBeTruthy();
-		expect((await response.body()).byteLength).toBe(15209266);
+		expect((await response.body()).byteLength).toBeCloseTo(15209266, 2);
 	});
 
 	test('should provide the embed.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/embed.js`);
 		expect(response.ok()).toBeTruthy();
-		expect((await response.body()).byteLength).toBe(12364167);
+		expect((await response.body()).byteLength).toBeCloseTo(12364167, 2);
 	});
 
 	test('should provide the config.js', async ({ request }) => {

--- a/test/e2e/entryPointsAndChunks.spec.js
+++ b/test/e2e/entryPointsAndChunks.spec.js
@@ -21,7 +21,7 @@ test.describe('entry points', () => {
 	});
 });
 
-test.describe('entry points', () => {
+test.describe('chunks', () => {
 	test('should provide the ba-elevation.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/elevation-profile.js`);
 		expect(response.ok()).toBeTruthy();

--- a/test/e2e/entryPointsAndChunks.spec.js
+++ b/test/e2e/entryPointsAndChunks.spec.js
@@ -6,10 +6,24 @@ test.describe('entry points', () => {
 	test('should provide the bundle.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/bundle.js`);
 		expect(response.ok()).toBeTruthy();
+		expect((await response.body()).byteLength).toBe(15209266);
+	});
+
+	test('should provide the embed.js', async ({ request }) => {
+		const response = await request.get(`${BASE_URL}/embed.js`);
+		expect(response.ok()).toBeTruthy();
+		expect((await response.body()).byteLength).toBe(12364167);
 	});
 
 	test('should provide the config.js', async ({ request }) => {
 		const response = await request.get(`${BASE_URL}/config.js`);
+		expect(response.ok()).toBeTruthy();
+	});
+});
+
+test.describe('entry points', () => {
+	test('should provide the ba-elevation.js', async ({ request }) => {
+		const response = await request.get(`${BASE_URL}/elevation-profile.js`);
 		expect(response.ok()).toBeTruthy();
 	});
 });

--- a/test/modules/commons/components/LazyLoadWrapper.test.js
+++ b/test/modules/commons/components/LazyLoadWrapper.test.js
@@ -24,12 +24,14 @@ describe('LazyLoadWrapper', () => {
 		it('displays a loading hint', async () => {
 			const element = await setup();
 
-			expect(element.shadowRoot.querySelectorAll('.loading')).toHaveSize(1);
+			expect(element.shadowRoot.querySelectorAll('ba-spinner')).toHaveSize(1);
+			expect(element.shadowRoot.querySelectorAll('.content')).toHaveSize(0);
 		});
 
 		it('displays the content after the chunk was loaded', async () => {
 			const element = await setup({ chunkName: 'mockChunk', content: html`<div class="content"></div>` });
 
+			expect(element.shadowRoot.querySelectorAll('ba-spinner')).toHaveSize(0);
 			expect(element.shadowRoot.querySelectorAll('.content')).toHaveSize(1);
 		});
 	});

--- a/test/modules/commons/components/LazyLoadWrapper.test.js
+++ b/test/modules/commons/components/LazyLoadWrapper.test.js
@@ -1,0 +1,36 @@
+import { html } from 'lit-html';
+import { $injector } from '../../../../src/injection';
+import { LazyLoadWrapper } from '../../../../src/modules/commons/components/lazy/LazyLoadWrapper';
+import { TestUtils } from '../../../test-utils.js';
+window.customElements.define(LazyLoadWrapper.tag, LazyLoadWrapper);
+
+describe('LazyLoadWrapper', () => {
+	const setup = async (properties = {}) => {
+		TestUtils.setupStoreAndDi({});
+		$injector.registerSingleton('TranslationService', { translate: (key) => key });
+		return TestUtils.renderAndLogLifecycle(LazyLoadWrapper.tag, properties);
+	};
+
+	describe('when instantiated', () => {
+		it('has a model containing default values', async () => {
+			await setup();
+			const element = new LazyLoadWrapper();
+
+			expect(element.getModel().loaded).toBeFalse();
+		});
+	});
+
+	describe('when initialized', () => {
+		it('displays a loading hint', async () => {
+			const element = await setup();
+
+			expect(element.shadowRoot.querySelectorAll('.loading')).toHaveSize(1);
+		});
+
+		it('displays the content after the chunk was loaded', async () => {
+			const element = await setup({ chunkName: 'mockChunk', content: html`<div class="content"></div>` });
+
+			expect(element.shadowRoot.querySelectorAll('.content')).toHaveSize(1);
+		});
+	});
+});

--- a/test/modules/feedback/components/toggleFeedback/ToggleFeedbackPanel.test.js
+++ b/test/modules/feedback/components/toggleFeedback/ToggleFeedbackPanel.test.js
@@ -9,7 +9,7 @@ import { TestUtils } from '../../../../test-utils';
 window.customElements.define(ToggleFeedbackPanel.tag, ToggleFeedbackPanel);
 
 let store;
-const setup = (state = {}) => {
+const setup = (state = {}, properties = {}) => {
 	const initialState = {
 		...state
 	};
@@ -18,7 +18,7 @@ const setup = (state = {}) => {
 
 	$injector.registerSingleton('TranslationService', { translate: (key) => key });
 
-	return TestUtils.renderAndLogLifecycle(ToggleFeedbackPanel.tag);
+	return TestUtils.renderAndLogLifecycle(ToggleFeedbackPanel.tag, properties);
 };
 
 describe('ToggleFeedbackPanel', () => {
@@ -151,9 +151,7 @@ describe('ToggleFeedbackPanel', () => {
 	describe('property "onSubmit"', () => {
 		it('sets the onSubmit callback', async () => {
 			const onSubmbitFn = () => {};
-			const element = await setup();
-
-			element.onSubmit = onSubmbitFn;
+			const element = await setup({}, { onSubmit: onSubmbitFn });
 
 			expect(element._onSubmit).toEqual(onSubmbitFn);
 		});
@@ -161,10 +159,8 @@ describe('ToggleFeedbackPanel', () => {
 
 	describe('property "center"', () => {
 		it('sets the center coordinate and updates the view', async () => {
-			const element = await setup();
+			const element = await setup({}, { center: [21, 42] });
 			element.type = FeedbackType.MAP;
-
-			element.center = [21, 42];
 
 			expect(element.shadowRoot.querySelector(MapFeedbackPanel.tag).center).toEqual([21, 42]);
 		});

--- a/test/plugins/ElevationProfilePlugin.test.js
+++ b/test/plugins/ElevationProfilePlugin.test.js
@@ -8,6 +8,8 @@ import { drawReducer, initialState as drawInitialState } from '../../src/store/d
 import { measurementReducer, initialState as measurementInitialState } from '../../src/store/measurement/measurement.reducer';
 import { deactivate as deactivateDraw } from '../../src/store/draw/draw.action';
 import { deactivate as deactivateMeasurement } from '../../src/store/measurement/measurement.action';
+import { LazyLoadWrapper } from '../../src/modules/commons/components/lazy/LazyLoadWrapper';
+import { ElevationProfile } from '../../src/modules/elevationProfile/components/panel/ElevationProfile';
 
 describe('ElevationProfilePlugin', () => {
 	const setup = (state) => {
@@ -40,7 +42,10 @@ describe('ElevationProfilePlugin', () => {
 			]);
 
 			const wrapperElement = TestUtils.renderTemplateResult(store.getState().bottomSheet.data);
-			expect(wrapperElement.querySelectorAll('ba-elevation-profile')).toHaveSize(1);
+			expect(wrapperElement.querySelectorAll(LazyLoadWrapper.tag)).toHaveSize(1);
+			expect(wrapperElement.querySelectorAll(LazyLoadWrapper.tag)[0].chunkName).toBe('elevation-profile');
+			const wrapperElementForContent = TestUtils.renderTemplateResult(wrapperElement.querySelectorAll(LazyLoadWrapper.tag)[0].content);
+			expect(wrapperElementForContent.querySelectorAll(ElevationProfile.tag)).toHaveSize(1);
 
 			closeProfile();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,9 @@ module.exports = {
 		port: port
 	},
 	resolve: {
+		alias: {
+			'@chunk': path.resolve(__dirname, './src/chunks')
+		},
 		fallback: {
 			https: false,
 			http: false,

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 module.exports = {
 	mode: 'development',
 	devtool: 'inline-source-map',
@@ -28,6 +29,9 @@ module.exports = {
 		]
 	},
 	resolve: {
+		alias: {
+			'@chunk': path.resolve(__dirname, './test/chunkUtil')
+		},
 		fallback: {
 			https: false,
 			http: false,


### PR DESCRIPTION
In this PR the ElevationProfile component and its dependencies (incl. Chart.js) are loaded dynamically on demand by using webpack's dynamic import feature.

The initial build size decreases by almost 10% from 2.97 MiB to  2.77 MiB.

This feature will get much more interesting when we are trying to integrate something like Cesium.js.