### PR TITLE
#bugfix sharing of link while an external wms is enabled does not work

### DIFF
--- a/src/plugins/LayersPlugin.js
+++ b/src/plugins/LayersPlugin.js
@@ -54,7 +54,7 @@ export class LayersPlugin extends BaPlugin {
 		};
 
 		const parsedLayers = parseLayer(
-			queryParams.get(QueryParameters.LAYER),
+			decodeURIComponent(queryParams.get(QueryParameters.LAYER)),
 			queryParams.get(QueryParameters.LAYER_VISIBILITY),
 			queryParams.get(QueryParameters.LAYER_OPACITY)
 		);

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -161,7 +161,7 @@ export class ShareService {
 		if (layer_opacity.filter((lo) => lo !== 1).length === 0) {
 			layer_opacity = null;
 		}
-		extractedState[QueryParameters.LAYER] = geoResourceIds;
+		extractedState[QueryParameters.LAYER] = encodeURIComponent(geoResourceIds);
 		if (layer_visibility) {
 			extractedState[QueryParameters.LAYER_VISIBILITY] = layer_visibility;
 		}

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -99,7 +99,7 @@ describe('ShareService', () => {
 				addLayer('anotherLayer_123', { geoResourceId: 'anotherLayer' });
 
 				const extract = instanceUnderTest._extractLayers();
-				expect(extract[QueryParameters.LAYER]).toEqual(['someLayer', 'anotherLayer']);
+				expect(extract[QueryParameters.LAYER]).toEqual(encodeURIComponent(['someLayer', 'anotherLayer']));
 				expect(extract[QueryParameters.LAYER_OPACITY]).not.toBeDefined();
 				expect(extract[QueryParameters.LAYER_VISIBILITY]).not.toBeDefined();
 			});
@@ -112,7 +112,7 @@ describe('ShareService', () => {
 				addLayer('anotherLayer');
 
 				const extract = instanceUnderTest._extractLayers();
-				expect(extract[QueryParameters.LAYER]).toEqual(['anotherLayer']);
+				expect(extract[QueryParameters.LAYER]).toEqual(encodeURIComponent(['anotherLayer']));
 				expect(extract[QueryParameters.LAYER_OPACITY]).not.toBeDefined();
 				expect(extract[QueryParameters.LAYER_VISIBILITY]).not.toBeDefined();
 			});
@@ -127,7 +127,7 @@ describe('ShareService', () => {
 				addLayer('anotherLayer');
 
 				const extract = instanceUnderTest._extractLayers();
-				expect(extract[QueryParameters.LAYER]).toEqual(['anotherLayer']);
+				expect(extract[QueryParameters.LAYER]).toEqual(encodeURIComponent(['anotherLayer']));
 				expect(extract[QueryParameters.LAYER_OPACITY]).not.toBeDefined();
 				expect(extract[QueryParameters.LAYER_VISIBILITY]).not.toBeDefined();
 			});
@@ -140,7 +140,7 @@ describe('ShareService', () => {
 				addLayer('anotherLayer', { visible: false });
 
 				const extract = instanceUnderTest._extractLayers();
-				expect(extract[QueryParameters.LAYER]).toEqual(['someLayer', 'anotherLayer']);
+				expect(extract[QueryParameters.LAYER]).toEqual(encodeURIComponent(['someLayer', 'anotherLayer']));
 				expect(extract[QueryParameters.LAYER_OPACITY]).toEqual([0.5, 1.0]);
 				expect(extract[QueryParameters.LAYER_VISIBILITY]).toEqual([true, false]);
 			});


### PR DESCRIPTION
It is not possible to share a link whenever an external wms is active
1. enable an external WMS layer
2. share link (copy)
3. Result: The shortening service cannot create a short url for this link, because the "layer" parameter is not URI encoded

Proposed fix: URI encode/decode the "layer" query parameter 