### PR TITLE
OlDrawHandler: always clear drawing listeners

### DIFF
--- a/src/modules/olMap/utils/olInteractionUtils.js
+++ b/src/modules/olMap/utils/olInteractionUtils.js
@@ -151,7 +151,7 @@ export const getSelectableFeatures = (map, interactionLayer, pixel) => {
  * removes the defined list of features from the defined layer
  * @param {Array<Feature>} selectedFeatures
  * @param {Layer} interactionLayer the layer, which contains the features
- * @param {Function} [additionalAction] a additional action before the removing of each feature takes place
+ * @param {Function} [additionalAction] an additional action before the removal of each feature takes place
  */
 export const removeSelectedFeatures = (selectedFeatures, interactionLayer, additionalAction) => {
 	const additionalRemoveAction = typeof additionalAction === 'function' ? additionalAction : () => {};

--- a/src/modules/olMap/utils/olInteractionUtils.js
+++ b/src/modules/olMap/utils/olInteractionUtils.js
@@ -151,7 +151,7 @@ export const getSelectableFeatures = (map, interactionLayer, pixel) => {
  * removes the defined list of features from the defined layer
  * @param {Array<Feature>} selectedFeatures
  * @param {Layer} interactionLayer the layer, which contains the features
- * @param {Function} additionalAction a additional action before the removing of each feature takes place
+ * @param {Function} [additionalAction] a additional action before the removing of each feature takes place
  */
 export const removeSelectedFeatures = (selectedFeatures, interactionLayer, additionalAction) => {
 	const additionalRemoveAction = typeof additionalAction === 'function' ? additionalAction : () => {};

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -1226,7 +1226,7 @@ describe('OlDrawHandler', () => {
 			);
 		});
 
-		it('adds layer with specific contraints', async () => {
+		it('adds layer with specific constraints', async () => {
 			const state = { ...initialState, fileSaveResult: { fileId: null, adminId: null } };
 			const store = await setup(state);
 			const classUnderTest = new OlDrawHandler();
@@ -1296,6 +1296,27 @@ describe('OlDrawHandler', () => {
 			expect(classUnderTest._draw).toBeNull();
 			expect(initSpy).toHaveBeenCalled();
 		});
+
+		it('clears the drawing listeners', async () => {
+			await setup();
+			const classUnderTest = new OlDrawHandler();
+			const map = setupMap();
+			const geometry = new LineString([
+				[0, 0],
+				[1, 0]
+			]);
+			const feature = new Feature({ geometry: geometry });
+
+			classUnderTest.activate(map);
+			setType('line');
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+
+			expect(classUnderTest._drawingListeners).toHaveSize(1);
+
+			classUnderTest.deactivate(map);
+
+			expect(classUnderTest._drawingListeners).toEqual(jasmine.arrayWithExactContents([{}]));
+		});
 	});
 
 	describe('when draw a line', () => {
@@ -1311,7 +1332,6 @@ describe('OlDrawHandler', () => {
 
 			classUnderTest.activate(map);
 			setType('line');
-
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 
 			const id = feature.getId();

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -758,6 +758,26 @@ describe('OlMeasurementHandler', () => {
 			await TestUtils.timeout();
 			expect(store.getState().layers.active.length).toBe(0);
 		});
+
+		fit('clears the drawing listeners', async () => {
+			await setup();
+			const classUnderTest = new OlMeasurementHandler();
+			const map = setupMap();
+			const geometry = new LineString([
+				[0, 0],
+				[1, 0]
+			]);
+			const feature = new Feature({ geometry: geometry });
+
+			classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+
+			expect(classUnderTest._drawingListeners).toHaveSize(2);
+
+			classUnderTest.deactivate(map);
+
+			expect(classUnderTest._drawingListeners).toEqual(jasmine.arrayWithExactContents([{}, {}]));
+		});
 	});
 
 	describe('when draw a line', () => {

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -759,7 +759,7 @@ describe('OlMeasurementHandler', () => {
 			expect(store.getState().layers.active.length).toBe(0);
 		});
 
-		fit('clears the drawing listeners', async () => {
+		it('clears the drawing listeners', async () => {
 			await setup();
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();


### PR DESCRIPTION


- [x] add test for changes from  #1878
- [x] applying changes based on #1878 

