### PR TITLE
Drawing: Show text under symbol instead of inside symbol

### DIFF
--- a/src/modules/olMap/utils/olStyleUtils.js
+++ b/src/modules/olMap/utils/olStyleUtils.js
@@ -29,7 +29,7 @@ const Default_Symbol = 'marker';
 export const DEFAULT_TEXT = 'new text';
 export const DEFAULT_STYLE_OPTION = { symbolSrc: null, color: null, scale: null, text: null };
 
-const getTextStyle = (text, color, scale) => {
+const getTextStyle = (text, color, scale, offsetY = -5) => {
 	const strokeWidth = 1;
 	const createStyle = (text, color, scale) => {
 		return new TextStyle({
@@ -43,7 +43,7 @@ const getTextStyle = (text, color, scale) => {
 				color: hexToRgb(color).concat([1])
 			}),
 			scale: scale,
-			offsetY: -5
+			offsetY
 		});
 	};
 	return text ? createStyle(text, color, scale) : null;
@@ -310,7 +310,7 @@ export const markerStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
 	return [
 		new Style({
 			image: new Icon(iconOptions),
-			text: styleOption.text ? getTextStyle(styleOption.text, markerColor, getTextScale(styleOption.scale)) : null
+			text: styleOption.text ? getTextStyle(styleOption.text, markerColor, getTextScale(styleOption.scale), 6) : null
 		})
 	];
 };

--- a/test/modules/olMap/util/olStyleUtils.test.js
+++ b/test/modules/olMap/util/olStyleUtils.test.js
@@ -446,6 +446,7 @@ describe('markerStyleFunction', () => {
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getText().getText()).toBe('foo');
+		expect(styles[0].getText().getOffsetY()).toBe(6);
 	});
 
 	it('should return a style WITHOUT a Text', () => {


### PR DESCRIPTION
Currently when creating a symbol with text, the text is shown inside the symbol:
![Screenshot from 2023-10-26 16-15-58](https://github.com/ldbv-by/bav4/assets/4209805/a368b03f-aa69-49e2-beb3-4eb20a15c83a)


Show the text under the symbol:
![Screenshot from 2023-10-26 16-22-07](https://github.com/ldbv-by/bav4/assets/4209805/e69a47ff-c303-41cc-b497-342da59debe5)
