### PR TITLE
indicate when a feature is selectable

### DIFF
--- a/src/modules/olMap/components/OlMap.js
+++ b/src/modules/olMap/components/OlMap.js
@@ -51,7 +51,8 @@ export class OlMap extends MvuElement {
 			OlFeatureInfoHandler: olFeatureInfoHandler,
 			OlElevationProfileHandler: olElevationProfileHandler,
 			OlMfpHandler: olMfpHandler,
-			OlRoutingHandler: olRoutingHandler
+			OlRoutingHandler: olRoutingHandler,
+			OlSelectableFeatureHandler: olSelectableFeatureHandler
 		} = $injector.inject(
 			'MapService',
 			'GeoResourceService',
@@ -65,7 +66,8 @@ export class OlMap extends MvuElement {
 			'OlFeatureInfoHandler',
 			'OlElevationProfileHandler',
 			'OlMfpHandler',
-			'OlRoutingHandler'
+			'OlRoutingHandler',
+			'OlSelectableFeatureHandler'
 		);
 
 		this._mapService = mapService;
@@ -84,7 +86,8 @@ export class OlMap extends MvuElement {
 		]);
 		this._mapHandler = new Map([
 			[olFeatureInfoHandler.id, olFeatureInfoHandler],
-			[olElevationProfileHandler.id, olElevationProfileHandler]
+			[olElevationProfileHandler.id, olElevationProfileHandler],
+			[olSelectableFeatureHandler.id, olSelectableFeatureHandler]
 		]);
 		this._unsubscribers = [];
 	}

--- a/src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.js
+++ b/src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.js
@@ -1,0 +1,64 @@
+/**
+ * @module modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler
+ */
+import BaseTileLayer from '../../../../../node_modules/ol/layer/BaseTile';
+import ImageLayer from '../../../../../node_modules/ol/layer/Image';
+import { $injector } from '../../../../injection/index';
+import { observe } from '../../../../utils/storeUtils';
+import { OlMapHandler } from '../OlMapHandler';
+
+/**
+ * `MapHandler` that indicates if a vector feature or a pixel of a WMS or tile image is selectable
+ * (e.g. for a retrieving a feature info)
+ * by changing the cursor when a user moves the pointer over it.
+ * @class
+ * @author taulinger
+ */
+export class OlSelectableFeatureHandler extends OlMapHandler {
+	#handleEvent = false;
+	constructor() {
+		super('SelectableFeature_Handler');
+		const { StoreService: storeService } = $injector.inject('StoreService');
+		this._storeService = storeService;
+	}
+
+	register(map) {
+		observe(
+			this._storeService.getStore(),
+			(state) => state.tools.current,
+			(current) => {
+				this.#handleEvent = current === null;
+			},
+			false
+		);
+
+		const getDataAtPixel = (pixel) => {
+			return map
+				.getLayers()
+				.getArray()
+				.filter((l) => l instanceof ImageLayer || l instanceof BaseTileLayer)
+				.find((wmsLayer) => {
+					const data = wmsLayer.getData(pixel);
+					return data && data[3] > 0; // transparent pixels have zero for data[3]
+				})
+				? true
+				: false;
+		};
+
+		map.on('pointermove', (evt) => {
+			if (evt.dragging || !this.#handleEvent) {
+				// the event is a drag gesture, no need to handle here
+				return;
+			}
+
+			const pixel = map.getEventPixel(evt.originalEvent);
+			const feature = map.forEachFeatureAtPixel(
+				pixel,
+				(someFeature) => someFeature // returns first element
+			);
+
+			// change the cursor style
+			map.getTargetElement().style.cursor = feature || getDataAtPixel(evt.pixel) ? 'pointer' : '';
+		});
+	}
+}

--- a/src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.js
+++ b/src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.js
@@ -9,7 +9,7 @@ import { OlMapHandler } from '../OlMapHandler';
 
 /**
  * `MapHandler` that indicates if a vector feature or a pixel of a WMS or tile image is selectable
- * (e.g. for a retrieving a feature info)
+ * (e.g. for a retrieving feature info)
  * by changing the cursor when a user moves the pointer over it.
  * The handler does nothing when a tool is active.
  * @class

--- a/src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.js
+++ b/src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.js
@@ -11,6 +11,7 @@ import { OlMapHandler } from '../OlMapHandler';
  * `MapHandler` that indicates if a vector feature or a pixel of a WMS or tile image is selectable
  * (e.g. for a retrieving a feature info)
  * by changing the cursor when a user moves the pointer over it.
+ * The handler does nothing when a tool is active.
  * @class
  * @author taulinger
  */

--- a/src/modules/olMap/injection/index.js
+++ b/src/modules/olMap/injection/index.js
@@ -11,6 +11,7 @@ import { OlFeatureInfoHandler } from '../handler/featureInfo/OlFeatureInfoHandle
 import { OlMfpHandler } from '../handler/mfp/OlMfpHandler';
 import { OlElevationProfileHandler } from '../handler/elevationProfile/OlElevationProfileHandler';
 import { OlRoutingHandler } from '../handler/routing/OlRoutingHandler';
+import { OlSelectableFeatureHandler } from '../handler/selectableFeature/OlSelectableFeatureHandler';
 
 export const mapModule = ($injector) => {
 	$injector
@@ -26,5 +27,6 @@ export const mapModule = ($injector) => {
 		.register('OlFeatureInfoHandler', OlFeatureInfoHandler)
 		.register('OlElevationProfileHandler', OlElevationProfileHandler)
 		.register('OlMfpHandler', OlMfpHandler)
-		.register('OlRoutingHandler', OlRoutingHandler);
+		.register('OlRoutingHandler', OlRoutingHandler)
+		.register('OlSelectableFeatureHandler', OlSelectableFeatureHandler);
 };

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -9,7 +9,7 @@ import { createUniqueId } from './numberUtils';
  * @param {object} store The redux store
  * @param {function(state)} extract A function that extract a portion (single value or a object) from the current state which will be observed for comparison
  * @param {function(observedPartOfState, state)} onChange A function that will be called when the observed state has changed
- * @param {boolean|true} ignoreInitialState A boolean which indicate, if the callback should be initially called with the current state immediately after the observer has been registered. Default is `true`
+ * @param {boolean|true} [ignoreInitialState] A boolean which indicate, if the callback should be initially called with the current state immediately after the observer has been registered. Default is `true`
  * @returns  A function that unsubscribes the observer
  */
 export const observe = (store, extract, onChange, ignoreInitialState = true) => {

--- a/test/injection/config.test.js
+++ b/test/injection/config.test.js
@@ -6,7 +6,7 @@ import { Injector } from '../../src/injection/core/injector.js';
 describe('injector configuration', () => {
 	it('registers the expected dependencies', () => {
 		expect($injector.isReady()).toBeTrue();
-		expect($injector.count()).toBe(71);
+		expect($injector.count()).toBe(72);
 
 		expect($injector.getScope('ProjectionService')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('HttpService')).toBe(Injector.SCOPE_PERLOOKUP);
@@ -82,6 +82,7 @@ describe('injector configuration', () => {
 		expect($injector.getScope('OlElevationProfileHandler')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('OlMfpHandler')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('OlRoutingHandler')).toBe(Injector.SCOPE_PERLOOKUP);
+		expect($injector.getScope('OlSelectableFeatureHandler')).toBe(Injector.SCOPE_PERLOOKUP);
 
 		// topic module
 		expect($injector.getScope('CatalogService')).toBe(Injector.SCOPE_SINGLETON);

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -134,6 +134,12 @@ describe('OlMap', () => {
 			return 'olElevationProfileHandlerMockId';
 		}
 	};
+	const olSelectableFeatureHandlerMock = {
+		register() {},
+		get id() {
+			return 'olSelectableFeatureHandlerMockId';
+		}
+	};
 	const mfpHandlerMock = {
 		activate() {},
 		deactivate() {},
@@ -200,6 +206,7 @@ describe('OlMap', () => {
 			.registerSingleton('OlHighlightLayerHandler', highlightLayerHandlerMock)
 			.registerSingleton('OlFeatureInfoHandler', featureInfoHandlerMock)
 			.registerSingleton('OlElevationProfileHandler', olElevationProfileHandlerMock)
+			.registerSingleton('OlSelectableFeatureHandler', olSelectableFeatureHandlerMock)
 			.registerSingleton('OlMfpHandler', mfpHandlerMock)
 			.registerSingleton('OlRoutingHandler', routingHandlerMock)
 			.registerSingleton('VectorLayerService', vectorLayerServiceMock)
@@ -1464,6 +1471,14 @@ describe('OlMap', () => {
 			const element = await setup();
 
 			expect(element._mapHandler.get('olElevationProfileHandlerMockId')).toEqual(olElevationProfileHandlerMock);
+		});
+	});
+
+	describe('elevationProfile handler', () => {
+		it('registers the handler', async () => {
+			const element = await setup();
+
+			expect(element._mapHandler.get('olSelectableFeatureHandlerMockId')).toEqual(olSelectableFeatureHandlerMock);
 		});
 	});
 });

--- a/test/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.test.js
+++ b/test/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler.test.js
@@ -1,0 +1,210 @@
+import { Feature, Map, View } from 'ol';
+import { Point } from 'ol/geom';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import { OlSelectableFeatureHandler } from '../../../../../src/modules/olMap/handler/selectableFeature/OlSelectableFeatureHandler';
+import { TestUtils } from '../../../../test-utils';
+import { fromLonLat } from 'ol/proj';
+import { toolsReducer } from '../../../../../src/store/tools/tools.reducer';
+import { simulateMapBrowserEvent } from '../../mapTestUtils';
+import MapBrowserEventType from 'ol/MapBrowserEventType';
+import ImageLayer from 'ol/layer/Image';
+import ImageWMS from 'ol/source/ImageWMS.js';
+import { Tools } from '../../../../../src/domain/tools';
+import TileLayer from 'ol/layer/Tile';
+import { XYZ as XYZSource } from 'ol/source';
+
+describe('OlSelectableFeatureHandler', () => {
+	const renderComplete = (map) => {
+		return new Promise((resolve) => {
+			map.on('rendercomplete', () => {
+				resolve();
+			});
+		});
+	};
+
+	const matchingCoordinate = fromLonLat([11, 48]);
+	const notMatchingCoordinate = fromLonLat([5, 12]);
+
+	const setup = (state = {}) => {
+		TestUtils.setupStoreAndDi(state, { tools: toolsReducer });
+		return new OlSelectableFeatureHandler();
+	};
+
+	const setupMap = () => {
+		const container = document.createElement('div');
+		container.style.height = '100px';
+		container.style.width = '100px';
+		container.style.position = 'absolute';
+		container.style.left = '0';
+		container.style.top = '0';
+		document.body.appendChild(container);
+
+		return new Map({
+			target: container,
+			view: new View({
+				center: matchingCoordinate,
+				zoom: 1
+			})
+		});
+	};
+
+	it('instantiates the handler', () => {
+		setup();
+		const handler = new OlSelectableFeatureHandler();
+
+		expect(handler.id).toBe('SelectableFeature_Handler');
+		expect(handler.register).toBeDefined();
+	});
+
+	describe('when pointer moves over vector feature', () => {
+		it('changes the cursor', async () => {
+			const map = setupMap();
+			const vectorSource = new VectorSource();
+			vectorSource.addFeature(new Feature(new Point(matchingCoordinate)));
+			map.addLayer(new VectorLayer({ source: vectorSource }));
+			const handler = setup();
+			handler.register(map);
+			await renderComplete(map);
+			// safe to call map.getPixelFromCoordinate from now on
+			const matchingCoordinateInPixel = map.getPixelFromCoordinate(matchingCoordinate);
+			const notMatchingCoordinateInPixel = map.getPixelFromCoordinate(notMatchingCoordinate);
+
+			expect(map.getTargetElement().style.cursor).toBe('');
+
+			simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, matchingCoordinateInPixel[0], matchingCoordinateInPixel[1], false);
+
+			expect(map.getTargetElement().style.cursor).toBe('pointer');
+
+			simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, notMatchingCoordinateInPixel[0], notMatchingCoordinateInPixel[1], false);
+
+			expect(map.getTargetElement().style.cursor).toBe('');
+		});
+	});
+
+	describe('when pointer moves over an image', () => {
+		describe('and pixel is NOT transparent', () => {
+			it('changes the cursor', async () => {
+				const map = setupMap();
+				const wmsSource = new ImageWMS();
+				const wmsLayer = new ImageLayer({ source: wmsSource });
+				map.addLayer(wmsLayer);
+				const handler = setup();
+				handler.register(map);
+				await renderComplete(map);
+				// safe to call map.getPixelFromCoordinate from now on
+				const matchingCoordinateInPixel = map.getPixelFromCoordinate(matchingCoordinate);
+				const notMatchingCoordinateInPixel = map.getPixelFromCoordinate(notMatchingCoordinate);
+				spyOn(wmsLayer, 'getData').and.callFake((pixel) => {
+					return pixel[0] === matchingCoordinateInPixel[0] ? [42, 42, 42, 42] : [42, 42, 42, 0];
+				});
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+
+				simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, matchingCoordinateInPixel[0], matchingCoordinateInPixel[1], false);
+
+				expect(map.getTargetElement().style.cursor).toBe('pointer');
+
+				simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, notMatchingCoordinateInPixel[0], notMatchingCoordinateInPixel[1], false);
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+			});
+		});
+
+		describe('and pixel is transparent', () => {
+			it('does nothing', async () => {
+				const map = setupMap();
+				const wmsSource = new ImageWMS();
+				const wmsLayer = new ImageLayer({ source: wmsSource });
+				map.addLayer(wmsLayer);
+				const handler = setup();
+				handler.register(map);
+				await renderComplete(map);
+				// safe to call map.getPixelFromCoordinate from now on
+				const matchingCoordinateInPixel = map.getPixelFromCoordinate(matchingCoordinate);
+				spyOn(wmsLayer, 'getData').withArgs(matchingCoordinateInPixel).and.returnValue([42, 42, 42, 0]);
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+
+				simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, matchingCoordinateInPixel[0], matchingCoordinateInPixel[1], false);
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+			});
+		});
+	});
+
+	describe('when pointer moves over an image tile', () => {
+		describe('and pixel is NOT transparent', () => {
+			it('changes the cursor', async () => {
+				const map = setupMap();
+				const tileSource = new XYZSource();
+				const tileLayer = new TileLayer({ source: tileSource });
+				map.addLayer(tileLayer);
+				const handler = setup();
+				handler.register(map);
+				await renderComplete(map);
+				// safe to call map.getPixelFromCoordinate from now on
+				const matchingCoordinateInPixel = map.getPixelFromCoordinate(matchingCoordinate);
+				const notMatchingCoordinateInPixel = map.getPixelFromCoordinate(notMatchingCoordinate);
+				spyOn(tileLayer, 'getData').and.callFake((pixel) => {
+					return pixel[0] === matchingCoordinateInPixel[0] ? [42, 42, 42, 42] : [42, 42, 42, 0];
+				});
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+
+				simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, matchingCoordinateInPixel[0], matchingCoordinateInPixel[1], false);
+
+				expect(map.getTargetElement().style.cursor).toBe('pointer');
+
+				simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, notMatchingCoordinateInPixel[0], notMatchingCoordinateInPixel[1], false);
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+			});
+		});
+
+		describe('and pixel is transparent', () => {
+			it('does nothing', async () => {
+				const map = setupMap();
+				const tileSource = new XYZSource();
+				const tileLayer = new TileLayer({ source: tileSource });
+				map.addLayer(tileLayer);
+				const handler = setup();
+				handler.register(map);
+				await renderComplete(map);
+				// safe to call map.getPixelFromCoordinate from now on
+				const matchingCoordinateInPixel = map.getPixelFromCoordinate(matchingCoordinate);
+				spyOn(tileLayer, 'getData').withArgs(matchingCoordinateInPixel).and.returnValue([42, 42, 42, 0]);
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+
+				simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, matchingCoordinateInPixel[0], matchingCoordinateInPixel[1], false);
+
+				expect(map.getTargetElement().style.cursor).toBe('');
+			});
+		});
+	});
+
+	describe('when a tool is active', () => {
+		it('does nothing', async () => {
+			const map = setupMap();
+			const vectorSource = new VectorSource();
+			vectorSource.addFeature(new Feature(new Point(matchingCoordinate)));
+			map.addLayer(new VectorLayer({ source: vectorSource }));
+			const handler = setup({
+				tools: {
+					current: Tools.DRAW
+				}
+			});
+			handler.register(map);
+			await renderComplete(map);
+			// safe to call map.getPixelFromCoordinate from now on
+			const matchingCoordinateInPixel = map.getPixelFromCoordinate(matchingCoordinate);
+
+			expect(map.getTargetElement().style.cursor).toBe('');
+
+			simulateMapBrowserEvent(map, MapBrowserEventType.POINTERMOVE, matchingCoordinateInPixel[0], matchingCoordinateInPixel[1], false);
+
+			expect(map.getTargetElement().style.cursor).toBe('');
+		});
+	});
+});


### PR DESCRIPTION
Changes the cursor when a vector feature or a pixel of a WMS or tile image is selectable.
The default cursor will change to a pointer (👆) in the following cases:


![grafik](https://github.com/ldbv-by/bav4/assets/49945713/3c325a0c-cd5d-4588-9052-4b15af3378b3)


![grafik](https://github.com/ldbv-by/bav4/assets/49945713/3a26301f-0049-4848-b9da-6422d8d79811)
