### PR TITLE
extend MvuContentPanel

### DIFF
--- a/src/modules/menu/components/mainMenu/MainMenu.js
+++ b/src/modules/menu/components/mainMenu/MainMenu.js
@@ -16,6 +16,7 @@ import { BvvMiscContentPanel } from './content/misc/BvvMiscContentPanel';
 import { RoutingPanel } from './content/routing/RoutingPanel';
 import { MvuElement } from '../../../MvuElement';
 import VanillaSwipe from 'vanilla-swipe';
+import { isString } from '../../../../utils/checks';
 
 const Update_Main_Menu = 'update_main_menu';
 const Update_Media = 'update_media';
@@ -77,9 +78,11 @@ export class MainMenu extends MvuElement {
 
 	_activateTab(key) {
 		const tabcontents = [...this._root.querySelectorAll('.tabcontent')];
-		tabcontents.forEach((tabcontent, i) =>
-			Object.values(TabIds)[i] === key ? tabcontent.classList.add('is-active') : tabcontent.classList.remove('is-active')
-		);
+		tabcontents.forEach((tabcontent, i) => {
+			const active = Object.values(TabIds)[i] === key;
+			tabcontent.firstElementChild.active = active;
+			active ? tabcontent.classList.add('is-active') : tabcontent.classList.remove('is-active');
+		});
 	}
 
 	/**
@@ -124,7 +127,9 @@ export class MainMenu extends MvuElement {
 
 		const getPreloadClass = () => (observeResponsiveParameter ? '' : 'prevent-transition');
 
-		const contentPanels = Object.values(TabIds).map((v) => this._getContentPanel(v));
+		const contentPanels = Object.values(TabIds)
+			.filter((v) => isString(v))
+			.map((v) => this._getContentPanel(v));
 
 		const translate = (key) => this._translationService.translate(key);
 

--- a/src/modules/menu/components/mainMenu/MainMenu.js
+++ b/src/modules/menu/components/mainMenu/MainMenu.js
@@ -197,8 +197,6 @@ export class MainMenu extends MvuElement {
 				return html`${unsafeHTML(`<${TopicsContentPanel.tag} data-test-id />`)}`;
 			case TabIds.FEATUREINFO:
 				return html`${unsafeHTML(`<${FeatureInfoPanel.tag} data-test-id />`)}`;
-			default:
-				return nothing;
 		}
 	}
 

--- a/src/modules/menu/components/mainMenu/MainMenu.js
+++ b/src/modules/menu/components/mainMenu/MainMenu.js
@@ -1,7 +1,7 @@
 /**
  * @module modules/menu/components/mainMenu/MainMenu
  */
-import { html, nothing } from 'lit-html';
+import { html } from 'lit-html';
 import css from './mainMenu.css';
 import { $injector } from '../../../../injection';
 import { DevInfo } from '../../../utils/components/devInfo/DevInfo';

--- a/src/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.js
+++ b/src/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.js
@@ -49,8 +49,4 @@ export class AbstractMvuContentPanel extends MvuElement {
 	get active() {
 		return this.getModel().active;
 	}
-
-	setActive(active) {
-		this.signal(Update_Active, active);
-	}
 }

--- a/src/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.js
+++ b/src/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.js
@@ -5,19 +5,28 @@ import { html } from 'lit-html';
 import { MvuElement } from '../../../../MvuElement';
 import contentPanelCss from './abstractContentPanel.css';
 
+const Update_Active = 'update_disabled';
+
 /**
  * Base class for all content panels of the main menu.
- * Just prepends common CSS classes.
+ * @property {boolean} active - `true` when the content panel is currently active
  * @class
  * @author taulinger
  * @abstract
  */
 export class AbstractMvuContentPanel extends MvuElement {
 	constructor(model = {}) {
-		super(model);
+		super({ ...model, active: false });
 		if (this.constructor === AbstractMvuContentPanel) {
 			// Abstract class can not be constructed.
 			throw new TypeError('Can not construct abstract class.');
+		}
+	}
+
+	update(type, data, model) {
+		switch (type) {
+			case Update_Active:
+				return { ...model, active: data };
 		}
 	}
 
@@ -31,5 +40,17 @@ export class AbstractMvuContentPanel extends MvuElement {
 				${contentPanelCss}
 			</style>
 		`;
+	}
+
+	set active(active) {
+		this.signal(Update_Active, active);
+	}
+
+	get active() {
+		return this.getModel().active;
+	}
+
+	setActive(active) {
+		this.signal(Update_Active, active);
 	}
 }

--- a/test/modules/featureInfo/components/FeatureInfoPanel.test.js
+++ b/test/modules/featureInfo/components/FeatureInfoPanel.test.js
@@ -46,7 +46,8 @@ describe('FeatureInfoPanel', () => {
 
 			expect(model).toEqual({
 				featureInfoData: [],
-				isPortrait: false
+				isPortrait: false,
+				active: false
 			});
 		});
 	});

--- a/test/modules/menu/components/mainMenu/MainMenu.test.js
+++ b/test/modules/menu/components/mainMenu/MainMenu.test.js
@@ -21,8 +21,35 @@ import { MapsContentPanel } from '../../../../../src/modules/menu/components/mai
 import { BvvMiscContentPanel } from '../../../../../src/modules/menu/components/mainMenu/content/misc/BvvMiscContentPanel';
 import { RoutingPanel } from '../../../../../src/modules/menu/components/mainMenu/content/routing/RoutingPanel';
 import { REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME, TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
+import { AbstractMvuContentPanel } from '../../../../../src/modules/menu/components/mainMenu/content/AbstractMvuContentPanel';
 
 window.customElements.define(MainMenu.tag, MainMenu);
+
+// shallow content panels, just for testing if the "active" property is set
+class MapsContentPanelMock extends AbstractMvuContentPanel {
+	createView() {}
+}
+class BvvMiscContentPanelMock extends AbstractMvuContentPanel {
+	createView() {}
+}
+class RoutingPanelMock extends AbstractMvuContentPanel {
+	createView() {}
+}
+class SearchResultsPanelMock extends AbstractMvuContentPanel {
+	createView() {}
+}
+class TopicsContentPanelMock extends AbstractMvuContentPanel {
+	createView() {}
+}
+class FeatureInfoPanelMock extends AbstractMvuContentPanel {
+	createView() {}
+}
+window.customElements.define(MapsContentPanel.tag, MapsContentPanelMock);
+window.customElements.define(BvvMiscContentPanel.tag, BvvMiscContentPanelMock);
+window.customElements.define(RoutingPanel.tag, RoutingPanelMock);
+window.customElements.define(SearchResultsPanel.tag, SearchResultsPanelMock);
+window.customElements.define(TopicsContentPanel.tag, TopicsContentPanelMock);
+window.customElements.define(FeatureInfoPanel.tag, FeatureInfoPanelMock);
 
 describe('MainMenu', () => {
 	const setup = (state = {}, config = {}) => {
@@ -163,7 +190,7 @@ describe('MainMenu', () => {
 			const element = await setup();
 
 			const contentPanels = element.shadowRoot.querySelectorAll('.tabcontent');
-			expect(contentPanels.length).toBe(Object.keys(TabIds).length);
+			expect(contentPanels.length).toBe(6);
 			for (let i = 0; i < contentPanels.length; i++) {
 				switch (i) {
 					case TabIds.SEARCH:
@@ -181,6 +208,8 @@ describe('MainMenu', () => {
 					case TabIds.MISC:
 						expect(contentPanels[i].innerHTML.toString().includes(BvvMiscContentPanel.tag)).toBeTrue();
 						break;
+					case TabIds.RoutingPanel:
+						expect(contentPanels[i].innerHTML.toString().includes(RoutingPanel.tag)).toBeTrue();
 				}
 			}
 		});
@@ -197,11 +226,11 @@ describe('MainMenu', () => {
 			expect(element.shadowRoot.querySelector(RoutingPanel.tag).hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 		});
 
-		it('display the content panel for default index = 0', async () => {
+		it('displays the content panel for default index = 0', async () => {
 			const element = await setup();
 
 			const contentPanels = element.shadowRoot.querySelectorAll('.tabcontent');
-			expect(contentPanels.length).toBe(Object.keys(TabIds).length);
+			expect(contentPanels.length).toBe(6);
 			for (let i = 0; i < contentPanels.length; i++) {
 				expect(contentPanels[i].classList.contains('is-active')).toBe(Object.values(TabIds)[i] === 0);
 			}
@@ -218,7 +247,7 @@ describe('MainMenu', () => {
 			const element = await setup(state);
 
 			const contentPanels = element.shadowRoot.querySelectorAll('.tabcontent');
-			expect(contentPanels.length).toBe(Object.keys(TabIds).length);
+			expect(contentPanels.length).toBe(6);
 			for (let i = 0; i < contentPanels.length; i++) {
 				expect(contentPanels[i].classList.contains('is-active')).toBe(Object.values(TabIds)[i] === activeTabIndex);
 			}
@@ -282,9 +311,10 @@ describe('MainMenu', () => {
 	});
 
 	describe('when tab-index changes', () => {
-		const check = (index, panels) => {
+		const check = (index, panels, spies) => {
 			for (let i = 0; i < panels.length; i++) {
 				expect(panels[i].classList.contains('is-active')).toBe(Object.values(TabIds)[i] === index);
+				expect(spies[i]).toHaveBeenCalledWith(Object.values(TabIds)[i] === index);
 			}
 		};
 
@@ -292,23 +322,28 @@ describe('MainMenu', () => {
 			const element = await setup();
 			const contentPanels = element.shadowRoot.querySelectorAll('.tabcontent');
 
+			const spies = [...contentPanels].map((el) => spyOnProperty(el.firstElementChild, 'active', 'set'));
+
 			setTab(TabIds.MAPS);
-			check(TabIds.MAPS, contentPanels);
+			check(TabIds.MAPS, contentPanels, spies);
 
 			setTab(TabIds.MISC);
-			check(TabIds.MISC, contentPanels);
+			check(TabIds.MISC, contentPanels, spies);
 
 			setTab(TabIds.ROUTING);
-			check(TabIds.ROUTING, contentPanels);
+			check(TabIds.ROUTING, contentPanels, spies);
 
 			setTab(TabIds.SEARCH);
-			check(TabIds.SEARCH, contentPanels);
+			check(TabIds.SEARCH, contentPanels, spies);
 
 			setTab(TabIds.FEATUREINFO);
-			check(TabIds.FEATUREINFO, contentPanels);
+			check(TabIds.FEATUREINFO, contentPanels, spies);
 
 			setTab(TabIds.TOPICS);
-			check(TabIds.TOPICS, contentPanels);
+			check(TabIds.TOPICS, contentPanels, spies);
+
+			setTab(TabIds.ROUTING);
+			check(TabIds.ROUTING, contentPanels, spies);
 		});
 
 		it('adds or removes a special Css class for the FeatureInfoContentPanel', async () => {

--- a/test/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.test.js
+++ b/test/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.test.js
@@ -24,17 +24,20 @@ describe('AbstractMvuContentPanel', () => {
 		setupStoreAndDi();
 	});
 
-	it('calls the parent constructor with model', () => {
-		const model = { foo: 'bar' };
-		class MyContentPanel extends AbstractMvuContentPanel {
-			constructor() {
-				super(model);
+	describe('constructor', () => {
+		it('contains a model combined from the child model and its own model', () => {
+			const model = { foo: 'bar' };
+			class MyContentPanel extends AbstractMvuContentPanel {
+				constructor() {
+					super(model);
+				}
 			}
-		}
-		window.customElements.define('ba-mycontent-panel', MyContentPanel);
+			window.customElements.define('ba-mycontent-panel', MyContentPanel);
 
-		const instance = new MyContentPanel();
-		expect(instance.getModel()).toEqual(model);
+			const instance = new MyContentPanel();
+
+			expect(instance.getModel()).toEqual({ foo: 'bar', active: false });
+		});
 	});
 
 	describe('expected errors', () => {
@@ -50,6 +53,19 @@ describe('AbstractMvuContentPanel', () => {
 			const element = await TestUtils.render(AbstractMvuContentPanelImpl.tag);
 
 			expect(element.shadowRoot.querySelectorAll('style')).toHaveSize(2);
+		});
+	});
+
+	describe('when property "active" is set', () => {
+		it('updates the model', async () => {
+			const element = await TestUtils.render(AbstractMvuContentPanelImpl.tag);
+
+			expect(element.active).toBeFalse();
+
+			element.active = true;
+
+			expect(element.active).toBeTrue();
+			expect(element.getModel().active).toBeTrue();
 		});
 	});
 });

--- a/test/modules/menu/components/mainMenu/content/RoutingPanel.test.js
+++ b/test/modules/menu/components/mainMenu/content/RoutingPanel.test.js
@@ -47,7 +47,7 @@ describe('RoutingPanel', () => {
 			await setup();
 			const model = new RoutingPanel().getModel();
 
-			expect(model).toEqual({});
+			expect(model).toEqual({ active: false });
 		});
 	});
 

--- a/test/modules/topics/components/menu/TopicsContentPanel.test.js
+++ b/test/modules/topics/components/menu/TopicsContentPanel.test.js
@@ -1,5 +1,4 @@
 import { $injector } from '../../../../../src/injection';
-import { AbstractContentPanel } from '../../../../../src/modules/menu/components/mainMenu/content/AbstractContentPanel';
 import { CatalogContentPanel } from '../../../../../src/modules/topics/components/menu/catalog/CatalogContentPanel';
 import { TopicsContentPanel, TopicsContentPanelIndex } from '../../../../../src/modules/topics/components/menu/TopicsContentPanel';
 import { Topic } from '../../../../../src/domain/topic';
@@ -8,6 +7,7 @@ import { topicsReducer } from '../../../../../src/store/topics/topics.reducer';
 import { topicsContentPanelReducer } from '../../../../../src/store/topicsContentPanel/topicsContentPanel.reducer';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
 import { TestUtils } from '../../../../test-utils.js';
+import { AbstractMvuContentPanel } from '../../../../../src/modules/menu/components/mainMenu/content/AbstractMvuContentPanel.js';
 
 window.customElements.define(TopicsContentPanel.tag, TopicsContentPanel);
 
@@ -38,10 +38,24 @@ describe('TopicsContentPanel', () => {
 	};
 
 	describe('class', () => {
-		it('inherits from AbstractContentPanel', async () => {
+		it('inherits from AbstractMvuContentPanel', async () => {
 			const element = await setup();
 
-			expect(element instanceof AbstractContentPanel).toBeTrue();
+			expect(element instanceof AbstractMvuContentPanel).toBeTrue();
+		});
+	});
+
+	describe('when instantiated', () => {
+		it('has a model with default values', async () => {
+			await setup();
+			const model = new TopicsContentPanel().getModel();
+
+			expect(model).toEqual({
+				currentTopicId: null,
+				topicsReady: false,
+				contentIndex: null,
+				active: false // from parent class
+			});
 		});
 	});
 


### PR DESCRIPTION
Allows lazy loading of the content now:

```
export class MyPanel extends AbstractMvuContentPanel {
	

	createView(model) {
		const { active } = model;
		

		return active ?  ...

```