### PR TITLE
v4.1: fix chips scroll button portrait

### DIFF
--- a/src/modules/chips/components/chipsContainer/chipsContainer.css
+++ b/src/modules/chips/components/chipsContainer/chipsContainer.css
@@ -5,6 +5,8 @@
 	position: absolute;
 	scroll-behavior: smooth;
 	overflow: hidden;
+	-ms-overflow-style: none;
+	scrollbar-width: none;
 }
 .chips__button {
 	background: var(--chip-background-color);
@@ -63,7 +65,7 @@
 	width: 100%;
 	z-index: 100;
 	padding: 0 1em;
-	overflow: hidden;
+	overflow: scroll;
 }
 .chips__scroll-button {
 	display: none;
@@ -122,6 +124,10 @@ iframe {
 	width: 100%;
 	min-width: auto;
 }
+.is-portrait .chips__scroll-button {
+	display: none;
+}
+
 ::-webkit-scrollbar {
 	height: 0;
 }

--- a/test/modules/chips/components/ChipsContainer.test.js
+++ b/test/modules/chips/components/ChipsContainer.test.js
@@ -339,8 +339,23 @@ describe('ChipsContainer', () => {
 			expect(window.getComputedStyle(scrollButton[1]).display).toBe('none');
 		});
 
-		it('shows two scroll buttons on shortage of space', async () => {
-			const element = await setup({ chips: { current: chipsConfiguration1 } });
+		it('does not show scroll buttons in portrait layout', async () => {
+			const element = await setup({ media: { portrait: true }, chips: { current: chipsConfiguration1 } });
+			const container = element.shadowRoot.querySelectorAll('#chipscontainer')[0];
+
+			// let's make the scroll buttons visible by minimizing the containers width
+			container.style.width = '1px';
+			await TestUtils.timeout(animationTimeout /** give the browser some time */);
+
+			expect(container.classList.contains('show')).toBeTrue();
+			const scrollButton = element.shadowRoot.querySelectorAll('.chips__scroll-button');
+			expect(scrollButton).toHaveSize(2);
+			expect(window.getComputedStyle(scrollButton[0]).display).toBe('none');
+			expect(window.getComputedStyle(scrollButton[1]).display).toBe('none');
+		});
+
+		it('shows tow scroll buttons on shortage of space in desktop layout', async () => {
+			const element = await setup({ media: { portrait: false }, chips: { current: chipsConfiguration1 } });
 			const container = element.shadowRoot.querySelectorAll('#chipscontainer')[0];
 
 			// let's make the scroll buttons visible by minimizing the containers width


### PR DESCRIPTION
Improve usability when multiple chips are displayed on a mobile device (especially Safari and FF)