### PR TITLE
add QueryParameter for zooming on the extent of a layer

### DIFF
--- a/src/domain/queryParameters.js
+++ b/src/domain/queryParameters.js
@@ -8,20 +8,70 @@
  */
 export const QueryParameters = Object.freeze({
 	// official parameters
+	/**
+	 * The zoom level of the map (`number`)
+	 */
 	ZOOM: 'z',
+	/**
+	 * The center of the map (two `numbers`, comma-separated)
+	 */
 	CENTER: 'c',
+	/**
+	 * The rotation of the map (`number`, in radians)
+	 */
 	ROTATION: 'r',
+	/**
+	 * The ids of the layer of the map  (`string`, comma-separated).
+	 * The id internally represent the id of a {@link GeoResource}
+	 */
 	LAYER: 'l',
+	/**
+	 * The visibility of a layer (`boolean`, comma-separated)
+	 */
 	LAYER_VISIBILITY: 'l_v',
+	/**
+	 * The opacity of a layer (`number`, 0-1, comma-separated)
+	 */
 	LAYER_OPACITY: 'l_o',
+	/**
+	 * Currently not supported. The active topic (`string`)
+	 */
 	TOPIC: 't',
+	/**
+	 * A `string` which will initialize a search request for that query
+	 */
 	QUERY: 'q',
+	/**
+	 * Id (`string`) of a Chip component which should be displayed
+	 */
 	CHIP_ID: 'chid',
+	/**
+	 * Id (`integer`) of a menu item which should be displayed
+	 */
 	MENU_ID: 'mid',
+	/**
+	 * Id (`string`)  of a tool item which should initially active
+	 */
 	TOOL_ID: 'tid',
+	/**
+	 * Ids of components (`string`, comma-separated) which should be displayed within the iframe
+	 */
 	IFRAME_COMPONENTS: 'ifc',
+	/**
+	 * Id (`string`) of the type of marker which should be initially displayed in the center of the map
+	 */
 	CROSSHAIR: 'crh',
+	/**
+	 *The index (`number`) of the layer (see `LAYER` parameter) which extent should be used to fit on the map size.
+	 */
+	ZOOM_TO_EXTENT: 'zte',
 	// technical parameters
+	/**
+	 * Render test ids (`boolean`)
+	 */
 	T_ENABLE_TEST_IDS: 't_enable-test-ids',
+	/**
+	 * Currently not supported.
+	 */
 	T_DISABLE_INITIAL_UI_HINTS: 't_disable-initial-ui-hints'
 });

--- a/src/plugins/LayersPlugin.js
+++ b/src/plugins/LayersPlugin.js
@@ -6,6 +6,8 @@ import { QueryParameters } from '../domain/queryParameters';
 import { BaPlugin } from './BaPlugin';
 import { addLayer, setReady } from '../store/layers/layers.action';
 import { createUniqueId } from '../utils/numberUtils';
+import { fitLayer } from '../store/position/position.action';
+import { isNumber } from '../utils/checks';
 
 /**
  * @class
@@ -58,7 +60,15 @@ export class LayersPlugin extends BaPlugin {
 			queryParams.get(QueryParameters.LAYER_VISIBILITY),
 			queryParams.get(QueryParameters.LAYER_OPACITY)
 		);
-		parsedLayers.forEach((l) => {
+		const zteIndex = parseInt(queryParams.get(QueryParameters.ZOOM_TO_EXTENT));
+		const zoomToExtentLayerIndex = isNumber(zteIndex) ? zteIndex : -1;
+
+		parsedLayers.forEach((l, index) => {
+			if (index === zoomToExtentLayerIndex) {
+				setTimeout(() => {
+					fitLayer(l.id);
+				});
+			}
 			addLayer(l.id, l.layerProperties);
 		});
 	}

--- a/test/domain/queryParameters.test.js
+++ b/test/domain/queryParameters.test.js
@@ -2,7 +2,7 @@ import { QueryParameters } from '../../src/domain/queryParameters';
 
 describe('QueryParameters', () => {
 	it('provides an enum of all valid query parameters', () => {
-		expect(Object.keys(QueryParameters).length).toBe(15);
+		expect(Object.keys(QueryParameters).length).toBe(16);
 
 		expect(QueryParameters.CENTER).toBe('c');
 		expect(QueryParameters.ZOOM).toBe('z');
@@ -17,6 +17,7 @@ describe('QueryParameters', () => {
 		expect(QueryParameters.TOOL_ID).toBe('tid');
 		expect(QueryParameters.IFRAME_COMPONENTS).toBe('ifc');
 		expect(QueryParameters.CROSSHAIR).toBe('crh');
+		expect(QueryParameters.ZOOM_TO_EXTENT).toBe('zte');
 
 		expect(QueryParameters.T_ENABLE_TEST_IDS).toBe('t_enable-test-ids');
 		expect(QueryParameters.T_DISABLE_INITIAL_UI_HINTS).toBe('t_disable-initial-ui-hints');

--- a/test/plugins/LayersPlugin.test.js
+++ b/test/plugins/LayersPlugin.test.js
@@ -7,6 +7,7 @@ import { QueryParameters } from '../../src/domain/queryParameters';
 import { Topic } from '../../src/domain/topic';
 import { setCurrent } from '../../src/store/topics/topics.action';
 import { topicsReducer } from '../../src/store/topics/topics.reducer';
+import { initialState as initialPositionState, positionReducer } from '../../src/store/position/position.reducer.js';
 
 describe('LayersPlugin', () => {
 	const geoResourceServiceMock = {
@@ -33,7 +34,8 @@ describe('LayersPlugin', () => {
 	const setup = (state) => {
 		const store = TestUtils.setupStoreAndDi(state, {
 			layers: layersReducer,
-			topics: topicsReducer
+			topics: topicsReducer,
+			position: positionReducer
 		});
 		$injector
 			.registerSingleton('GeoResourceService', geoResourceServiceMock)
@@ -359,6 +361,58 @@ describe('LayersPlugin', () => {
 				instanceUnderTest._addLayersFromQueryParams(new URLSearchParams(queryParam));
 
 				expect(store.getState().layers.active.length).toBe(0);
+			});
+
+			describe('handle query parameter ZOOM_TO_EXTENT', () => {
+				it('calls #fitLayer() for the correct layer', async () => {
+					const queryParam = new URLSearchParams(`${QueryParameters.LAYER}=some0,some1&${QueryParameters.ZOOM_TO_EXTENT}=1`);
+					const store = setup({
+						position: initialPositionState
+					});
+					const instanceUnderTest = new LayersPlugin();
+					spyOn(environmentService, 'getQueryParams').and.returnValue(queryParam);
+					spyOn(geoResourceServiceMock, 'byId').and.callFake((id) => {
+						switch (id) {
+							case 'some0':
+								return new XyzGeoResource('some0', 'someLabel0', 'someUrl0');
+							case 'some1':
+								return new XyzGeoResource('some1', 'someLabel1', 'someUrl1');
+						}
+					});
+
+					expect(store.getState().position.fitLayerRequest.payload).toBeNull();
+
+					instanceUnderTest._addLayersFromQueryParams(new URLSearchParams(queryParam));
+
+					await TestUtils.timeout();
+
+					expect(store.getState().position.fitLayerRequest.payload.id).toContain('some1_');
+				});
+
+				it('does nothing when parameter values is not an integer', async () => {
+					const queryParam = new URLSearchParams(`${QueryParameters.LAYER}=some0,some1&${QueryParameters.ZOOM_TO_EXTENT}=foo`);
+					const store = setup({
+						position: initialPositionState
+					});
+					const instanceUnderTest = new LayersPlugin();
+					spyOn(environmentService, 'getQueryParams').and.returnValue(queryParam);
+					spyOn(geoResourceServiceMock, 'byId').and.callFake((id) => {
+						switch (id) {
+							case 'some0':
+								return new XyzGeoResource('some0', 'someLabel0', 'someUrl0');
+							case 'some1':
+								return new XyzGeoResource('some1', 'someLabel1', 'someUrl1');
+						}
+					});
+
+					expect(store.getState().position.fitLayerRequest.payload).toBeNull();
+
+					instanceUnderTest._addLayersFromQueryParams(new URLSearchParams(queryParam));
+
+					await TestUtils.timeout();
+
+					expect(store.getState().position.fitLayerRequest.payload).toBeNull();
+				});
 			});
 		});
 	});

--- a/test/plugins/LayersPlugin.test.js
+++ b/test/plugins/LayersPlugin.test.js
@@ -364,7 +364,7 @@ describe('LayersPlugin', () => {
 			});
 
 			describe('handle query parameter ZOOM_TO_EXTENT', () => {
-				it('calls #fitLayer() for the correct layer', async () => {
+				it('calls action fitLayer() for the correct layer', async () => {
 					const queryParam = new URLSearchParams(`${QueryParameters.LAYER}=some0,some1&${QueryParameters.ZOOM_TO_EXTENT}=1`);
 					const store = setup({
 						position: initialPositionState
@@ -389,7 +389,7 @@ describe('LayersPlugin', () => {
 					expect(store.getState().position.fitLayerRequest.payload.id).toContain('some1_');
 				});
 
-				it('does nothing when parameter values is not an integer', async () => {
+				it('does nothing when parameter value is not an integer', async () => {
 					const queryParam = new URLSearchParams(`${QueryParameters.LAYER}=some0,some1&${QueryParameters.ZOOM_TO_EXTENT}=foo`);
 					const store = setup({
 						position: initialPositionState


### PR DESCRIPTION
This PR restores a currently missing functionality. In v3 we have the query parameter `kmlZoomToExtent` to realize a fit of the map on the extent of one layer.
Now in v4, the parameter `zte` references the index of the layer which should be used for fitting.

Example URL (for review):

http://localhost:8080/?c=-13.45104,46.96160&z=5&l=atkis,https%3A%2F%2Fgeodaten.bayern.de%2Fodd%2Fm%2F3%2Fdaten%2Ffreizeit%2Fkml%2Frodelbahnen.kml&t=ba&zte=1
