### PR TITLE
KML: update icon-replace behavior

### DIFF
--- a/src/modules/olMap/formats/kml.js
+++ b/src/modules/olMap/formats/kml.js
@@ -23,6 +23,9 @@ const replaceIcon = (old) => {
 	const svgScale = old.getScale();
 	const { IconService: iconService } = $injector.inject('IconService');
 	const iconResult = iconService.getIconResult(svgSrc);
+
+	// A nullish IconResult/IconUrl leads to a invalid KML (according to the specification).
+	// Nevertheless some applications/frameworks can handle such a kml (icons with base64 image sources).
 	const iconUrl = iconResult?.getUrl(old.getColor());
 
 	const iconOptions = {

--- a/src/modules/olMap/formats/kml.js
+++ b/src/modules/olMap/formats/kml.js
@@ -23,7 +23,7 @@ const replaceIcon = (old) => {
 	const svgScale = old.getScale();
 	const { IconService: iconService } = $injector.inject('IconService');
 	const iconResult = iconService.getIconResult(svgSrc);
-	const iconUrl = iconResult.getUrl(old.getColor());
+	const iconUrl = iconResult?.getUrl(old.getColor());
 
 	const iconOptions = {
 		anchor: [0.5, 1],

--- a/test/modules/olMap/formats/kml.test.js
+++ b/test/modules/olMap/formats/kml.test.js
@@ -282,6 +282,27 @@ describe('kml', () => {
 				expect(containsRemoteIcon).toBeFalse();
 			});
 		});
+
+		describe('when iconService fails to resolve iconResult ', () => {
+			it('should use the old svg icon style-properties ', () => {
+				const color = [255, 42, 42];
+				const iconSrc =
+					'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgZmlsbD0icmdiKDI1NSwyNTUsMjU1KSIgY2xhc3M9ImJpIGJpLWdlby1hbHQtZmlsbCIgdmlld0JveD0iMCAwIDE2IDE2Ij48IS0tIE1JVCBMaWNlbnNlIC0tPjxwYXRoIGQ9Ik04IDE2czYtNS42ODYgNi0xMEE2IDYgMCAwIDAgMiA2YzAgNC4zMTQgNiAxMCA2IDEwem0wLTdhMyAzIDAgMSAxIDAtNiAzIDMgMCAwIDEgMCA2eiIvPjwvc3ZnPg==';
+				const expectedKmlIcon = `<Icon><href>${iconSrc}</href></Icon>`;
+				const expectedUrl = `backend.url/icon/${color}/${iconSrc.substr(iconSrc.length - 5)}`;
+				aPointFeature.setStyle(getAIconStyleFunction(color, iconSrc));
+				spyOn(iconServiceMock, 'getIconResult').and.callFake(() => null);
+				const features = [aPointFeature];
+				const layer = createLayerMock(features);
+				const actual = create(layer, projection);
+				const containsIconStyle = actual.includes('<IconStyle>');
+				const containsBase64Icon = actual.includes(expectedKmlIcon);
+				const containsRemoteIcon = actual.includes(`<Icon><href>${expectedUrl}</href></Icon>`);
+				expect(containsIconStyle).toBeTrue();
+				expect(containsBase64Icon).toBeTrue();
+				expect(containsRemoteIcon).toBeFalse();
+			});
+		});
 	});
 
 	describe('toKmlStyleProperties', () => {


### PR DESCRIPTION
The replacement of an SVG resource is updated to a expected NULL as a result of the IconService request
IconService.getIconResult(idOrUrlOrBase64). The behavior changes to: return the old image to enable the creation of a (local) kml-layer, which cannot be exported.