### PR TITLE
configurable response interceptor

### DIFF
--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -13,13 +13,21 @@ import { Projection } from 'ol/proj';
 import ImageWMS from 'ol/source/ImageWMS.js';
 
 /**
+ * A function that returns a `ol.image.LoadFunction` for loading restricted images via basic access authentication
+ * @typedef {Function} baaImageLoadFunctionProvider
+ * @param {module:domain/credentialDef~Credential} credential The credential for basic access authentication
+ * @param {number[]} maxSize Maximum width and height of the requested image in px
+ * @returns {Function} ol.image.LoadFunction
+ */
+
+/**
  * Converts a GeoResource to a ol layer instance.
  * @class
  * @author taulinger
  */
 export class LayerService {
 	/**
-	 * @param {baaImageLoadFunctionProvider} [baaImageLoadFunctionProvider=getBvvBaaImageLoadFunction]
+	 * @param {module:modules/olMap/services/LayerService~baaImageLoadFunctionProvider} [baaImageLoadFunctionProvider=getBvvBaaImageLoadFunction]
 	 */
 	constructor(baaImageLoadFunctionProvider = getBvvBaaImageLoadFunction) {
 		this._baaImageLoadFunctionProvider = baaImageLoadFunctionProvider;

--- a/src/modules/olMap/utils/baaImageLoadFunction.provider.js
+++ b/src/modules/olMap/utils/baaImageLoadFunction.provider.js
@@ -7,9 +7,8 @@ import { $injector } from '../../../injection';
  * Returns a BVV specific image load function loading restricted images via basic access authentication.
  * The requested maximum width and height of the image is limited to a configurable size (default is 2000x2000).
  * If width and/or height exceed the configured maximum size, the image will be scaled.
- * @param {Credential} credential
- * @param {number[]} maxSize maximum width and height of the requested image in px. Default is 2000*2000.
- * @returns ol.image.LoadFunction
+ * @function
+ * @type {module:modules/olMap/services/LayerService~baaImageLoadFunctionProvider}
  */
 export const getBvvBaaImageLoadFunction = (credential, maxSize = [2000, 2000]) => {
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -139,10 +139,10 @@ export class NetworkStateSyncHttpService extends HttpService {
 	/**
 	 * @see {@link HttpService#fetch}
 	 */
-	async fetch(resource, options = {}, controller = new AbortController()) {
+	async fetch(resource, options = {}, controller = new AbortController(), interceptors = {}) {
 		setFetching(true);
 		try {
-			return await super.fetch(resource, options, controller);
+			return await super.fetch(resource, options, controller, interceptors);
 		} finally {
 			setFetching(false);
 		}

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -4,6 +4,21 @@
 import { setFetching } from '../store/network/network.action';
 
 /**
+ * A function that takes and returns a Fetch API `Response`.
+ * @async
+ * @typedef {Function} responseInterceptor
+ * @param {Response} response Fetch API response
+ * @returns {Promise<Response>} response Fetch API response
+ */
+
+/**
+ * Configuration for a response interceptor. A request interceptor may be available in the future.
+ * @async
+ * @typedef {Object} HttpServiceInterceptors
+ * @property {module:services/HttpService~responseInterceptor} responseInterceptor
+ */
+
+/**
  * @class
  * @author taulinger
  */
@@ -16,14 +31,16 @@ export class HttpService {
 	 * Wraps a Fetch API fetch call, so that a custom timeout can be set. Default is 1000ms.<br>
 	 * If a timeout occurs, the request is cancelled by an <code>AbortController</code>.<br>
 	 * In that case, a promise with an <code>AbortError</code> is returned.<br>
-	 * Additionally, the request can be made cancelable by an custom <code>AbortController</code>.<br>
+	 * Additionally, the request can be made cancelable by an custom <code>AbortController</code><br>
+	 * and can be intercepted by a `HttpServiceInterceptors` configuration.
 	 * @param {String} resource url
-	 * @param {Object} [options] fetch api options, set timeout via timeout property, default is 1000ms
-	 * @param {AbortController} [controller] controller which can be used to cancel the request
-	 * @returns Fetch API Response
+	 * @param {Object} [options={}] fetch api options, set timeout via timeout property, default is 1000ms
+	 * @param {AbortController} [controller=AbortController] controller which can be used to cancel the request
+	 * @param {module:services/HttpService~HttpServiceInterceptors} [interceptors={}] interceptors for this fetch call
+	 * @returns Fetch API response
 	 * @see credits: https://dmitripavlutin.com/timeout-fetch-request/
 	 */
-	async fetch(resource, options = {}, controller = new AbortController()) {
+	async fetch(resource, options = {}, controller = new AbortController(), interceptors = {}) {
 		const { timeout = 1000 } = options;
 
 		const id = setTimeout(() => controller.abort(), timeout);
@@ -34,7 +51,7 @@ export class HttpService {
 		});
 		clearTimeout(id);
 
-		return response;
+		return interceptors.response ? interceptors.response(response) : response;
 	}
 
 	/**
@@ -43,14 +60,15 @@ export class HttpService {
 	 * Mode 'cors' ist set by default.
 	 * @param {string} resource URL
 	 * @param {object} options fetch options
+	 * @param {module:services/HttpService~HttpServiceInterceptors} [interceptors={}] interceptors for this GET call
 	 * @returns Fetch API Response
 	 */
-	async get(resource, options = {}) {
+	async get(resource, options = {}, interceptors = {}) {
 		const fetchOptions = {
 			mode: HttpService.DEFAULT_REQUEST_MODE,
 			...options
 		};
-		return this.fetch(resource, fetchOptions);
+		return this.fetch(resource, fetchOptions, undefined, interceptors);
 	}
 
 	/**
@@ -99,15 +117,16 @@ export class HttpService {
 	 * Mode 'cors' ist set by default.
 	 * @param {string} resource URL
 	 * @param {object} options fetch options
+	 * @param {module:services/HttpService~HttpServiceInterceptors} [interceptors={}] interceptors for this HEAD call
 	 * @returns Fetch API Response
 	 */
-	async head(resource, options = {}) {
+	async head(resource, options = {}, interceptors = {}) {
 		const fetchOptions = {
 			mode: HttpService.DEFAULT_REQUEST_MODE,
 			method: 'HEAD',
 			...options
 		};
-		return this.fetch(resource, fetchOptions);
+		return this.fetch(resource, fetchOptions, undefined, interceptors);
 	}
 }
 

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -8,7 +8,7 @@ import { setFetching } from '../store/network/network.action';
  * @async
  * @typedef {Function} responseInterceptor
  * @param {Response} response Fetch API response
- * @param {function} fetchCall A function which can be used to repeat the original fetch call
+ * @param {function} fetchCall A function which can be used to retry the original fetch call
  * @param {String} resource the URL (resource) of the original fetch call
  * @returns {Promise<Response>} Fetch API response
  */

--- a/test/service/FeedbackService.test.js
+++ b/test/service/FeedbackService.test.js
@@ -28,7 +28,6 @@ describe('Entities', () => {
 });
 
 describe('FeedbackService', () => {
-	// todo - generalFeedbackCategoriesProvider
 	const setup = (
 		mapFeedbackStorageProvider = bvvFeedbackStorageProvider,
 		mapFeedbackCategoriesProvider = bvvMapFeedbackCategoriesProvider,

--- a/test/service/HttpService.test.js
+++ b/test/service/HttpService.test.js
@@ -310,7 +310,6 @@ describe('NetworkStateSyncHttpService', () => {
 		it("calls parent's fetch and updates the store", async () => {
 			const store = setup();
 			const instanceUnderTest = new NetworkStateSyncHttpService();
-
 			spyOn(window, 'fetch').and.callFake(() => {
 				expect(store.getState().network.fetching).toBeTrue();
 				return Promise.resolve({
@@ -319,10 +318,13 @@ describe('NetworkStateSyncHttpService', () => {
 					}
 				});
 			});
+			const parentFetchSpy = spyOn(HttpService.prototype, 'fetch').and.callThrough();
 
 			const result = await instanceUnderTest.fetch('something');
+
 			expect(store.getState().network.fetching).toBeFalse();
 			expect(result.text()).toBe(42);
+			expect(parentFetchSpy).toHaveBeenCalledWith('something', {}, jasmine.any(AbortController), {});
 		});
 
 		it('regards pending responses', async () => {

--- a/test/service/HttpService.test.js
+++ b/test/service/HttpService.test.js
@@ -48,7 +48,7 @@ describe('HttpService', () => {
 			const result = await httpService.fetch('something', undefined, undefined, { response: interceptorSpy });
 
 			expect(spy).toHaveBeenCalled();
-			expect(interceptorSpy).toHaveBeenCalled();
+			expect(interceptorSpy).toHaveBeenCalledWith(jasmine.objectContaining({ text: jasmine.any(Function) }), jasmine.any(Function), 'something');
 			expect(result.text()).toBe(42);
 		});
 

--- a/test/service/HttpService.test.js
+++ b/test/service/HttpService.test.js
@@ -34,6 +34,24 @@ describe('HttpService', () => {
 			expect(result.text()).toBe(42);
 		});
 
+		it('provides a result by calling a response interceptor', async () => {
+			const httpService = new HttpService();
+			const spy = spyOn(window, 'fetch').and.returnValue(
+				Promise.resolve({
+					text: () => {
+						return 42;
+					}
+				})
+			);
+			const interceptorSpy = jasmine.createSpy().and.callFake(async (response) => response);
+
+			const result = await httpService.fetch('something', undefined, undefined, { response: interceptorSpy });
+
+			expect(spy).toHaveBeenCalled();
+			expect(interceptorSpy).toHaveBeenCalled();
+			expect(result.text()).toBe(42);
+		});
+
 		it('provides a result with customized timeout ', async () => {
 			const httpService = new HttpService();
 
@@ -84,7 +102,24 @@ describe('HttpService', () => {
 
 			const result = await httpService.get('something');
 
-			expect(spy).toHaveBeenCalledWith('something', { mode: HttpService.DEFAULT_REQUEST_MODE });
+			expect(spy).toHaveBeenCalledWith('something', { mode: HttpService.DEFAULT_REQUEST_MODE }, undefined, {});
+			expect(result.text()).toBe(42);
+		});
+
+		it('provides a result by calling a response interceptor', async () => {
+			const httpService = new HttpService();
+			const spy = spyOn(httpService, 'fetch').and.returnValue(
+				Promise.resolve({
+					text: () => {
+						return 42;
+					}
+				})
+			);
+			const interceptors = { response: jasmine.createSpy().and.callFake(async (response) => response) };
+
+			const result = await httpService.get('something', {}, interceptors);
+
+			expect(spy).toHaveBeenCalledWith('something', { mode: HttpService.DEFAULT_REQUEST_MODE }, undefined, interceptors);
 			expect(result.text()).toBe(42);
 		});
 
@@ -100,7 +135,7 @@ describe('HttpService', () => {
 
 			const result = await httpService.get('something', { timeout: 2000 });
 
-			expect(spy).toHaveBeenCalledWith('something', { mode: HttpService.DEFAULT_REQUEST_MODE, timeout: 2000 });
+			expect(spy).toHaveBeenCalledWith('something', { mode: HttpService.DEFAULT_REQUEST_MODE, timeout: 2000 }, undefined, {});
 			expect(result.text()).toBe(42);
 		});
 	});
@@ -199,11 +234,33 @@ describe('HttpService', () => {
 
 			const result = await httpService.head('something');
 
-			expect(spy).toHaveBeenCalledWith('something', {
-				method: 'HEAD',
-				mode: HttpService.DEFAULT_REQUEST_MODE
-			});
+			expect(spy).toHaveBeenCalledWith(
+				'something',
+				{
+					method: 'HEAD',
+					mode: HttpService.DEFAULT_REQUEST_MODE
+				},
+				undefined,
+				{}
+			);
 			expect(result.ok).toBeTrue();
+		});
+
+		it('provides a result by calling a response interceptor', async () => {
+			const httpService = new HttpService();
+			const spy = spyOn(httpService, 'fetch').and.returnValue(
+				Promise.resolve({
+					text: () => {
+						return 42;
+					}
+				})
+			);
+			const interceptors = { response: jasmine.createSpy().and.callFake(async (response) => response) };
+
+			const result = await httpService.head('something', {}, interceptors);
+
+			expect(spy).toHaveBeenCalledWith('something', { method: 'HEAD', mode: HttpService.DEFAULT_REQUEST_MODE }, undefined, interceptors);
+			expect(result.text()).toBe(42);
 		});
 
 		it('provides a result with custom options', async () => {
@@ -216,11 +273,16 @@ describe('HttpService', () => {
 
 			const result = await httpService.head('something', { timeout: 2000 });
 
-			expect(spy).toHaveBeenCalledWith('something', {
-				method: 'HEAD',
-				mode: HttpService.DEFAULT_REQUEST_MODE,
-				timeout: 2000
-			});
+			expect(spy).toHaveBeenCalledWith(
+				'something',
+				{
+					method: 'HEAD',
+					mode: HttpService.DEFAULT_REQUEST_MODE,
+					timeout: 2000
+				},
+				undefined,
+				{}
+			);
 			expect(result.ok).toBeTrue();
 		});
 	});

--- a/test/service/provider/mfp.provider.test.js
+++ b/test/service/provider/mfp.provider.test.js
@@ -1,7 +1,7 @@
-import { $injector } from '../../src/injection';
-import { HttpService } from '../../src/services/HttpService';
-import { MediaType } from '../../src/domain/mediaTypes';
-import { getMfpCapabilities, postMfpSpec } from '../../src/services/provider/mfp.provider';
+import { $injector } from '../../../src/injection';
+import { HttpService } from '../../../src/services/HttpService';
+import { MediaType } from '../../../src/domain/mediaTypes';
+import { getMfpCapabilities, postMfpSpec } from '../../../src/services/provider/mfp.provider';
 describe('mfp provider', () => {
 	describe('getMfpCapabilities', () => {
 		const configService = {


### PR DESCRIPTION
Extend the `HttpService` for registering a response interceptor.
A request interceptor may be supported in the future.