### PR TITLE
finetune authentication

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Install dependencies
         run: |

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -329,9 +329,9 @@ export class GeoResource {
 /**
  * An async function that loads a {@link GeoResource}.
  * @async
- * @callback asyncGeoResourceLoader
+ * @typedef {Function} asyncGeoResourceLoader
  * @param {string} id Id of the requested GeoResource
- * @returns {GeoResource}
+ * @returns {GeoResource} the loaded GeoResource
  */
 
 /**

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -3,7 +3,7 @@
  */
 import { $injector } from '../injection';
 import { getDefaultAttribution } from '../services/provider/attribution.provider';
-import { defaultVectorGeoResourceLoaderForUrl } from '../services/provider/geoResource.provider';
+import { getDefaultVectorGeoResourceLoaderForUrl } from '../services/provider/geoResource.provider';
 import { isExternalGeoResourceId } from '../utils/checks';
 
 /**
@@ -332,6 +332,7 @@ export class GeoResource {
  * @typedef {Function} asyncGeoResourceLoader
  * @param {string} id Id of the requested GeoResource
  * @returns {GeoResource} the loaded GeoResource
+ * @throws when resource cannot be loaded
  */
 
 /**
@@ -593,7 +594,7 @@ export class VectorGeoResource extends GeoResource {
 	 * @returns {GeoResourceFuture}
 	 */
 	static forUrl(id, url, sourceType, label = null) {
-		return new GeoResourceFuture(id, defaultVectorGeoResourceLoaderForUrl(url, sourceType, id, label))
+		return new GeoResourceFuture(id, getDefaultVectorGeoResourceLoaderForUrl(url, sourceType, id, label))
 			.setLabel(label)
 			.onResolve((resolved, future) => {
 				resolved.copyPropertiesFrom(future);

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -332,7 +332,7 @@ export class GeoResource {
  * @typedef {Function} asyncGeoResourceLoader
  * @param {string} id Id of the requested GeoResource
  * @returns {GeoResource} the loaded GeoResource
- * @throws when resource cannot be loaded
+ * @throws {UnavailableGeoResourceError}
  */
 
 /**
@@ -384,6 +384,7 @@ export class GeoResourceFuture extends GeoResource {
 	 *
 	 * Note: It's up to the loader implementation which properties of the GeoResourceFuture instance are copied to the resolved GeoResource.
 	 * @returns GeoResource
+	 * @throws {UnavailableGeoResourceError} Error of the underlying loader
 	 */
 	async get() {
 		try {

--- a/src/i18n/global.provider.js
+++ b/src/i18n/global.provider.js
@@ -20,8 +20,7 @@ export const provide = (lang) => {
 				global_marker_symbol_label: 'Marker',
 				global_featureInfo_not_available: 'FeatureInfo is not available',
 				global_routingService_init_exception: 'Routing currently not available',
-				global_geoResource_not_available: (params) =>
-					`Failed to add a layer for the GeoResource with ID "${params[0]}"${params[1] ? ` (${params[1]})` : ``}`,
+				global_geoResource_not_available: (params) => `Failed to add a layer for the GeoResource "${params[0]}"${params[1] ? ` (${params[1]})` : ``}`,
 				global_geoResource_unauthorized: '401 - Unauthorized',
 				global_geoResource_forbidden: '403 - Forbidden'
 			};
@@ -47,7 +46,7 @@ export const provide = (lang) => {
 				global_featureInfo_not_available: 'FeatureInfo ist nicht verfügbar',
 				global_routingService_init_exception: 'Die Routing-Funktion steht derzeit leider nicht zur Verfügung',
 				global_geoResource_not_available: (params) =>
-					`Es konnte keine Ebene für die GeoRessource mit der ID "${params[0]}" geladen werden${params[1] ? ` (${params[1]})` : ``}`,
+					`Es konnte keine Ebene für die GeoRessource "${params[0]}" geladen werden${params[1] ? ` (${params[1]})` : ``}`,
 				global_geoResource_unauthorized: '401 - Fehlende Berechtigung',
 				global_geoResource_forbidden: '403 - Zugriff nicht erlaubt'
 			};

--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -3,7 +3,7 @@ import { StoreService } from '../services/StoreService';
 import { OlCoordinateService } from '../services/OlCoordinateService';
 import { EnvironmentService } from '../services/EnvironmentService';
 import { ProcessEnvConfigService } from '../services/ProcessEnvConfigService';
-import { AuthInvalidatingAfter401HttpService } from '../services/HttpService';
+import { BvvHttpService } from '../services/HttpService';
 import { TranslationService } from '../services/TranslationService';
 import { ShareService } from '../services/ShareService';
 import { UnitsService } from '../services/UnitsService';
@@ -65,7 +65,7 @@ $injector
 	.registerSingleton('ProjectionService', new Proj4JsService())
 	.registerSingleton('AuthService', new AuthService())
 	.registerSingleton('ConfigService', new ProcessEnvConfigService())
-	.register('HttpService', AuthInvalidatingAfter401HttpService)
+	.register('HttpService', BvvHttpService)
 	.register('EnvironmentService', EnvironmentService)
 	.registerSingleton('TranslationService', new TranslationService())
 	.register('CoordinateService', OlCoordinateService)

--- a/src/modules/olMap/components/OlMap.js
+++ b/src/modules/olMap/components/OlMap.js
@@ -361,12 +361,6 @@ export class OlMap extends MvuElement {
 						updateOlLayer(realOlLayer, layer);
 						this._map.getLayers().remove(getLayerById(this._map, id));
 						this._map.getLayers().insertAt(layer.zIndex, realOlLayer);
-					})
-					// eslint-disable-next-line promise/prefer-await-to-then
-					.catch((error) => {
-						console.warn(error);
-						emitNotification(`${translate('global_geoResource_not_available', [geoResource.id])}`, LevelTypes.WARN);
-						removeLayer(id);
 					});
 			}
 			toOlLayer(id, geoResource);

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -6,7 +6,7 @@ import { GeoResourceAuthenticationType, GeoResourceTypes } from '../../../domain
 import { Image as ImageLayer, Group as LayerGroup, Layer } from 'ol/layer';
 import TileLayer from 'ol/layer/Tile';
 import { XYZ as XYZSource } from 'ol/source';
-import { getBvvBaaImageLoadFunction } from '../utils/baaImageLoadFunction.provider';
+import { getBvvBaaImageLoadFunction } from '../utils/olLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
 import { AdvWmtsTileGrid } from '../ol/tileGrid/AdvWmtsTileGrid';
 import { Projection } from 'ol/proj';

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -155,7 +155,7 @@ export class LayerService {
 				const layerGroup = new LayerGroup({
 					id: id,
 					opacity: opacity,
-					layers: geoResource.geoResourceIds.map((id) => this.toOlLayer(id, geoResourceService.byId(id))),
+					layers: geoResource.geoResourceIds.map((id) => this.toOlLayer(id, geoResourceService.byId(id), olMap)),
 					minZoom: minZoom ?? undefined,
 					maxZoom: maxZoom ?? undefined
 				});

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -22,6 +22,13 @@ import ImageWMS from 'ol/source/ImageWMS.js';
  */
 
 /**
+ * A function that returns a `ol.tile.LoadFunction`.
+ * @typedef {Function} tileLoadFunctionProvider
+ * @param {string} geoResourceId The id of the corresponding GeoResource
+ * @returns {Function} ol.tile.LoadFunction
+ */
+
+/**
  * Converts a GeoResource to a ol layer instance.
  * @class
  * @author taulinger
@@ -30,8 +37,9 @@ export class LayerService {
 	/**
 	 * @param {module:modules/olMap/services/LayerService~imageLoadFunctionProvider} [imageLoadFunctionProvider=getBvvBaaImageLoadFunction]
 	 */
-	constructor(imageLoadFunctionProvider = getBvvBaaImageLoadFunction) {
+	constructor(imageLoadFunctionProvider = getBvvBaaImageLoadFunction, tileLoadFunctionProvider = getBvvTileLoadFunction) {
 		this._imageLoadFunctionProvider = imageLoadFunctionProvider;
+		this._tileLoadFunctionProvider = tileLoadFunctionProvider;
 	}
 
 	/**
@@ -43,7 +51,7 @@ export class LayerService {
 	 */
 	toOlLayer(id, geoResource, olMap) {
 		const {
-			GeoResourceService: georesourceService,
+			GeoResourceService: geoResourceService,
 			VectorLayerService: vectorLayerService,
 			BaaCredentialService: baaCredentialService
 		} = $injector.inject('GeoResourceService', 'VectorLayerService', 'BaaCredentialService');
@@ -98,7 +106,8 @@ export class LayerService {
 				const xyzSource = () => {
 					const config = {
 						url: Array.isArray(geoResource.urls) ? undefined : geoResource.urls,
-						urls: Array.isArray(geoResource.urls) ? geoResource.urls : undefined
+						urls: Array.isArray(geoResource.urls) ? geoResource.urls : undefined,
+						tileLoadFunction: this._tileLoadFunctionProvider(geoResource.id)
 					};
 					switch (geoResource.tileGridId) {
 						case 'adv_wmts':
@@ -146,7 +155,7 @@ export class LayerService {
 				const layerGroup = new LayerGroup({
 					id: id,
 					opacity: opacity,
-					layers: geoResource.geoResourceIds.map((id) => this.toOlLayer(id, georesourceService.byId(id))),
+					layers: geoResource.geoResourceIds.map((id) => this.toOlLayer(id, geoResourceService.byId(id))),
 					minZoom: minZoom ?? undefined,
 					maxZoom: maxZoom ?? undefined
 				});

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -6,7 +6,7 @@ import { GeoResourceAuthenticationType, GeoResourceTypes } from '../../../domain
 import { Image as ImageLayer, Group as LayerGroup, Layer } from 'ol/layer';
 import TileLayer from 'ol/layer/Tile';
 import { XYZ as XYZSource } from 'ol/source';
-import { getBvvBaaImageLoadFunction } from '../utils/olLoadFunction.provider';
+import { getBvvBaaImageLoadFunction, getBvvTileLoadFunction } from '../utils/olLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
 import { AdvWmtsTileGrid } from '../ol/tileGrid/AdvWmtsTileGrid';
 import { Projection } from 'ol/proj';
@@ -14,7 +14,7 @@ import ImageWMS from 'ol/source/ImageWMS.js';
 
 /**
  * A function that returns a `ol.image.LoadFunction` for loading also restricted images via basic access authentication
- * @typedef {Function} baaImageLoadFunctionProvider
+ * @typedef {Function} imageLoadFunctionProvider
  * @param {string} geoResourceId The id of the corresponding GeoResource
  * @param {module:domain/credentialDef~Credential} [credential] The credential for basic access authentication (when BAA is requested)
  * @param {number[]} [maxSize] Maximum width and height of the requested image in px
@@ -28,10 +28,10 @@ import ImageWMS from 'ol/source/ImageWMS.js';
  */
 export class LayerService {
 	/**
-	 * @param {module:modules/olMap/services/LayerService~baaImageLoadFunctionProvider} [baaImageLoadFunctionProvider=getBvvBaaImageLoadFunction]
+	 * @param {module:modules/olMap/services/LayerService~imageLoadFunctionProvider} [imageLoadFunctionProvider=getBvvBaaImageLoadFunction]
 	 */
-	constructor(baaImageLoadFunctionProvider = getBvvBaaImageLoadFunction) {
-		this._baaImageLoadFunctionProvider = baaImageLoadFunctionProvider;
+	constructor(imageLoadFunctionProvider = getBvvBaaImageLoadFunction) {
+		this._imageLoadFunctionProvider = imageLoadFunctionProvider;
 	}
 
 	/**
@@ -75,11 +75,11 @@ export class LayerService {
 						if (!credential) {
 							throw new Error(`No credential available for GeoResource with id '${geoResource.id}' and url '${geoResource.url}'`);
 						}
-						imageWmsSource.setImageLoadFunction(this._baaImageLoadFunctionProvider(geoResource.id, credential));
+						imageWmsSource.setImageLoadFunction(this._imageLoadFunctionProvider(geoResource.id, credential));
 						break;
 					}
 					default: {
-						imageWmsSource.setImageLoadFunction(this._baaImageLoadFunctionProvider(geoResource.id));
+						imageWmsSource.setImageLoadFunction(this._imageLoadFunctionProvider(geoResource.id));
 					}
 				}
 

--- a/src/modules/olMap/utils/baaImageLoadFunction.provider.js
+++ b/src/modules/olMap/utils/baaImageLoadFunction.provider.js
@@ -5,7 +5,8 @@ import { $injector } from '../../../injection';
 import { LevelTypes, emitNotification } from '../../../store/notifications/notifications.action';
 
 /**
- * Returns a BVV specific image load function loading restricted images via basic access authentication.
+ * Returns a BVV specific image load function loading either unrestricted images, restricted images via basic access authentication or application restricted images (via backend).
+ * <br>
  * The requested maximum width and height of the image is limited to a configurable size (default is 2000x2000).
  * If width and/or height exceed the configured maximum size, the image will be scaled.
  * @function

--- a/src/modules/olMap/utils/olLoadFunction.provider.js
+++ b/src/modules/olMap/utils/olLoadFunction.provider.js
@@ -138,11 +138,15 @@ export const getBvvTileLoadFunction = (geoResourceId) => {
 					},
 					{ response: [geoResourceService.getAuthResponseInterceptorForGeoResource(geoResourceId)] }
 				);
-
-				if (response.status !== 200) {
-					handleUnexpectedStatusCodeThrottled(response, geoResourceId);
+				switch (response.status) {
+					case 200:
+						return URL.createObjectURL(await response.blob());
+					case 400 /** expected status code when zoom-level is not supported > client-side zooming*/:
+						tile.setState(TileState.ERROR);
+						break;
+					default:
+						handleUnexpectedStatusCodeThrottled(response, geoResourceId);
 				}
-				return URL.createObjectURL(await response.blob());
 			} catch (error) {
 				tile.setState(TileState.ERROR);
 				console.error('Tile could not be fetched', error);

--- a/src/modules/olMap/utils/olLoadFunction.provider.js
+++ b/src/modules/olMap/utils/olLoadFunction.provider.js
@@ -119,6 +119,11 @@ export const getBvvBaaImageLoadFunction = (geoResourceId, credential = null, max
 	};
 };
 
+/**
+ * BVV specific implementation of {@link module:modules/olMap/services/LayerService~tileLoadFunctionProvider}.
+ * @function
+ * @type {module:modules/olMap/services/LayerService~tileLoadFunctionProvider}
+ */
 export const getBvvTileLoadFunction = (geoResourceId) => {
 	const { HttpService: httpService, GeoResourceService: geoResourceService } = $injector.inject('HttpService', 'GeoResourceService');
 

--- a/src/modules/olMap/utils/olLoadFunction.provider.js
+++ b/src/modules/olMap/utils/olLoadFunction.provider.js
@@ -39,7 +39,7 @@ const handleUnexpectedStatusCodeThrottled = throttled(3000, (response, geoResour
  * The requested maximum width and height of the image is limited to a configurable size (default is 2000x2000).
  * If width and/or height exceed the configured maximum size, the image will be scaled.
  * @function
- * @type {module:modules/olMap/services/LayerService~baaImageLoadFunctionProvider}
+ * @type {module:modules/olMap/services/LayerService~imageLoadFunctionProvider}
  */
 export const getBvvBaaImageLoadFunction = (geoResourceId, credential = null, maxSize = [2000, 2000]) => {
 	const {

--- a/src/modules/olMap/utils/olLoadFunction.provider.js
+++ b/src/modules/olMap/utils/olLoadFunction.provider.js
@@ -1,5 +1,5 @@
 /**
- * @module modules/olMap/utils/baaImageLoadFunction_provider
+ * @module modules/olMap/utils/olLoadFunction_provider
  */
 import { $injector } from '../../../injection';
 import { LevelTypes, emitNotification } from '../../../store/notifications/notifications.action';

--- a/src/plugins/GlobalErrorPlugin.js
+++ b/src/plugins/GlobalErrorPlugin.js
@@ -17,26 +17,30 @@ export class GlobalErrorPlugin extends BaPlugin {
 	 * @override
 	 */
 	async register() {
-		const { TranslationService: translationService } = $injector.inject('TranslationService');
+		const { TranslationService: translationService, GeoResourceService: geoResourceService } = $injector.inject(
+			'TranslationService',
+			'GeoResourceService'
+		);
 		const translate = (key, params = []) => translationService.translate(key, params);
 
 		const handleError = (error) => {
 			if (error instanceof UnavailableGeoResourceError) {
+				const geoResourceName = geoResourceService.byId(error.geoResourceId)?.label ?? error.geoResourceId;
 				switch (error.httpStatus) {
 					case 401:
 						emitNotification(
-							`${translate('global_geoResource_not_available', [error.geoResourceId, translate('global_geoResource_unauthorized')])}`,
+							`${translate('global_geoResource_not_available', [geoResourceName, translate('global_geoResource_unauthorized')])}`,
 							LevelTypes.WARN
 						);
 						break;
 					case 403:
 						emitNotification(
-							`${translate('global_geoResource_not_available', [error.geoResourceId, translate('global_geoResource_forbidden')])}`,
+							`${translate('global_geoResource_not_available', [geoResourceName, translate('global_geoResource_forbidden')])}`,
 							LevelTypes.WARN
 						);
 						break;
 					default:
-						emitNotification(`${translate('global_geoResource_not_available', [error.geoResourceId])}`, LevelTypes.WARN);
+						emitNotification(`${translate('global_geoResource_not_available', [geoResourceName])}`, LevelTypes.WARN);
 						break;
 				}
 			} else {

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -19,7 +19,8 @@
  * A function that returns an response interceptor for authentication tasks
  * @async
  * @typedef {Function} authResponseInterceptorProvider
- * @param {string[]} [roles] One or more roles the interceptor should show an auth UI for
+ * @param {string[]} roles One or more roles the interceptor should show an auth UI for
+ * @param {string} [identifier] Possible identifier to give the interceptor the chance to detect requests for the same resource
  * @returns {module:services/HttpService~responseInterceptor} the response interceptor
  */
 

--- a/src/services/GeoResourceService.js
+++ b/src/services/GeoResourceService.js
@@ -182,7 +182,7 @@ export class GeoResourceService {
 	 */
 	getAuthResponseInterceptorForGeoResource(geoResourceId) {
 		const roles = this.byId(geoResourceId)?.authRoles ?? [];
-		return this._authResponseInterceptorProvider(roles);
+		return this._authResponseInterceptorProvider(roles, geoResourceId);
 	}
 
 	_newFallbackGeoResources() {

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -32,13 +32,6 @@ export class HttpService {
 		return 'cors';
 	}
 
-	#configService;
-
-	constructor() {
-		const { ConfigService: configService } = $injector.inject('ConfigService');
-		this.#configService = configService;
-	}
-
 	/**
 	 * Wraps a Fetch API fetch call, so that a custom timeout can be set. Default is 1000ms.<br>
 	 * If a timeout occurs, the request is cancelled by an <code>AbortController</code>.<br>
@@ -59,7 +52,6 @@ export class HttpService {
 			const id = setTimeout(() => controller.abort(), timeout);
 
 			const response = await fetch(resource, {
-				credentials: this.#configService.getValue('FETCH_API_CREDENTIALS', 'same-origin' /** Fetch API default value */),
 				...options,
 				signal: controller.signal
 			});

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -221,15 +221,21 @@ export class AuthInvalidatingAfter401HttpService extends NetworkStateSyncHttpSer
  */
 export class BvvHttpService extends AuthInvalidatingAfter401HttpService {
 	#configService;
+	#environmentService;
 	constructor() {
 		super();
-		const { ConfigService: configService } = $injector.inject('ConfigService');
+		const { ConfigService: configService, EnvironmentService: environmentService } = $injector.inject('ConfigService', 'EnvironmentService');
 		this.#configService = configService;
+		this.#environmentService = environmentService;
 	}
 	/**
 	 * @see {@link HttpService#fetch}
 	 */
 	async fetch(resource, options = {}, controller = new AbortController(), interceptors = defaultInterceptors) {
+		if (this.#environmentService.isStandalone()) {
+			return super.fetch(resource, options, controller, interceptors);
+		}
+
 		const fetchOptions = resource.trim().startsWith(this.#configService.getValueAsPath('BACKEND_URL'))
 			? { credentials: 'include', ...options }
 			: { ...options };

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -221,7 +221,6 @@ export class BvvHttpService extends AuthInvalidatingAfter401HttpService {
 	 * @see {@link HttpService#fetch}
 	 */
 	async fetch(resource, options = {}, controller = new AbortController(), interceptors = defaultInterceptors) {
-		// return await super.fetch(resource, options, controller, interceptors);
 		return super.fetch(resource, { credentials: 'include', ...options }, controller, interceptors);
 	}
 }

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -197,8 +197,8 @@ export class AuthInvalidatingAfter401HttpService extends NetworkStateSyncHttpSer
 		const invalidateAfter401Interceptor = async (originalResponse) => {
 			if (
 				originalResponse.status === 401 &&
-				resource.startsWith(this.#configService.getValueAsPath('BACKEND_URL')) &&
-				!this._ignorePathProvider().find((path) => resource.includes(path))
+				resource.trim().startsWith(this.#configService.getValueAsPath('BACKEND_URL')) &&
+				!this._ignorePathProvider().find((path) => resource.trim().includes(path))
 			) {
 				this.#authService.invalidate();
 			}
@@ -230,7 +230,7 @@ export class BvvHttpService extends AuthInvalidatingAfter401HttpService {
 	 * @see {@link HttpService#fetch}
 	 */
 	async fetch(resource, options = {}, controller = new AbortController(), interceptors = defaultInterceptors) {
-		const fetchOptions = resource.startsWith(this.#configService.getValueAsPath('BACKEND_URL'))
+		const fetchOptions = resource.trim().startsWith(this.#configService.getValueAsPath('BACKEND_URL'))
 			? { credentials: 'include', ...options }
 			: { ...options };
 		return super.fetch(resource, fetchOptions, controller, interceptors);

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -150,6 +150,7 @@ export class HttpService {
 /**
  * {@link HttpService} that updates the 'fetching' property of the network state.
  * @class
+ * @extends HttpService
  * @author taulinger
  */
 export class NetworkStateSyncHttpService extends HttpService {
@@ -175,8 +176,10 @@ export class NetworkStateSyncHttpService extends HttpService {
 /**
  * {@link HttpService} that invalidates the current authentication when a status code 401 occurs.
  * @class
+ * @extends NetworkStateSyncHttpService
  * @author taulinger
- */ export class AuthInvalidatingAfter401HttpService extends NetworkStateSyncHttpService {
+ */
+export class AuthInvalidatingAfter401HttpService extends NetworkStateSyncHttpService {
 	#authService;
 	#configService;
 
@@ -203,5 +206,22 @@ export class NetworkStateSyncHttpService extends HttpService {
 		};
 
 		return super.fetch(resource, options, controller, { response: [invalidateAfter401Interceptor, ...interceptors.response] });
+	}
+}
+
+/**
+ * BVV specific {@link HttpService} that set the Fetch API `credentials` option to `include`.
+ * Reason: Frontend and Backend may run on different origins
+ * @class
+ * @extends AuthInvalidatingAfter401HttpService
+ * @author taulinger
+ */
+export class BvvHttpService extends AuthInvalidatingAfter401HttpService {
+	/**
+	 * @see {@link HttpService#fetch}
+	 */
+	async fetch(resource, options = {}, controller = new AbortController(), interceptors = defaultInterceptors) {
+		// return await super.fetch(resource, options, controller, interceptors);
+		return super.fetch(resource, { credentials: 'include', ...options }, controller, interceptors);
 	}
 }

--- a/src/services/HttpService.js
+++ b/src/services/HttpService.js
@@ -210,17 +210,29 @@ export class AuthInvalidatingAfter401HttpService extends NetworkStateSyncHttpSer
 }
 
 /**
- * BVV specific {@link HttpService} that set the Fetch API `credentials` option to `include`.
- * Reason: Frontend and Backend may run on different origins
+ * BVV specific {@link HttpService} that sets the Fetch API `credentials` option to `include` when a backend resource is called
+ * cause Frontend and Backend may run on different origins.
+ * Otherwise the `credentials` option stays untouched.
+ * A given `credentials` option won't be overridden.
+ *
  * @class
  * @extends AuthInvalidatingAfter401HttpService
  * @author taulinger
  */
 export class BvvHttpService extends AuthInvalidatingAfter401HttpService {
+	#configService;
+	constructor() {
+		super();
+		const { ConfigService: configService } = $injector.inject('ConfigService');
+		this.#configService = configService;
+	}
 	/**
 	 * @see {@link HttpService#fetch}
 	 */
 	async fetch(resource, options = {}, controller = new AbortController(), interceptors = defaultInterceptors) {
-		return super.fetch(resource, { credentials: 'include', ...options }, controller, interceptors);
+		const fetchOptions = resource.startsWith(this.#configService.getValueAsPath('BACKEND_URL'))
+			? { credentials: 'include', ...options }
+			: { ...options };
+		return super.fetch(resource, fetchOptions, controller, interceptors);
 	}
 }

--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -9,6 +9,7 @@ import {
 	getAttributionForLocallyImportedOrCreatedGeoResource,
 	getAttributionProviderForGeoResourceImportedByUrl
 } from './provider/attribution.provider';
+import { UnavailableGeoResourceError } from '../domain/errors';
 
 /**
  *
@@ -83,9 +84,9 @@ export class ImportVectorDataService {
 						.setAttributionProvider(getAttributionProviderForGeoResourceImportedByUrl(url));
 					return vgr;
 				}
-				throw new Error(`GeoResource for '${url}' could not be loaded: SourceType could not be detected`);
+				throw new UnavailableGeoResourceError(`GeoResource for '${url}' could not be loaded: SourceType could not be detected`, id);
 			}
-			throw new Error(`GeoResource for '${url}' could not be loaded: Http-Status ${result.status}`);
+			throw new UnavailableGeoResourceError(`GeoResource for '${url}' could not be loaded`, id, result.status);
 		};
 
 		const geoResource = new GeoResourceFuture(id, loader);

--- a/src/services/ProcessEnvConfigService.js
+++ b/src/services/ProcessEnvConfigService.js
@@ -29,8 +29,6 @@ export class ProcessEnvConfigService {
 		);
 		// eslint-disable-next-line no-undef
 		this._properties.set('SHORTENING_SERVICE_URL', window?.ba_externalConfigProperties?.SHORTENING_SERVICE_URL ?? process.env.SHORTENING_SERVICE_URL);
-		// primarily used for development, so not included in ba_externalConfigProperties
-		this._properties.set('FETCH_API_CREDENTIALS', process.env.FETCH_API_CREDENTIALS);
 
 		this._properties.forEach((value, key) => {
 			if (value === undefined) {

--- a/src/services/ProcessEnvConfigService.js
+++ b/src/services/ProcessEnvConfigService.js
@@ -29,7 +29,7 @@ export class ProcessEnvConfigService {
 		);
 		// eslint-disable-next-line no-undef
 		this._properties.set('SHORTENING_SERVICE_URL', window?.ba_externalConfigProperties?.SHORTENING_SERVICE_URL ?? process.env.SHORTENING_SERVICE_URL);
-		// primarily needed for local development, so not included in ba_externalConfigProperties
+		// primarily used for development, so not included in ba_externalConfigProperties
 		this._properties.set('FETCH_API_CREDENTIALS', process.env.FETCH_API_CREDENTIALS);
 
 		this._properties.forEach((value, key) => {

--- a/src/services/provider/auth.provider.js
+++ b/src/services/provider/auth.provider.js
@@ -69,8 +69,8 @@ export const BvvCredentialPanelIntervalMs = 10_000;
  */
 export const bvvAuthResponseInterceptorProvider = (roles = [], identifier = null, credentialPanelInterval = BvvCredentialPanelIntervalMs) => {
 	const bvvAuthResponseInterceptor = async (response, doFetch) => {
-		// in that case we open the credential ui as modal window
 		switch (response.status) {
+			// in that case we open the credential ui as modal window
 			case 401: {
 				const handler401 = () => {
 					return new Promise((resolve) => {

--- a/src/services/provider/auth.provider.js
+++ b/src/services/provider/auth.provider.js
@@ -137,7 +137,7 @@ export const bvvAuthResponseInterceptorProvider = (roles = []) => {
 };
 
 /**
- * Bvv specific implementation of {@link module:services/HttpService~httpServiceIgnore401PathProvidern}.
+ * Bvv specific implementation of {@link module:services/HttpService~httpServiceIgnore401PathProvider}.
  * @function
  * @type {module:services/HttpService~httpServiceIgnore401PathProvider}
  */

--- a/src/services/provider/fileStorage.provider.js
+++ b/src/services/provider/fileStorage.provider.js
@@ -5,6 +5,7 @@ import { $injector } from '../../injection';
 import { GeoResourceFuture, VectorGeoResource, VectorSourceType } from '../../domain/geoResources';
 import { FileStorageServiceDataTypes } from '../FileStorageService';
 import { getAttributionForLocallyImportedOrCreatedGeoResource } from './attribution.provider';
+import { UnavailableGeoResourceError } from '../../domain/errors';
 
 export const _newLoader = (id) => {
 	return async () => {
@@ -20,9 +21,12 @@ export const _newLoader = (id) => {
 					.setAttributionProvider(getAttributionForLocallyImportedOrCreatedGeoResource);
 				return vgr;
 			}
-			throw new Error(`Unsupported FileStorageServiceDataType '${type}'`);
+			throw new UnavailableGeoResourceError(`Unsupported FileStorageServiceDataType '${type}'`, id);
 		} catch (e) {
-			throw new Error(`Could not load vector data for id '${id}'`, { cause: e });
+			if (e instanceof UnavailableGeoResourceError) {
+				throw e;
+			}
+			throw new UnavailableGeoResourceError(`Could not load vector data for id '${id}'`, id, null, { cause: e });
 		}
 	};
 };

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -1,6 +1,7 @@
 /**
  * @module services/provider/geoResource_provider
  */
+import { UnavailableGeoResourceError } from '../../domain/errors';
 import { AggregateGeoResource, VectorGeoResource, WmsGeoResource, XyzGeoResource, GeoResourceFuture, VTGeoResource } from '../../domain/geoResources';
 import { SourceTypeName, SourceTypeResultStatus } from '../../domain/sourceType';
 import { $injector } from '../../injection';
@@ -119,7 +120,7 @@ export const loadBvvGeoResourceById = (id) => {
 				return geoResource;
 			}
 		}
-		throw new Error(`GeoResource for id '${id}' could not be loaded`);
+		throw new UnavailableGeoResourceError(`GeoResource for id '${id}' could not be loaded`, id, result.status);
 	};
 
 	return new GeoResourceFuture(id, loader);
@@ -185,8 +186,9 @@ export const loadExternalGeoResource = (urlBasedAsId) => {
 				};
 				return getGeoResource(sourceType);
 			}
-			throw new Error(
-				`SourceTypeService returns status=${Object.keys(SourceTypeResultStatus).find((key) => SourceTypeResultStatus[key] === status)} for ${url}`
+			throw new UnavailableGeoResourceError(
+				`SourceTypeService returns status=${Object.keys(SourceTypeResultStatus).find((key) => SourceTypeResultStatus[key] === status)} for ${url}`,
+				urlBasedAsId
 			);
 		};
 		return new GeoResourceFuture(urlBasedAsId, loader);
@@ -213,7 +215,7 @@ export const getDefaultVectorGeoResourceLoaderForUrl = (url, sourceType, id = cr
 
 			return new VectorGeoResource(id, label, sourceType).setSource(data, 4326 /**valid for kml, gpx and geoJson**/);
 		}
-		throw new Error(`GeoResource for '${url}' could not be loaded: Http-Status ${result.status}`);
+		throw new UnavailableGeoResourceError(`VectorGeoResource for '${url}' could not be loaded`, id, result.status);
 	};
 };
 
@@ -244,6 +246,6 @@ export const getBvvVectorGeoResourceLoaderForUrl = (url, sourceType, id, label) 
 
 			return new VectorGeoResource(id, label, sourceType).setSource(data, 4326 /**valid for kml, gpx and geoJson**/);
 		}
-		throw new Error(`VectorGeoResource for '${url}' could not be loaded: Http-Status ${result.status}`);
+		throw new UnavailableGeoResourceError(`VectorGeoResource for '${url}' could not be loaded`, id, result.status);
 	};
 };

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -202,9 +202,8 @@ export const loadExternalGeoResource = (urlBasedAsId) => {
  * @param {string | null} [id]
  * @param {string | null} [label]
  * @returns {module:domain/geoResources~asyncGeoResourceLoader}
- * @throws when resource cannot be loaded
  */
-export const defaultVectorGeoResourceLoaderForUrl = (url, sourceType, id = createUniqueId().toString(), label = null) => {
+export const getDefaultVectorGeoResourceLoaderForUrl = (url, sourceType, id = createUniqueId().toString(), label = null) => {
 	return async () => {
 		const { HttpService: httpService } = $injector.inject('HttpService');
 		const result = await httpService.get(url, { timeout: 5000 });

--- a/test/e2e/page.spec.js
+++ b/test/e2e/page.spec.js
@@ -63,10 +63,13 @@ test.describe('page', () => {
 		});
 
 		test('should contain 15 top level ba-components', async ({ page }) => {
-			// for (const el of await page.locator('body > *').all()) {
-			// 	// eslint-disable-next-line no-console
-			// 	console.log(await el.evaluate((el) => el.outerHTML));
-			// }
+			/**
+			 * Print current top level element with:
+			 * for (const el of await page.locator('body > *').all()) {
+			 * 	console.log(await el.evaluate((el) => el.outerHTML));
+			 * }
+			 */
+
 			expect(await page.locator('body > *').count()).toBe(15);
 
 			expect(await page.locator('ba-header').count()).toBe(1);

--- a/test/e2e/page.spec.js
+++ b/test/e2e/page.spec.js
@@ -64,6 +64,7 @@ test.describe('page', () => {
 
 		test('should contain 15 top level ba-components', async ({ page }) => {
 			for (const el of await page.locator('body > *').all()) {
+				// eslint-disable-next-line no-console
 				console.log(await el.evaluate((el) => el.outerHTML));
 			}
 			expect(await page.locator('body > *').count()).toBe(15);

--- a/test/e2e/page.spec.js
+++ b/test/e2e/page.spec.js
@@ -63,6 +63,9 @@ test.describe('page', () => {
 		});
 
 		test('should contain 15 top level ba-components', async ({ page }) => {
+			for (const el of await page.locator('body > *').all()) {
+				console.log(await el.evaluate((el) => el.outerHTML));
+			}
 			expect(await page.locator('body > *').count()).toBe(15);
 
 			expect(await page.locator('ba-header').count()).toBe(1);

--- a/test/e2e/page.spec.js
+++ b/test/e2e/page.spec.js
@@ -63,10 +63,10 @@ test.describe('page', () => {
 		});
 
 		test('should contain 15 top level ba-components', async ({ page }) => {
-			for (const el of await page.locator('body > *').all()) {
-				// eslint-disable-next-line no-console
-				console.log(await el.evaluate((el) => el.outerHTML));
-			}
+			// for (const el of await page.locator('body > *').all()) {
+			// 	// eslint-disable-next-line no-console
+			// 	console.log(await el.evaluate((el) => el.outerHTML));
+			// }
 			expect(await page.locator('body > *').count()).toBe(15);
 
 			expect(await page.locator('ba-header').count()).toBe(1);

--- a/test/i18n/global.provider.test.js
+++ b/test/i18n/global.provider.test.js
@@ -22,8 +22,8 @@ describe('global i18n', () => {
 		expect(map.global_marker_symbol_label).toBe('Marker');
 		expect(map.global_featureInfo_not_available).toBe('FeatureInfo is not available');
 		expect(map.global_routingService_init_exception).toBe('Routing currently not available');
-		expect(map.global_geoResource_not_available(['id'])).toBe('Failed to add a layer for the GeoResource with ID "id"');
-		expect(map.global_geoResource_not_available(['id', 'Reason...'])).toBe('Failed to add a layer for the GeoResource with ID "id" (Reason...)');
+		expect(map.global_geoResource_not_available(['id'])).toBe('Failed to add a layer for the GeoResource "id"');
+		expect(map.global_geoResource_not_available(['id', 'Reason...'])).toBe('Failed to add a layer for the GeoResource "id" (Reason...)');
 		expect(map.global_geoResource_unauthorized).toBe('401 - Unauthorized');
 		expect(map.global_geoResource_forbidden).toBe('403 - Forbidden');
 	});
@@ -49,9 +49,9 @@ describe('global i18n', () => {
 		expect(map.global_marker_symbol_label).toBe('Markierung');
 		expect(map.global_featureInfo_not_available).toBe('FeatureInfo ist nicht verfügbar');
 		expect(map.global_routingService_init_exception).toBe('Die Routing-Funktion steht derzeit leider nicht zur Verfügung');
-		expect(map.global_geoResource_not_available(['id'])).toBe('Es konnte keine Ebene für die GeoRessource mit der ID "id" geladen werden');
+		expect(map.global_geoResource_not_available(['id'])).toBe('Es konnte keine Ebene für die GeoRessource "id" geladen werden');
 		expect(map.global_geoResource_not_available(['id', 'Grund...'])).toBe(
-			'Es konnte keine Ebene für die GeoRessource mit der ID "id" geladen werden (Grund...)'
+			'Es konnte keine Ebene für die GeoRessource "id" geladen werden (Grund...)'
 		);
 		expect(map.global_geoResource_unauthorized).toBe('401 - Fehlende Berechtigung');
 		expect(map.global_geoResource_forbidden).toBe('403 - Zugriff nicht erlaubt');

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -521,11 +521,11 @@ describe('OlMap', () => {
 		});
 
 		describe('on touch device', () => {
-			beforeEach(async () => {
+			beforeEach(() => {
 				jasmine.clock().install();
 			});
 
-			afterEach(function () {
+			afterEach(() => {
 				jasmine.clock().uninstall();
 			});
 
@@ -653,11 +653,11 @@ describe('OlMap', () => {
 			});
 
 			describe('on touch device', () => {
-				beforeEach(async () => {
+				beforeEach(() => {
 					jasmine.clock().install();
 				});
 
-				afterEach(function () {
+				afterEach(() => {
 					jasmine.clock().uninstall();
 				});
 

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -1206,29 +1206,6 @@ describe('OlMap', () => {
 			expect(map.getLayers().item(1)).toEqual(nonAsyncOlLayer);
 		});
 
-		it('adds NO layer for an unresolveable GeoResourceFuture', async () => {
-			const element = await setup();
-			const map = element._map;
-			const message = 'error';
-			const future = new GeoResourceFuture(geoResourceId0, async () => Promise.reject(message));
-			spyOn(layerServiceMock, 'toOlLayer')
-				.withArgs(id0, jasmine.anything(), map)
-				.and.callFake((id) => new Layer({ id: id, render: () => {}, properties: { placeholder: true } }));
-			spyOn(geoResourceServiceStub, 'byId').withArgs(geoResourceId0).and.returnValue(future);
-			const warnSpy = spyOn(console, 'warn');
-
-			addLayer(id0, { geoResourceId: geoResourceId0 });
-			expect(map.getLayers().getLength()).toBe(1);
-			const layer = map.getLayers().item(0);
-			expect(layer.get('id')).toBe(id0);
-
-			await TestUtils.timeout();
-			expect(map.getLayers().getLength()).toBe(0);
-			expect(warnSpy).toHaveBeenCalledWith(message);
-			expect(store.getState().notifications.latest.payload.content).toBe('global_geoResource_not_available [geoResourceId0]');
-			expect(store.getState().notifications.latest.payload.level).toEqual(LevelTypes.WARN);
-		});
-
 		it('removes layer from state store when olLayer not available', async () => {
 			const element = await setup();
 			const map = element._map;

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -13,7 +13,7 @@ import { LayerService } from '../../../../src/modules/olMap/services/LayerServic
 import { Map } from 'ol';
 import VectorLayer from 'ol/layer/Vector';
 import { TestUtils } from '../../../test-utils';
-import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/olLoadFunction.provider';
+import { getBvvBaaImageLoadFunction, getBvvTileLoadFunction } from '../../../../src/modules/olMap/utils/olLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
 import { createXYZ } from 'ol/tilegrid';
 import { AdvWmtsTileGrid } from '../../../../src/modules/olMap/ol/tileGrid/AdvWmtsTileGrid';
@@ -23,22 +23,22 @@ describe('LayerService', () => {
 	const vectorLayerService = {
 		createVectorLayer: () => {}
 	};
-	const georesourceService = {
+	const geoResourceService = {
 		byId: () => {}
 	};
 	const baaCredentialService = {
 		get: () => {}
 	};
 
-	const setup = (baaImageLoadFunctionProvider) => {
-		return new LayerService(baaImageLoadFunctionProvider);
+	const setup = (imageLoadFunctionProvider, tileLoadFunctionProvider) => {
+		return new LayerService(imageLoadFunctionProvider, tileLoadFunctionProvider);
 	};
 
 	beforeEach(() => {
 		TestUtils.setupStoreAndDi({});
 		$injector
 			.registerSingleton('VectorLayerService', vectorLayerService)
-			.registerSingleton('GeoResourceService', georesourceService)
+			.registerSingleton('GeoResourceService', geoResourceService)
 			.registerSingleton('BaaCredentialService', baaCredentialService);
 	});
 
@@ -46,12 +46,15 @@ describe('LayerService', () => {
 		it('initializes the service with default providers', () => {
 			const instanceUnderTest = new LayerService();
 			expect(instanceUnderTest._imageLoadFunctionProvider).toEqual(getBvvBaaImageLoadFunction);
+			expect(instanceUnderTest._tileLoadFunctionProvider).toEqual(getBvvTileLoadFunction);
 		});
 
 		it('initializes the service with custom provider', () => {
-			const getBvvBaaImageLoadFunctionCustomProvider = () => {};
-			const instanceUnderTest = setup(getBvvBaaImageLoadFunctionCustomProvider);
-			expect(instanceUnderTest._imageLoadFunctionProvider).toEqual(getBvvBaaImageLoadFunctionCustomProvider);
+			const getImageLoadFunctionCustomProvider = () => {};
+			const getTileLoadFunctionCustomProvider = () => {};
+			const instanceUnderTest = setup(getImageLoadFunctionCustomProvider, getTileLoadFunctionCustomProvider);
+			expect(instanceUnderTest._imageLoadFunctionProvider).toEqual(getImageLoadFunctionCustomProvider);
+			expect(instanceUnderTest._tileLoadFunctionProvider).toEqual(getTileLoadFunctionCustomProvider);
 		});
 	});
 
@@ -61,9 +64,9 @@ describe('LayerService', () => {
 				const instanceUnderTest = setup();
 				const id = 'id';
 				const geoResourceId = 'geoResourceId';
-				const wmsGeoresource = new GeoResourceFuture(geoResourceId, () => {});
+				const wmsGeoResource = new GeoResourceFuture(geoResourceId, () => {});
 
-				const placeholderOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoresource);
+				const placeholderOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoResource);
 
 				expect(placeholderOlLayer.get('id')).toBe(id);
 				expect(placeholderOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -74,31 +77,31 @@ describe('LayerService', () => {
 			});
 		});
 
-		describe('VectorGeoresource', () => {
+		describe('VectorGeoResource', () => {
 			it('calls the VectorLayerService', () => {
 				const instanceUnderTest = setup();
 				const id = 'id';
 				const olMap = new Map();
 				const olLayer = new VectorLayer();
-				const vectorGeoresource = new VectorGeoResource('geoResourceId', 'label', VectorSourceType.KML);
+				const vectorGeoResource = new VectorGeoResource('geoResourceId', 'label', VectorSourceType.KML);
 				const vectorSourceForUrlSpy = spyOn(vectorLayerService, 'createVectorLayer').and.returnValue(olLayer);
 
-				instanceUnderTest.toOlLayer(id, vectorGeoresource, olMap);
+				instanceUnderTest.toOlLayer(id, vectorGeoResource, olMap);
 
-				expect(vectorSourceForUrlSpy).toHaveBeenCalledWith(id, vectorGeoresource, olMap);
+				expect(vectorSourceForUrlSpy).toHaveBeenCalledWith(id, vectorGeoResource, olMap);
 			});
 		});
 
-		describe('WmsGeoresource', () => {
-			it('converts a WmsGeoresource to a olLayer', () => {
+		describe('WmsGeoResource', () => {
+			it('converts a WmsGeoResource to a olLayer', () => {
 				const mockImageLoadFunction = () => {};
 				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
 				const instanceUnderTest = setup(providerSpy);
 				const id = 'id';
 				const geoResourceId = 'geoResourceId';
-				const wmsGeoresource = new WmsGeoResource(geoResourceId, 'label', 'https://some.url', 'layer', 'image/png');
+				const wmsGeoResource = new WmsGeoResource(geoResourceId, 'label', 'https://some.url', 'layer', 'image/png');
 
-				const wmsOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoresource);
+				const wmsOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoResource);
 
 				expect(wmsOlLayer.get('id')).toBe(id);
 				expect(wmsOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -116,19 +119,19 @@ describe('LayerService', () => {
 				expect(wmsOlLayer.getSource().getImageLoadFunction()).toBe(mockImageLoadFunction);
 			});
 
-			it('converts a WmsGeoresource containing optional properties to a olLayer', () => {
+			it('converts a WmsGeoResource containing optional properties to a olLayer', () => {
 				const mockImageLoadFunction = () => {};
 				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
 				const instanceUnderTest = setup(providerSpy);
 				const id = 'id';
 				const geoResourceId = 'geoResourceId';
-				const wmsGeoresource = new WmsGeoResource(geoResourceId, 'label', 'https://some.url', 'layer', 'image/png')
+				const wmsGeoResource = new WmsGeoResource(geoResourceId, 'label', 'https://some.url', 'layer', 'image/png')
 					.setOpacity(0.5)
 					.setMinZoom(5)
 					.setMaxZoom(19)
 					.setExtraParams({ STYLES: 'some' });
 
-				const wmsOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoresource);
+				const wmsOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoResource);
 
 				expect(wmsOlLayer.get('id')).toBe(id);
 				expect(wmsOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -157,11 +160,11 @@ describe('LayerService', () => {
 					const instanceUnderTest = setup(providerSpy);
 					const id = 'id';
 					const geoResourceId = 'geoResourceId';
-					const wmsGeoresource = new WmsGeoResource(geoResourceId, 'label', url, 'layer', 'image/png').setAuthenticationType(
+					const wmsGeoResource = new WmsGeoResource(geoResourceId, 'label', url, 'layer', 'image/png').setAuthenticationType(
 						GeoResourceAuthenticationType.BAA
 					);
 
-					const wmsOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoresource);
+					const wmsOlLayer = instanceUnderTest.toOlLayer(id, wmsGeoResource);
 
 					expect(providerSpy).toHaveBeenCalledWith(geoResourceId, credential);
 					expect(wmsOlLayer.getSource().getImageLoadFunction()).toBe(mockImageLoadFunction);
@@ -176,26 +179,28 @@ describe('LayerService', () => {
 					const instanceUnderTest = setup(providerSpy);
 					const id = 'id';
 					const geoResourceId = 'geoResourceId';
-					const wmsGeoresource = new WmsGeoResource(geoResourceId, 'label', url, 'layer', 'image/png').setAuthenticationType(
+					const wmsGeoResource = new WmsGeoResource(geoResourceId, 'label', url, 'layer', 'image/png').setAuthenticationType(
 						GeoResourceAuthenticationType.BAA
 					);
 
 					expect(providerSpy).not.toHaveBeenCalledWith(geoResourceId, credential);
 					expect(() => {
-						instanceUnderTest.toOlLayer(id, wmsGeoresource);
-					}).toThrowError(`No credential available for GeoResource with id '${wmsGeoresource.id}' and url '${wmsGeoresource.url}'`);
+						instanceUnderTest.toOlLayer(id, wmsGeoResource);
+					}).toThrowError(`No credential available for GeoResource with id '${wmsGeoResource.id}' and url '${wmsGeoResource.url}'`);
 				});
 			});
 		});
 
-		describe('XyzGeoresource', () => {
-			it('converts a XyzGeoresource to a olLayer', () => {
-				const instanceUnderTest = setup();
+		describe('XyzGeoResource', () => {
+			it('converts a XyzGeoResource to a olLayer', () => {
+				const mockImageLoadFunction = () => {};
+				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+				const instanceUnderTest = setup(null, providerSpy);
 				const id = 'id';
 				const geoResourceId = 'geoResourceId';
-				const xyzGeoresource = new XyzGeoResource(geoResourceId, 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+				const xyzGeoResource = new XyzGeoResource(geoResourceId, 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
 
-				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoresource);
+				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoResource);
 
 				expect(xyzOlLayer.get('id')).toBe(id);
 				expect(xyzOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -206,15 +211,19 @@ describe('LayerService', () => {
 				expect(xyzOlLayer.constructor.name).toBe('TileLayer');
 				expect(xyzSource.constructor.name).toBe('XYZ');
 				expect(xyzSource.getUrls()).toEqual(['https://some1/layer/{z}/{x}/{y}', 'https://some2/layer/{z}/{x}/{y}']);
+				expect(xyzSource.getTileLoadFunction()).toBe(mockImageLoadFunction);
+				expect(providerSpy).toHaveBeenCalledWith(geoResourceId);
 			});
 
-			it('converts a XyzGeoresource to a olLayer containing an array of urls', () => {
-				const instanceUnderTest = setup();
+			it('converts a XyzGeoResource to a olLayer containing an array of urls', () => {
+				const mockImageLoadFunction = () => {};
+				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+				const instanceUnderTest = setup(null, providerSpy);
 				const id = 'id';
 				const geoResourceId = 'geoResourceId';
-				const xyzGeoresource = new XyzGeoResource(geoResourceId, 'label', ['https://some1/layer/{z}/{x}/{y}', 'https://some2/layer/{z}/{x}/{y}']);
+				const xyzGeoResource = new XyzGeoResource(geoResourceId, 'label', ['https://some1/layer/{z}/{x}/{y}', 'https://some2/layer/{z}/{x}/{y}']);
 
-				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoresource);
+				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoResource);
 
 				expect(xyzOlLayer.get('id')).toBe(id);
 				expect(xyzOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -225,18 +234,22 @@ describe('LayerService', () => {
 				expect(xyzOlLayer.constructor.name).toBe('TileLayer');
 				expect(xyzSource.constructor.name).toBe('XYZ');
 				expect(xyzSource.getUrls()).toEqual(['https://some1/layer/{z}/{x}/{y}', 'https://some2/layer/{z}/{x}/{y}']);
+				expect(xyzSource.getTileLoadFunction()).toBe(mockImageLoadFunction);
+				expect(providerSpy).toHaveBeenCalledWith(geoResourceId);
 			});
 
-			it('converts a XyzGeoresource containing optional properties to a olLayer', () => {
-				const instanceUnderTest = setup();
+			it('converts a XyzGeoResource containing optional properties to a olLayer', () => {
+				const mockImageLoadFunction = () => {};
+				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+				const instanceUnderTest = setup(null, providerSpy);
 				const id = 'id';
 				const geoResourceId = 'geoResourceId';
-				const xyzGeoresource = new XyzGeoResource(geoResourceId, 'label', 'https://some{1-2}/layer/{z}/{x}/{y}')
+				const xyzGeoResource = new XyzGeoResource(geoResourceId, 'label', 'https://some{1-2}/layer/{z}/{x}/{y}')
 					.setOpacity(0.5)
 					.setMinZoom(5)
 					.setMaxZoom(19);
 
-				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoresource);
+				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoResource);
 
 				expect(xyzOlLayer.get('id')).toBe(id);
 				expect(xyzOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -248,14 +261,18 @@ describe('LayerService', () => {
 				expect(xyzOlLayer.constructor.name).toBe('TileLayer');
 				expect(xyzSource.constructor.name).toBe('XYZ');
 				expect(xyzSource.getUrls()).toEqual(['https://some1/layer/{z}/{x}/{y}', 'https://some2/layer/{z}/{x}/{y}']);
+				expect(xyzSource.getTileLoadFunction()).toBe(mockImageLoadFunction);
+				expect(providerSpy).toHaveBeenCalledWith(geoResourceId);
 			});
 
 			it('sets a XYZ source containing the default TileGrid', () => {
-				const instanceUnderTest = setup();
+				const mockImageLoadFunction = () => {};
+				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+				const instanceUnderTest = setup(null, providerSpy);
 				const id = 'id';
-				const xyzGeoresource = new XyzGeoResource('geoResourceId', 'Label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+				const xyzGeoResource = new XyzGeoResource('geoResourceId', 'Label', 'https://some{1-2}/layer/{z}/{x}/{y}');
 
-				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoresource);
+				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoResource);
 
 				const xyzSource = xyzOlLayer.getSource();
 				expect(xyzSource.getTileGrid()).toEqual(createXYZ());
@@ -263,11 +280,13 @@ describe('LayerService', () => {
 			});
 
 			it('sets a XYZ source containing the ADV WMTS TileGrid', () => {
-				const instanceUnderTest = setup();
+				const mockImageLoadFunction = () => {};
+				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+				const instanceUnderTest = setup(null, providerSpy);
 				const id = 'id';
-				const xyzGeoresource = new XyzGeoResource('geoResourceId', 'Label', 'https://some{1-2}/layer/{z}/{x}/{y}').setTileGridId('adv_wmts');
+				const xyzGeoResource = new XyzGeoResource('geoResourceId', 'Label', 'https://some{1-2}/layer/{z}/{x}/{y}').setTileGridId('adv_wmts');
 
-				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoresource);
+				const xyzOlLayer = instanceUnderTest.toOlLayer(id, xyzGeoResource);
 
 				const xyzSource = xyzOlLayer.getSource();
 				expect(xyzSource.getTileGrid()).toEqual(new AdvWmtsTileGrid());
@@ -275,17 +294,17 @@ describe('LayerService', () => {
 			});
 		});
 
-		describe('VTGeoresource', () => {
-			it('converts a VTGeoresource to a olLayer', () => {
+		describe('VTGeoResource', () => {
+			it('converts a VTGeoResource to a olLayer', () => {
 				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
 				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
 				if (supported()) {
 					const instanceUnderTest = setup();
 					const id = 'id';
 					const geoResourceId = 'geoResourceId';
-					const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null);
+					const vtGeoResource = new VTGeoResource(geoResourceId, 'label', null);
 
-					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
+					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoResource);
 
 					expect(vtOlLayer.get('id')).toBe(id);
 					expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -296,16 +315,16 @@ describe('LayerService', () => {
 				}
 			});
 
-			it('converts a VTGeoresource containing optional properties to a olLayer', () => {
+			it('converts a VTGeoResource containing optional properties to a olLayer', () => {
 				// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
 				// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
 				if (supported()) {
 					const instanceUnderTest = setup();
 					const id = 'id';
 					const geoResourceId = 'geoResourceId';
-					const vtGeoresource = new VTGeoResource(geoResourceId, 'label', null).setOpacity(0.5).setMinZoom(5).setMaxZoom(19);
+					const vtGeoResource = new VTGeoResource(geoResourceId, 'label', null).setOpacity(0.5).setMinZoom(5).setMaxZoom(19);
 
-					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoresource);
+					const vtOlLayer = instanceUnderTest.toOlLayer(id, vtGeoResource);
 					expect(vtOlLayer.get('id')).toBe(id);
 					expect(vtOlLayer.get('geoResourceId')).toBe(geoResourceId);
 					expect(vtOlLayer.getOpacity()).toBe(0.5);
@@ -317,51 +336,55 @@ describe('LayerService', () => {
 			});
 		});
 
-		it('converts a AggregateGeoresource to a olLayer(Group)', () => {
-			const instanceUnderTest = setup();
+		it('converts a AggregateGeoResource to a olLayer(Group)', () => {
+			const mockImageLoadFunction = () => {};
+			const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+			const instanceUnderTest = setup(null, providerSpy);
 			const id = 'id';
-			const xyzGeoresource0 = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			const xyzGeoresource1 = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			spyOn(georesourceService, 'byId').and.callFake((id) => {
+			const xyzGeoResource0 = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+			const xyzGeoResource1 = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+			spyOn(geoResourceService, 'byId').and.callFake((id) => {
 				switch (id) {
-					case xyzGeoresource0.id:
-						return xyzGeoresource0;
-					case xyzGeoresource1.id:
-						return xyzGeoresource1;
+					case xyzGeoResource0.id:
+						return xyzGeoResource0;
+					case xyzGeoResource1.id:
+						return xyzGeoResource1;
 				}
 			});
-			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource0.id, xyzGeoresource1.id]);
+			const aggregateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoResource0.id, xyzGeoResource1.id]);
 
-			const olLayerGroup = instanceUnderTest.toOlLayer(id, aggreggateGeoResource);
+			const olLayerGroup = instanceUnderTest.toOlLayer(id, aggregateGeoResource);
 
 			expect(olLayerGroup.get('id')).toBe(id);
 			expect(olLayerGroup.getMinZoom()).toBeNegativeInfinity();
 			expect(olLayerGroup.getMaxZoom()).toBePositiveInfinity();
 			expect(olLayerGroup.constructor.name).toBe('LayerGroup');
 			const layers = olLayerGroup.getLayers();
-			expect(layers.item(0).get('id')).toBe(xyzGeoresource0.id);
-			expect(layers.item(1).get('id')).toBe(xyzGeoresource1.id);
+			expect(layers.item(0).get('id')).toBe(xyzGeoResource0.id);
+			expect(layers.item(1).get('id')).toBe(xyzGeoResource1.id);
 		});
 
-		it('converts a AggregateGeoresource containing optional properties to a olLayer(Group)', () => {
-			const instanceUnderTest = setup();
+		it('converts a AggregateGeoResource containing optional properties to a olLayer(Group)', () => {
+			const mockImageLoadFunction = () => {};
+			const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+			const instanceUnderTest = setup(null, providerSpy);
 			const id = 'id';
-			const xyzGeoresource0 = new XyzGeoResource('geoResourceId0', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			const xyzGeoresource1 = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			spyOn(georesourceService, 'byId').and.callFake((id) => {
+			const xyzGeoResource0 = new XyzGeoResource('geoResourceId0', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+			const xyzGeoResource1 = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+			spyOn(geoResourceService, 'byId').and.callFake((id) => {
 				switch (id) {
-					case xyzGeoresource0.id:
-						return xyzGeoresource0;
-					case xyzGeoresource1.id:
-						return xyzGeoresource1;
+					case xyzGeoResource0.id:
+						return xyzGeoResource0;
+					case xyzGeoResource1.id:
+						return xyzGeoResource1;
 				}
 			});
-			const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource0.id, xyzGeoresource1.id])
+			const aggregateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoResource0.id, xyzGeoResource1.id])
 				.setOpacity(0.5)
 				.setMinZoom(5)
 				.setMaxZoom(19);
 
-			const olLayerGroup = instanceUnderTest.toOlLayer(id, aggreggateGeoResource);
+			const olLayerGroup = instanceUnderTest.toOlLayer(id, aggregateGeoResource);
 
 			expect(olLayerGroup.get('id')).toBe(id);
 			expect(olLayerGroup.getOpacity()).toBe(0.5);
@@ -369,28 +392,30 @@ describe('LayerService', () => {
 			expect(olLayerGroup.getMaxZoom()).toBe(19);
 			expect(olLayerGroup.constructor.name).toBe('LayerGroup');
 			const layers = olLayerGroup.getLayers();
-			expect(layers.item(0).get('id')).toBe(xyzGeoresource0.id);
-			expect(layers.item(1).get('id')).toBe(xyzGeoresource1.id);
+			expect(layers.item(0).get('id')).toBe(xyzGeoResource0.id);
+			expect(layers.item(1).get('id')).toBe(xyzGeoResource1.id);
 		});
 
 		it('registers an opacity change listener in order to synchronize the opacity of a MapLibreLayer', () => {
 			// FF currently throws a WebGL error when running in headless mode, so we first check if it does make sense to perform the test, otherwise, we skip them
 			// See https://bugzilla.mozilla.org/show_bug.cgi?id=1375585#c27 for more information
 			if (supported()) {
-				const instanceUnderTest = setup();
+				const mockImageLoadFunction = () => {};
+				const providerSpy = jasmine.createSpy().and.returnValue(mockImageLoadFunction);
+				const instanceUnderTest = setup(null, providerSpy);
 				const id = 'id';
-				const xyzGeoresource = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
-				const vtGeoresource = new VTGeoResource('geoResourceId2', 'label', null);
-				spyOn(georesourceService, 'byId').and.callFake((id) => {
+				const xyzGeoResource = new XyzGeoResource('geoResourceId1', 'label', 'https://some{1-2}/layer/{z}/{x}/{y}');
+				const vtGeoResource = new VTGeoResource('geoResourceId2', 'label', null);
+				spyOn(geoResourceService, 'byId').and.callFake((id) => {
 					switch (id) {
-						case xyzGeoresource.id:
-							return xyzGeoresource;
-						case vtGeoresource.id:
-							return vtGeoresource;
+						case xyzGeoResource.id:
+							return xyzGeoResource;
+						case vtGeoResource.id:
+							return vtGeoResource;
 					}
 				});
-				const aggreggateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoresource.id, vtGeoresource.id]);
-				const olLayerGroup = instanceUnderTest.toOlLayer(id, aggreggateGeoResource);
+				const aggregateGeoResource = new AggregateGeoResource('geoResourceId0', 'label', [xyzGeoResource.id, vtGeoResource.id]);
+				const olLayerGroup = instanceUnderTest.toOlLayer(id, aggregateGeoResource);
 				const layers = olLayerGroup.getLayers();
 				const otherOlLayerSetOpacitySpy = spyOn(layers.item(0), 'setOpacity').and.callThrough();
 				const mapLibreLayerSetOpacitySpy = spyOn(layers.item(1), 'setOpacity').and.callThrough();
@@ -402,7 +427,7 @@ describe('LayerService', () => {
 			}
 		});
 
-		it('throws an error when georesource type is not supported', () => {
+		it('throws an error when GeoResource type is not supported', () => {
 			const instanceUnderTest = setup();
 			const id = 'id';
 			expect(() => {

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -13,7 +13,7 @@ import { LayerService } from '../../../../src/modules/olMap/services/LayerServic
 import { Map } from 'ol';
 import VectorLayer from 'ol/layer/Vector';
 import { TestUtils } from '../../../test-utils';
-import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/baaImageLoadFunction.provider';
+import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/olLoadFunction.provider';
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer';
 import { createXYZ } from 'ol/tilegrid';
 import { AdvWmtsTileGrid } from '../../../../src/modules/olMap/ol/tileGrid/AdvWmtsTileGrid';

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -45,13 +45,13 @@ describe('LayerService', () => {
 	describe('constructor', () => {
 		it('initializes the service with default providers', () => {
 			const instanceUnderTest = new LayerService();
-			expect(instanceUnderTest._baaImageLoadFunctionProvider).toEqual(getBvvBaaImageLoadFunction);
+			expect(instanceUnderTest._imageLoadFunctionProvider).toEqual(getBvvBaaImageLoadFunction);
 		});
 
 		it('initializes the service with custom provider', () => {
 			const getBvvBaaImageLoadFunctionCustomProvider = () => {};
 			const instanceUnderTest = setup(getBvvBaaImageLoadFunctionCustomProvider);
-			expect(instanceUnderTest._baaImageLoadFunctionProvider).toEqual(getBvvBaaImageLoadFunctionCustomProvider);
+			expect(instanceUnderTest._imageLoadFunctionProvider).toEqual(getBvvBaaImageLoadFunctionCustomProvider);
 		});
 	});
 

--- a/test/modules/olMap/util/olLoadFunction.provider.test.js
+++ b/test/modules/olMap/util/olLoadFunction.provider.test.js
@@ -182,7 +182,7 @@ describe('olLoadFunction.provider', () => {
 			it('throws an exception when http status is not 200 and emits a notification', async () => {
 				const geoResourceId = 'geoResourceId';
 				const fakeImageWrapper = getFakeImageWrapperInstance();
-				const src = 'http://foo.var/some/11/1089/710';
+				const src = 'http://foo.var?WIDTH=2000&HEIGHT=2000';
 				spyOn(httpService, 'get').and.resolveTo(new Response(null, { status: 404 }));
 				const errorSpy = spyOn(console, 'error');
 				const imageLoadFunction = getBvvBaaImageLoadFunction(geoResourceId);

--- a/test/modules/olMap/util/olLoadFunction.provider.test.js
+++ b/test/modules/olMap/util/olLoadFunction.provider.test.js
@@ -342,7 +342,7 @@ describe('olLoadFunction.provider', () => {
 			};
 		};
 
-		it('throws an exception when http status is not 200 and emits a notification', async () => {
+		it('throws an exception when http status is other than 200 and 400 and emits a notification', async () => {
 			const geoResourceId = 'geoResourceId';
 			const fakeTileWrapper = getFakeTileWrapperInstance();
 			const src = 'http://foo.var/some/11/1089/710';
@@ -362,25 +362,16 @@ describe('olLoadFunction.provider', () => {
 			expect(fakeTileWrapper.state).toBe(TileState.ERROR);
 		});
 
-		it('throws an exception when http status is 403 and emits a notification', async () => {
+		it('throws an exception when http status is 400', async () => {
 			const geoResourceId = 'geoResourceId';
 			const fakeTileWrapper = getFakeTileWrapperInstance();
 			const src = 'http://foo.var/some/11/1089/710';
-			spyOn(httpService, 'get').and.resolveTo(new Response(null, { status: 403 }));
-			const errorSpy = spyOn(console, 'error');
+			spyOn(httpService, 'get').and.resolveTo(new Response(null, { status: 400 }));
 			const tileLoadFunction = getBvvTileLoadFunction(geoResourceId);
-			jasmine.clock().tick(throttleDelay);
 
-			// tile loading causes multiple simultaneously requests, therefore we check the use of the throttle function to keep the notification at a count of 1
-			await tileLoadFunction(fakeTileWrapper, src);
-			await tileLoadFunction(fakeTileWrapper, src);
 			await tileLoadFunction(fakeTileWrapper, src);
 
-			expect(errorSpy).toHaveBeenCalledOnceWith('Tile could not be fetched', new Error('Unexpected network status 403'));
-			expect(store.getState().notifications.latest.payload.content).toBe(
-				'global_geoResource_not_available [geoResourceId,global_geoResource_forbidden]'
-			);
-			expect(store.getState().notifications.latest.payload.level).toEqual(LevelTypes.WARN);
+			expect(store.getState().notifications.latest).toBeNull();
 			expect(fakeTileWrapper.state).toBe(TileState.ERROR);
 		});
 

--- a/test/modules/olMap/util/olLoadFunction.provider.test.js
+++ b/test/modules/olMap/util/olLoadFunction.provider.test.js
@@ -1,5 +1,5 @@
-import { $injector } from '../../../../src/injection';
-import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/baaImageLoadFunction.provider';
+import { $injector } from '../../../../src/injection/index.js';
+import { getBvvBaaImageLoadFunction } from '../../../../src/modules/olMap/utils/olLoadFunction.provider';
 import { LevelTypes } from '../../../../src/store/notifications/notifications.action.js';
 import { notificationReducer } from '../../../../src/store/notifications/notifications.reducer.js';
 import { TestUtils } from '../../../test-utils.js';

--- a/test/service/GeoResourceService.test.js
+++ b/test/service/GeoResourceService.test.js
@@ -362,7 +362,7 @@ describe('GeoResourceService', () => {
 				const geoResourceId = 'id';
 				const geoResource = { authRoles: ['TEST'] };
 				const responseInterceptor = () => {};
-				const authResponseInterceptorProvider = jasmine.createSpy().withArgs(['TEST']).and.returnValue(responseInterceptor);
+				const authResponseInterceptorProvider = jasmine.createSpy().withArgs(['TEST'], geoResourceId).and.returnValue(responseInterceptor);
 				const instanceUnderTest = setup(null, null, authResponseInterceptorProvider);
 				spyOn(instanceUnderTest, 'byId').withArgs(geoResourceId).and.returnValue(geoResource);
 
@@ -375,7 +375,7 @@ describe('GeoResourceService', () => {
 				it('returns `false`', async () => {
 					const geoResourceId = 'id';
 					const responseInterceptor = () => {};
-					const authResponseInterceptorProvider = jasmine.createSpy().withArgs([]).and.returnValue(responseInterceptor);
+					const authResponseInterceptorProvider = jasmine.createSpy().withArgs([], geoResourceId).and.returnValue(responseInterceptor);
 					const instanceUnderTest = setup(null, null, authResponseInterceptorProvider);
 					spyOn(instanceUnderTest, 'byId').withArgs(geoResourceId).and.returnValue(null);
 

--- a/test/service/HttpService.test.js
+++ b/test/service/HttpService.test.js
@@ -7,12 +7,7 @@ import { TestUtils } from '../test-utils';
 const defaultInterceptors = { response: [] };
 
 describe('HttpService', () => {
-	const configService = {
-		getValue: () => {}
-	};
-
 	beforeEach(function () {
-		$injector.registerSingleton('ConfigService', configService);
 		jasmine.clock().install();
 	});
 
@@ -48,17 +43,16 @@ describe('HttpService', () => {
 		it('provides a result setting the credentials options', async () => {
 			const url = 'http://foo.bar';
 			const httpService = new HttpService();
-			const spy = spyOn(window, 'fetch').and.returnValue(
+			spyOn(window, 'fetch').and.returnValue(
 				Promise.resolve({
 					text: () => {
 						return 42;
 					}
 				})
 			);
-			spyOn(configService, 'getValue').withArgs('FETCH_API_CREDENTIALS', 'same-origin').and.returnValue('include');
 
 			const result = await httpService.fetch(url);
-			expect(spy).toHaveBeenCalledOnceWith(url, jasmine.objectContaining({ credentials: 'include' }));
+
 			expect(result.text()).toBe(42);
 		});
 

--- a/test/service/HttpService.test.js
+++ b/test/service/HttpService.test.js
@@ -458,7 +458,7 @@ describe('NetworkStateSyncHttpService', () => {
 
 describe('AuthInvalidatingAfter401HttpService', () => {
 	const configService = {
-		getValue: () => {}
+		getValueAsPath: () => {}
 	};
 	const authService = {
 		invalidate: () => {}
@@ -495,6 +495,7 @@ describe('AuthInvalidatingAfter401HttpService', () => {
 				const mockHttpServiceIgnore401PathProvider = () => [];
 				const instanceUnderTest = setup(mockHttpServiceIgnore401PathProvider);
 				spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 401 }));
+				spyOn(configService, 'getValueAsPath').and.returnValue(url);
 				const parentFetchSpy = spyOn(HttpService.prototype, 'fetch').and.callThrough();
 				const authSpy = spyOn(authService, 'invalidate');
 
@@ -511,6 +512,25 @@ describe('AuthInvalidatingAfter401HttpService', () => {
 					const mockHttpServiceIgnore401PathProvider = () => ['foo.bar'];
 					const instanceUnderTest = setup(mockHttpServiceIgnore401PathProvider);
 					spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 401 }));
+					spyOn(configService, 'getValueAsPath').and.returnValue(url);
+					const parentFetchSpy = spyOn(HttpService.prototype, 'fetch').and.callThrough();
+					const authSpy = spyOn(authService, 'invalidate');
+
+					const result = await instanceUnderTest.fetch(url);
+
+					expect(authSpy).not.toHaveBeenCalled();
+					expect(result.status).toBe(401);
+					expect(parentFetchSpy).toHaveBeenCalledWith(url, {}, jasmine.any(AbortController), { response: [jasmine.any(Function)] });
+				});
+			});
+
+			describe('endpoint is is not a backend endpoint', () => {
+				it("calls only parent's fetch", async () => {
+					const url = 'http://foo.bar';
+					const mockHttpServiceIgnore401PathProvider = () => [];
+					const instanceUnderTest = setup(mockHttpServiceIgnore401PathProvider);
+					spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 401 }));
+					spyOn(configService, 'getValueAsPath').and.returnValue('http://backend.url');
 					const parentFetchSpy = spyOn(HttpService.prototype, 'fetch').and.callThrough();
 					const authSpy = spyOn(authService, 'invalidate');
 

--- a/test/service/ProcessEnvConfigService.test.js
+++ b/test/service/ProcessEnvConfigService.test.js
@@ -48,13 +48,12 @@ describe('tests for ProcessEnvConfigService', () => {
 				PROXY_URL: 'PROXY_URL_value',
 				FRONTEND_URL: 'FRONTEND_URL_value',
 				BACKEND_URL: 'BACKEND_URL_value',
-				SHORTENING_SERVICE_URL: 'SHORTENING_SERVICE_URL_value',
-				FETCH_API_CREDENTIALS: 'FETCH_API_CREDENTIALS_value'
+				SHORTENING_SERVICE_URL: 'SHORTENING_SERVICE_URL_value'
 			};
 
 			const configService = new ProcessEnvConfigService();
 
-			expect(configService._properties.size).toBe(8);
+			expect(configService._properties.size).toBe(7);
 			expect(configService.getValue('RUNTIME_MODE')).toBe('development');
 			expect(configService.getValue('SOFTWARE_INFO')).toBe('SOFTWARE_INFO_value');
 			expect(configService.getValue('DEFAULT_LANG')).toBe('DEFAULT_LANG_value');
@@ -62,7 +61,6 @@ describe('tests for ProcessEnvConfigService', () => {
 			expect(configService.getValue('FRONTEND_URL')).toBe('FRONTEND_URL_value');
 			expect(configService.getValue('BACKEND_URL')).toBe('BACKEND_URL_value');
 			expect(configService.getValue('SHORTENING_SERVICE_URL')).toBe('SHORTENING_SERVICE_URL_value');
-			expect(configService.getValue('FETCH_API_CREDENTIALS')).toBe('FETCH_API_CREDENTIALS_value');
 
 			expect(warnSpy).not.toHaveBeenCalled();
 		});
@@ -78,14 +76,10 @@ describe('tests for ProcessEnvConfigService', () => {
 				BACKEND_URL: 'BACKEND_URL_value',
 				SHORTENING_SERVICE_URL: 'SHORTENING_SERVICE_URL_value'
 			};
-			// Just for test setup and keys not included in ba_externalConfigProperties
-			process.env = {
-				FETCH_API_CREDENTIALS: 'FETCH_API_CREDENTIALS_value'
-			};
 
 			const configService = new ProcessEnvConfigService();
 
-			expect(configService._properties.size).toBe(8);
+			expect(configService._properties.size).toBe(7);
 			expect(configService.getValue('RUNTIME_MODE')).toBe('development');
 			expect(configService.getValue('SOFTWARE_INFO')).toBe('SOFTWARE_INFO_value');
 			expect(configService.getValue('DEFAULT_LANG')).toBe('DEFAULT_LANG_value');

--- a/test/service/provider/fileStorage.provider.test.js
+++ b/test/service/provider/fileStorage.provider.test.js
@@ -3,6 +3,7 @@ import { GeoResourceFuture, VectorGeoResource, VectorSourceType } from '../../..
 import { FileStorageServiceDataTypes } from '../../../src/services/FileStorageService';
 import { loadBvvFileStorageResourceById, _newLoader } from '../../../src/services/provider/fileStorage.provider';
 import { getAttributionForLocallyImportedOrCreatedGeoResource } from '../../../src/services/provider/attribution.provider';
+import { UnavailableGeoResourceError } from '../../../src/domain/errors';
 
 describe('BVV GeoResource provider', () => {
 	const fileStorageService = {
@@ -99,12 +100,7 @@ describe('BVV GeoResource provider', () => {
 			const loader = _newLoader(id);
 
 			await expectAsync(loader()).toBeRejectedWith(
-				jasmine.objectContaining({
-					message: "Could not load vector data for id 'id'",
-					cause: jasmine.objectContaining({
-						message: `Unsupported FileStorageServiceDataType '${type}'`
-					})
-				})
+				new UnavailableGeoResourceError(`Unsupported FileStorageServiceDataType '${type}'`, id)
 			);
 		});
 
@@ -116,8 +112,7 @@ describe('BVV GeoResource provider', () => {
 			spyOn(fileStorageService, 'get').withArgs(fileId).and.rejectWith(serviceError);
 			const loader = _newLoader(id);
 
-			await expectAsync(loader()).toBeRejectedWithError("Could not load vector data for id 'id'");
-			await expectAsync(loader()).toBeRejectedWith(jasmine.objectContaining({ cause: serviceError }));
+			await expectAsync(loader()).toBeRejectedWith(new UnavailableGeoResourceError(`Could not load vector data for id '${id}'`, id, null, { cause: serviceError }));
 		});
 	});
 });

--- a/test/service/provider/fileStorage.provider.test.js
+++ b/test/service/provider/fileStorage.provider.test.js
@@ -99,9 +99,7 @@ describe('BVV GeoResource provider', () => {
 				.and.returnValue(Promise.resolve({ data: data, type: type, srid: srid }));
 			const loader = _newLoader(id);
 
-			await expectAsync(loader()).toBeRejectedWith(
-				new UnavailableGeoResourceError(`Unsupported FileStorageServiceDataType '${type}'`, id)
-			);
+			await expectAsync(loader()).toBeRejectedWith(new UnavailableGeoResourceError(`Unsupported FileStorageServiceDataType '${type}'`, id));
 		});
 
 		it('throws an error when FileStorageService throws an error', async () => {
@@ -112,7 +110,9 @@ describe('BVV GeoResource provider', () => {
 			spyOn(fileStorageService, 'get').withArgs(fileId).and.rejectWith(serviceError);
 			const loader = _newLoader(id);
 
-			await expectAsync(loader()).toBeRejectedWith(new UnavailableGeoResourceError(`Could not load vector data for id '${id}'`, id, null, { cause: serviceError }));
+			await expectAsync(loader()).toBeRejectedWith(
+				new UnavailableGeoResourceError(`Could not load vector data for id '${id}'`, id, null, { cause: serviceError })
+			);
 		});
 	});
 });

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -1,3 +1,4 @@
+import { UnavailableGeoResourceError } from '../../../src/domain/errors';
 import { GeoResourceFuture, VectorGeoResource, VectorSourceType, WmsGeoResource } from '../../../src/domain/geoResources';
 import { SourceType, SourceTypeName, SourceTypeResult, SourceTypeResultStatus } from '../../../src/domain/sourceType';
 import { $injector } from '../../../src/injection';
@@ -267,8 +268,8 @@ describe('GeoResource provider', () => {
 				.and.resolveTo(new Response(null, { status: 404 }));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
-			await expectAsync(_definitionToGeoResource(vectorDefinition).get()).toBeRejectedWithError(
-				`VectorGeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
+			await expectAsync(_definitionToGeoResource(vectorDefinition).get()).toBeRejectedWith(
+				new UnavailableGeoResourceError(`VectorGeoResource for '${vectorDefinition.url}' could not be loaded`, vectorDefinition.id, 404)
 			);
 		});
 
@@ -846,8 +847,8 @@ describe('GeoResource provider', () => {
 				.withArgs(vectorDefinition.url, { timeout: 5000 })
 				.and.resolveTo(new Response(null, { status: 404 }));
 
-			await expectAsync(getDefaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWithError(
-				`GeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
+			await expectAsync(getDefaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWith(
+				new UnavailableGeoResourceError(`VectorGeoResource for '${vectorDefinition.url}' could not be loaded`, vectorDefinition.id, 404)
 			);
 		});
 	});
@@ -882,8 +883,8 @@ describe('GeoResource provider', () => {
 				.and.resolveTo(new Response(null, { status: 404 }));
 			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
 
-			await expectAsync(getBvvVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWithError(
-				`VectorGeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
+			await expectAsync(getBvvVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWith(
+				new UnavailableGeoResourceError(`VectorGeoResource for '${vectorDefinition.url}' could not be loaded`, vectorDefinition.id, 404)
 			);
 		});
 	});

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -8,7 +8,8 @@ import {
 	loadExternalGeoResource,
 	_definitionToGeoResource,
 	_parseBvvAttributionDefinition,
-	defaultVectorGeoResourceLoaderForUrl
+	defaultVectorGeoResourceLoaderForUrl,
+	getBvvVectorGeoResourceLoaderForUrl
 } from '../../../src/services/provider/geoResource.provider';
 import { TestUtils } from '../../test-utils';
 
@@ -19,8 +20,10 @@ describe('GeoResource provider', () => {
 	const httpService = {
 		async get() {}
 	};
+	const responseInterceptor = () => {};
 	const geoResourceService = {
-		addOrReplace() {}
+		addOrReplace() {},
+		getAuthResponseInterceptorForGeoResource: () => responseInterceptor
 	};
 	const sourceTypeService = {
 		async forUrl() {}
@@ -135,13 +138,13 @@ describe('GeoResource provider', () => {
 		...aggregateDefinition
 	};
 
-	const validateGeoResourceProperties = (georesource, definition) => {
-		expect(georesource.id).toBe(definition.id);
-		expect(georesource.label).toBe(definition.label);
-		expect(georesource.opacity).toBe(1.0);
-		expect(georesource.hidden).toBeFalse();
-		expect(georesource.queryable).toBeTrue();
-		expect(Symbol.keyFor(georesource.getType())).toBe(definition.type);
+	const validateGeoResourceProperties = (geoResource, definition) => {
+		expect(geoResource.id).toBe(definition.id);
+		expect(geoResource.label).toBe(definition.label);
+		expect(geoResource.opacity).toBe(1.0);
+		expect(geoResource.hidden).toBeFalse();
+		expect(geoResource.queryable).toBeTrue();
+		expect(Symbol.keyFor(geoResource.getType())).toBe(definition.type);
 	};
 
 	describe('_definitionToGeoResource', () => {
@@ -224,8 +227,8 @@ describe('GeoResource provider', () => {
 			const data = 'data';
 			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
 			spyOn(httpService, 'get')
-				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.returnValue(Promise.resolve(new Response(data, { status: 200 })));
+				.withArgs(vectorDefinition.url, { timeout: 5000 }, { response: [responseInterceptor] })
+				.and.resolveTo(new Response(data));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
 			const vectorGeoResource = await _definitionToGeoResource(vectorDefinition).get();
@@ -241,8 +244,8 @@ describe('GeoResource provider', () => {
 			const data = 'data';
 			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinitionOptionalProperties.url);
 			spyOn(httpService, 'get')
-				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.returnValue(Promise.resolve(new Response(data, { status: 200 })));
+				.withArgs(vectorDefinition.url, { timeout: 5000 }, { response: [responseInterceptor] })
+				.and.resolveTo(new Response(data));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
 			const vectorGeoResource = await _definitionToGeoResource(vectorDefinitionOptionalProperties).get();
@@ -260,12 +263,12 @@ describe('GeoResource provider', () => {
 		it('throws an Error when GeoResourceFuture for a VectorGeoResource cannot be resolved', async () => {
 			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
 			spyOn(httpService, 'get')
-				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.returnValue(Promise.resolve(new Response(null, { status: 404 })));
+				.withArgs(vectorDefinition.url, { timeout: 5000 }, { response: [responseInterceptor] })
+				.and.resolveTo(new Response(null, { status: 404 }));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
 			await expectAsync(_definitionToGeoResource(vectorDefinition).get()).toBeRejectedWithError(
-				`GeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
+				`VectorGeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
 			);
 		});
 
@@ -401,24 +404,24 @@ describe('GeoResource provider', () => {
 				.and.returnValue(backendUrl + '/');
 			const httpServiceSpy = spyOn(httpService, 'get')
 				.withArgs(expectedArgs0, expectedArgs1)
-				.and.returnValue(Promise.resolve(new Response(JSON.stringify([wmsDefinition, xyzDefinition, vectorDefinition, aggregateDefinition]))));
+				.and.resolveTo(new Response(JSON.stringify([wmsDefinition, xyzDefinition, vectorDefinition, aggregateDefinition])));
 
-			const georesources = await loadBvvGeoResources();
+			const geoResources = await loadBvvGeoResources();
 
 			expect(configServiceSpy).toHaveBeenCalled();
 			expect(httpServiceSpy).toHaveBeenCalled();
-			expect(georesources.length).toBe(4);
+			expect(geoResources.length).toBe(4);
 
-			const wmsGeoResource = georesources[0];
+			const wmsGeoResource = geoResources[0];
 			validateGeoResourceProperties(wmsGeoResource, wmsDefinition);
 
-			const xyzGeoResource = georesources[1];
+			const xyzGeoResource = geoResources[1];
 			validateGeoResourceProperties(xyzGeoResource, xyzDefinition);
 
-			const geoResourceFutureForVectorGeoResource /** Is's a GeoResourceFuture! */ = georesources[2];
+			const geoResourceFutureForVectorGeoResource /** Is's a GeoResourceFuture! */ = geoResources[2];
 			validateGeoResourceProperties(geoResourceFutureForVectorGeoResource, { ...vectorDefinition, type: 'future' });
 
-			const aggregateGeoResource = georesources[3];
+			const aggregateGeoResource = geoResources[3];
 			validateGeoResourceProperties(aggregateGeoResource, aggregateDefinition);
 		});
 
@@ -426,7 +429,7 @@ describe('GeoResource provider', () => {
 			const warnSpy = spyOn(console, 'warn');
 			const backendUrl = 'https://backend.url';
 			spyOn(configService, 'getValueAsPath').and.returnValue(backendUrl);
-			spyOn(httpService, 'get').and.returnValue(Promise.resolve(new Response(JSON.stringify([{ id: 'someId', type: 'somethingUnknown' }]))));
+			spyOn(httpService, 'get').and.resolveTo(new Response(JSON.stringify([{ id: 'someId', type: 'somethingUnknown' }])));
 
 			await loadBvvGeoResources();
 
@@ -442,7 +445,7 @@ describe('GeoResource provider', () => {
 			const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(backendUrl);
 			const httpServiceSpy = spyOn(httpService, 'get')
 				.withArgs(expectedArgs0, expectedArgs1)
-				.and.returnValue(Promise.resolve(new Response(null, { status: 404 })));
+				.and.resolveTo(new Response(null, { status: 404 }));
 
 			await expectAsync(loadBvvGeoResources()).toBeRejectedWithError('GeoResources could not be loaded');
 			expect(configServiceSpy).toHaveBeenCalled();
@@ -460,7 +463,7 @@ describe('GeoResource provider', () => {
 			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 			const httpServiceSpy = spyOn(httpService, 'get')
 				.withArgs(expectedArgs0)
-				.and.returnValue(Promise.resolve(new Response(JSON.stringify(wmsDefinition))));
+				.and.resolveTo(new Response(JSON.stringify(wmsDefinition)));
 
 			const future = loadBvvGeoResourceById(wmsDefinition.id);
 			const geoResource = await future.get();
@@ -477,7 +480,7 @@ describe('GeoResource provider', () => {
 			const id = 'foo';
 			const backendUrl = 'https://backend.url';
 			spyOn(configService, 'getValueAsPath').and.returnValue(backendUrl);
-			spyOn(httpService, 'get').and.returnValue(Promise.resolve(new Response(JSON.stringify({ id: id, type: 'somethingUnknown' }))));
+			spyOn(httpService, 'get').and.resolveTo(new Response(JSON.stringify({ id: id, type: 'somethingUnknown' })));
 			const future = loadBvvGeoResourceById(id);
 
 			await expectAsync(future.get()).toBeRejectedWithError(`GeoResource for id '${id}' could not be loaded`);
@@ -487,7 +490,7 @@ describe('GeoResource provider', () => {
 			const id = 'foo';
 			const backendUrl = 'https://backend.url';
 			spyOn(configService, 'getValueAsPath').and.returnValue(backendUrl);
-			spyOn(httpService, 'get').and.returnValue(Promise.resolve(new Response(null, { status: 404 })));
+			spyOn(httpService, 'get').and.resolveTo(new Response(null, { status: 404 }));
 			const future = loadBvvGeoResourceById(id);
 
 			await expectAsync(future.get()).toBeRejectedWithError(`GeoResource for id '${id}' could not be loaded`);
@@ -809,7 +812,7 @@ describe('GeoResource provider', () => {
 			const data = 'data';
 			spyOn(httpService, 'get')
 				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.returnValue(Promise.resolve(new Response(data, { status: 200 })));
+				.and.resolveTo(new Response(data));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
 			const vectorGeoResource = await defaultVectorGeoResourceLoaderForUrl(
@@ -830,7 +833,7 @@ describe('GeoResource provider', () => {
 			const data = 'data';
 			spyOn(httpService, 'get')
 				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.returnValue(Promise.resolve(new Response(data, { status: 200 })));
+				.and.resolveTo(new Response(data));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
 			const vectorGeoResource = await defaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, Symbol.for(vectorDefinition.sourceType))();
@@ -845,10 +848,46 @@ describe('GeoResource provider', () => {
 		it('returns an GeoResourceLoader throwing an Error when resource is not available', async () => {
 			spyOn(httpService, 'get')
 				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.returnValue(Promise.resolve(new Response(null, { status: 404 })));
+				.and.resolveTo(new Response(null, { status: 404 }));
 
 			await expectAsync(defaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWithError(
 				`GeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
+			);
+		});
+	});
+
+	describe('getBvvVectorGeoResourceLoaderForUrl', () => {
+		it('returns an GeoResourceLoader resolving to a VectorGeoResource', async () => {
+			const data = 'data';
+			spyOn(httpService, 'get')
+				.withArgs(vectorDefinition.url, { timeout: 5000 }, { response: [responseInterceptor] })
+				.and.resolveTo(new Response(data));
+			const urlServiceSpy = spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
+
+			const vectorGeoResource = await getBvvVectorGeoResourceLoaderForUrl(
+				vectorDefinition.url,
+				Symbol.for(vectorDefinition.sourceType),
+				vectorDefinition.id,
+				vectorDefinition.label
+			)();
+
+			expect(vectorGeoResource).toBeInstanceOf(VectorGeoResource);
+			expect(vectorGeoResource.id).toBe(vectorDefinition.id);
+			expect(vectorGeoResource.label).toBe(vectorDefinition.label);
+			expect(vectorGeoResource.data).toBe(data);
+			expect(vectorGeoResource.srid).toBe(4326);
+			expect(Symbol.keyFor(vectorGeoResource.sourceType)).toBe(vectorDefinition.sourceType);
+			expect(urlServiceSpy).toHaveBeenCalled();
+		});
+
+		it('returns an GeoResourceLoader throwing an Error when resource is not available', async () => {
+			spyOn(httpService, 'get')
+				.withArgs(vectorDefinition.url, { timeout: 5000 }, { response: [responseInterceptor] })
+				.and.resolveTo(new Response(null, { status: 404 }));
+			spyOn(urlService, 'proxifyInstant').withArgs(vectorDefinition.url).and.returnValue(vectorDefinition.url);
+
+			await expectAsync(getBvvVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWithError(
+				`VectorGeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
 			);
 		});
 	});

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -8,7 +8,7 @@ import {
 	loadExternalGeoResource,
 	_definitionToGeoResource,
 	_parseBvvAttributionDefinition,
-	defaultVectorGeoResourceLoaderForUrl,
+	getDefaultVectorGeoResourceLoaderForUrl,
 	getBvvVectorGeoResourceLoaderForUrl
 } from '../../../src/services/provider/geoResource.provider';
 import { TestUtils } from '../../test-utils';
@@ -807,15 +807,13 @@ describe('GeoResource provider', () => {
 		});
 	});
 
-	describe('defaultVectorGeoResourceLoaderForUrl', () => {
+	describe('getDefaultVectorGeoResourceLoaderForUrl', () => {
 		it('returns an GeoResourceLoader resolving to a VectorGeoResource', async () => {
 			const data = 'data';
-			spyOn(httpService, 'get')
-				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.resolveTo(new Response(data));
+			spyOn(httpService, 'get').withArgs(vectorDefinition.url, { timeout: 5000 }).and.resolveTo(new Response(data));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
-			const vectorGeoResource = await defaultVectorGeoResourceLoaderForUrl(
+			const vectorGeoResource = await getDefaultVectorGeoResourceLoaderForUrl(
 				vectorDefinition.url,
 				Symbol.for(vectorDefinition.sourceType),
 				vectorDefinition.id,
@@ -831,12 +829,10 @@ describe('GeoResource provider', () => {
 
 		it('returns an GeoResourceLoader resolving to a VectorGeoResource', async () => {
 			const data = 'data';
-			spyOn(httpService, 'get')
-				.withArgs(vectorDefinition.url, { timeout: 5000 })
-				.and.resolveTo(new Response(data));
+			spyOn(httpService, 'get').withArgs(vectorDefinition.url, { timeout: 5000 }).and.resolveTo(new Response(data));
 			spyOn(geoResourceService, 'addOrReplace').and.callFake((gr) => gr);
 
-			const vectorGeoResource = await defaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, Symbol.for(vectorDefinition.sourceType))();
+			const vectorGeoResource = await getDefaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, Symbol.for(vectorDefinition.sourceType))();
 
 			expect(vectorGeoResource.id).not.toBeNull();
 			expect(vectorGeoResource.label).not.toBeNull();
@@ -850,7 +846,7 @@ describe('GeoResource provider', () => {
 				.withArgs(vectorDefinition.url, { timeout: 5000 })
 				.and.resolveTo(new Response(null, { status: 404 }));
 
-			await expectAsync(defaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWithError(
+			await expectAsync(getDefaultVectorGeoResourceLoaderForUrl(vectorDefinition.url, vectorDefinition.sourceType)()).toBeRejectedWithError(
 				`GeoResource for '${vectorDefinition.url}' could not be loaded: Http-Status 404`
 			);
 		});


### PR DESCRIPTION
- [x]  add a BVV-specific HttpService and remove `FETCH_API_CREDENTIALS` config parameter
- [x] intercept XyzGeoResource fetch calls
- [x] intercept VetctorGeoResource fetch calls
- [x] use global error handling (see #2255 )