### PR TITLE
ElevationProfile: improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ For example, they could be responsible for setting an initial state or reacting 
 
 - If an update of the global state has an event-like character, it's recommended to wrap the payload within another object. This makes it possible to track changes and avoids second dispatching in order to "reset" the state. For this purpose, you can use use `EventLike` in storeUtils.js
 
+- Avoid adding huge objects or arrays to the Redux store (e.g. large arrays of coordinates). Detecting changes can be expensive in that case. Instead, try to reference them by an identifier and push this identifier to the store.
+
 ## Links
 
 ### Various topics relating to Web Components

--- a/src/modules/elevationProfile/components/panel/ElevationProfile.js
+++ b/src/modules/elevationProfile/components/panel/ElevationProfile.js
@@ -9,7 +9,6 @@ import { $injector } from '../../../../injection';
 
 import { SurfaceType } from '../../utils/elevationProfileAttributeTypes';
 import { addHighlightFeatures, HighlightFeatureType, removeHighlightFeaturesById } from '../../../../store/highlight/highlight.action';
-import { emitNotification, LevelTypes } from '../../../../store/notifications/notifications.action';
 import { toLocaleString } from '../../../../utils/numberUtils';
 import { isNumber } from '../../../../utils/checks';
 
@@ -119,8 +118,8 @@ export class ElevationProfile extends MvuElement {
 			(darkSchema) => this.signal(Update_Schema, darkSchema)
 		),
 			this.observe(
-				(state) => state.elevationProfile.coordinates,
-				(coordinates) => this._getElevationProfile(coordinates)
+				(state) => state.elevationProfile.id,
+				(id) => this._getElevationProfile(id)
 			),
 			this.observe(
 				(state) => state.media,
@@ -486,24 +485,15 @@ export class ElevationProfile extends MvuElement {
 	/**
 	 * @private
 	 */
-	async _getElevationProfile(coordinates) {
-		const translate = (key) => this._translationService.translate(key);
-		if (Array.isArray(coordinates) && coordinates.length >= 2) {
-			try {
-				const profile = await this._elevationService.getProfile(coordinates);
-				if (!profile) {
-					this.signal(Update_Profile_Data, Empty_Profile_Data);
-				} else {
-					this._enrichProfileData(profile);
-					this.signal(Update_Profile_Data, profile);
-				}
-			} catch (e) {
-				console.error(e);
-				emitNotification(translate('elevationProfile_could_not_load'), LevelTypes.ERROR);
+	async _getElevationProfile(id) {
+		if (id) {
+			const profile = await this._elevationService.fetchProfile(id);
+			if (!profile) {
 				this.signal(Update_Profile_Data, Empty_Profile_Data);
+			} else {
+				this._enrichProfileData(profile);
+				this.signal(Update_Profile_Data, profile);
 			}
-		} else {
-			this.signal(Update_Profile_Data, Empty_Profile_Data);
 		}
 	}
 

--- a/src/modules/olMap/handler/routing/OlRoutingHandler.js
+++ b/src/modules/olMap/handler/routing/OlRoutingHandler.js
@@ -26,7 +26,6 @@ import { provide as messageProvide } from './tooltipMessage.provider';
 import { setCategory, setProposal, setRouteAndStats, setWaypoints } from '../../../../store/routing/routing.action';
 import { CoordinateProposalType, RouteCalculationErrors, RoutingStatusCodes } from '../../../../domain/routing';
 import { fit } from '../../../../store/position/position.action';
-import { updateCoordinates } from '../../../../store/elevationProfile/elevationProfile.action';
 import { equals } from '../../../../../node_modules/ol/coordinate';
 import { GeoJSON as GeoJSONFormat } from 'ol/format';
 import { SourceType, SourceTypeName } from '../../../../domain/sourceType';
@@ -577,7 +576,7 @@ export class OlRoutingHandler extends OlLayerHandler {
 		const coordinates = geom.getCoordinates();
 
 		try {
-			const { stats: profileStats } = await this._elevationService.getProfile(coordinates);
+			const { stats: profileStats } = await this._elevationService.requestProfile(coordinates);
 			const routeStats = this._routeStatsProvider(ghRoute, profileStats);
 
 			const route = {
@@ -585,7 +584,6 @@ export class OlRoutingHandler extends OlLayerHandler {
 				type: new SourceType(SourceTypeName.GEOJSON)
 			};
 			setRouteAndStats(route, routeStats);
-			updateCoordinates(coordinates);
 		} catch (e) {
 			/**
 			 * In that case we remove all route features and reset the s-o-s,

--- a/src/plugins/ElevationProfilePlugin.js
+++ b/src/plugins/ElevationProfilePlugin.js
@@ -3,7 +3,7 @@
  */
 import { html } from 'lit-html';
 import { closeBottomSheet, openBottomSheet } from '../store/bottomSheet/bottomSheet.action';
-import { closeProfile } from '../store/elevationProfile/elevationProfile.action';
+import { closeProfile, indicateChange } from '../store/elevationProfile/elevationProfile.action';
 import { observe } from '../utils/storeUtils';
 import { BaPlugin } from './BaPlugin';
 
@@ -31,6 +31,11 @@ export class ElevationProfilePlugin extends BaPlugin {
 			}
 		};
 
+		// when feature info changes we reset the current profile id
+		const onFeatureInfoSelected = () => {
+			indicateChange(null);
+		};
+
 		const onProfileActiveStateChanged = (active) => {
 			this._bottomSheetUnsubscribeFn?.();
 			if (active) {
@@ -46,5 +51,6 @@ export class ElevationProfilePlugin extends BaPlugin {
 		observe(store, (state) => state.elevationProfile.active, onProfileActiveStateChanged, false);
 		observe(store, (state) => state.draw.active, onActiveStateChanged);
 		observe(store, (state) => state.measurement.active, onActiveStateChanged);
+		observe(store, (state) => state.featureInfo.current, onFeatureInfoSelected);
 	}
 }

--- a/src/store/elevationProfile/elevationProfile.action.js
+++ b/src/store/elevationProfile/elevationProfile.action.js
@@ -2,8 +2,7 @@
  * @module store/elevationProfile/elevationProfile_action
  */
 import { $injector } from '../../injection';
-import { isCoordinateLike } from '../../utils/checks';
-import { ELEVATION_PROFILE_ACTIVE_CHANGED, ELEVATION_PROFILE_COORDINATES_CHANGED } from './elevationProfile.reducer';
+import { ELEVATION_PROFILE_ACTIVE_CHANGED, ELEVATION_PROFILE_CHANGED } from './elevationProfile.reducer';
 
 const getStore = () => {
 	const { StoreService } = $injector.inject('StoreService');
@@ -11,34 +10,16 @@ const getStore = () => {
 };
 
 /**
- * Opens the profile component. Does nothing when `coordinates` contains invalid values.
- * @param {Array<module:domain/coordinateTypeDef~CoordinateLike>} [coordinates] The coordinates for the calculation of the elevation profile
+ * Opens the profile component.
  * @function
  */
-export const openProfile = (coordinates = []) => {
-	if (coordinates.filter((c) => !isCoordinateLike(c)).length === 0) {
-		getStore().dispatch({
-			type: ELEVATION_PROFILE_ACTIVE_CHANGED,
-			payload: {
-				active: true,
-				coordinates: coordinates
-			}
-		});
-	}
-};
-
-/**
- * Updates the coordinates of the elevation profile. Does nothing when `coordinates` contains invalid values.
- * @param {Array<module:domain/coordinateTypeDef~CoordinateLike>} coordinates The coordinates for the calculation of the elevation profile
- * @function
- */
-export const updateCoordinates = (coordinates) => {
-	if (coordinates.filter((c) => !isCoordinateLike(c)).length === 0) {
-		getStore().dispatch({
-			type: ELEVATION_PROFILE_COORDINATES_CHANGED,
-			payload: coordinates
-		});
-	}
+export const openProfile = () => {
+	getStore().dispatch({
+		type: ELEVATION_PROFILE_ACTIVE_CHANGED,
+		payload: {
+			active: true
+		}
+	});
 };
 
 /**
@@ -51,5 +32,17 @@ export const closeProfile = () => {
 		payload: {
 			active: false
 		}
+	});
+};
+
+/**
+ * Indicates that the elevation profile changed.
+ * @param {string} id identifier of the referenced coordinates
+ * @function
+ */
+export const indicateChange = (id) => {
+	getStore().dispatch({
+		type: ELEVATION_PROFILE_CHANGED,
+		payload: id
 	});
 };

--- a/src/store/elevationProfile/elevationProfile.action.js
+++ b/src/store/elevationProfile/elevationProfile.action.js
@@ -37,7 +37,7 @@ export const closeProfile = () => {
 
 /**
  * Indicates that the elevation profile changed.
- * @param {string} id identifier of the referenced coordinates
+ * @param {string} id identifier of the new profile
  * @function
  */
 export const indicateChange = (id) => {

--- a/src/store/elevationProfile/elevationProfile.action.js
+++ b/src/store/elevationProfile/elevationProfile.action.js
@@ -36,7 +36,7 @@ export const closeProfile = () => {
 };
 
 /**
- * Indicates that the elevation profile changed.
+ * Indicates that the elevation profile has changed.
  * @param {string|null} id identifier of the new profile
  * @function
  */

--- a/src/store/elevationProfile/elevationProfile.action.js
+++ b/src/store/elevationProfile/elevationProfile.action.js
@@ -37,7 +37,7 @@ export const closeProfile = () => {
 
 /**
  * Indicates that the elevation profile changed.
- * @param {string} id identifier of the new profile
+ * @param {string|null} id identifier of the new profile
  * @function
  */
 export const indicateChange = (id) => {

--- a/src/store/elevationProfile/elevationProfile.reducer.js
+++ b/src/store/elevationProfile/elevationProfile.reducer.js
@@ -1,16 +1,18 @@
 export const ELEVATION_PROFILE_ACTIVE_CHANGED = 'elevationProfile/activeChanged';
 export const ELEVATION_PROFILE_COORDINATES_CHANGED = 'elevationProfile/coordinatesChanged';
+export const ELEVATION_PROFILE_CHANGED = 'elevationProfile/changed';
 
 export const initialState = {
 	/**
-	 * @property {Array<CoordinateLike>}
-	 */
-	coordinates: [],
-
-	/**
+	 * Profile component is active
 	 * @property {boolean}
 	 */
-	active: false
+	active: false,
+	/**
+	 * Identifier of the referenced coordinates
+	 * @property {string}
+	 */
+	id: null
 };
 
 export const elevationProfileReducer = (state = initialState, action) => {
@@ -18,17 +20,17 @@ export const elevationProfileReducer = (state = initialState, action) => {
 
 	switch (type) {
 		case ELEVATION_PROFILE_ACTIVE_CHANGED: {
-			const { active, coordinates } = payload;
+			const { active } = payload;
 			return {
 				...state,
-				coordinates: coordinates ? [...coordinates] : [...state.coordinates],
 				active: active
 			};
 		}
-		case ELEVATION_PROFILE_COORDINATES_CHANGED: {
+
+		case ELEVATION_PROFILE_CHANGED: {
 			return {
 				...state,
-				coordinates: [...payload]
+				id: payload
 			};
 		}
 	}

--- a/test/modules/chips/components/ElevationProfileChip.test.js
+++ b/test/modules/chips/components/ElevationProfileChip.test.js
@@ -1,5 +1,5 @@
 import { $injector } from '../../../../src/injection';
-import { updateCoordinates } from '../../../../src/store/elevationProfile/elevationProfile.action';
+import { indicateChange } from '../../../../src/store/elevationProfile/elevationProfile.action';
 import { elevationProfileReducer } from '../../../../src/store/elevationProfile/elevationProfile.reducer';
 import { TestUtils } from '../../../test-utils';
 import profileSvg from '../../../../src/modules/chips/components/assistChips/assets/profile.svg';
@@ -8,10 +8,14 @@ import { ElevationProfileChip } from '../../../../src/modules/chips/components/a
 window.customElements.define(ElevationProfileChip.tag, ElevationProfileChip);
 
 describe('ElevationProfileChip', () => {
+	const elevationService = {
+		requestProfile() {}
+	};
+
 	const defaultState = {
 		elevationProfile: {
 			active: false,
-			coordinates: []
+			id: null
 		}
 	};
 
@@ -19,24 +23,21 @@ describe('ElevationProfileChip', () => {
 
 	const setup = async (state = defaultState, attributes = {}) => {
 		store = TestUtils.setupStoreAndDi(state, { elevationProfile: elevationProfileReducer });
-		$injector.registerSingleton('TranslationService', { translate: (key) => key });
+		$injector.registerSingleton('TranslationService', { translate: (key) => key }).registerSingleton('ElevationService', elevationService);
 
 		const element = await TestUtils.render(ElevationProfileChip.tag, attributes);
 
 		return element;
 	};
 
-	const coordinates = [
-		[42, 21],
-		[0, 0]
-	];
+	const id = 'profileReferenceId';
 
 	describe('when instantiated', () => {
 		it('has a model containing default values', async () => {
 			await setup();
 			const model = new ElevationProfileChip().getModel();
 
-			expect(model).toEqual({ profileCoordinates: [] });
+			expect(model).toEqual({ profileCoordinates: [], id: null });
 		});
 
 		it('properly implements abstract methods', async () => {
@@ -51,26 +52,28 @@ describe('ElevationProfileChip', () => {
 		it('contains default values in the model', async () => {
 			const element = await setup();
 
-			const { profileCoordinates } = element.getModel();
+			const { profileCoordinates, id } = element.getModel();
 
 			expect(profileCoordinates).toEqual([]);
+			expect(id).toBeNull();
 		});
 
-		it('renders the view', async () => {
-			const state = { elevationProfile: { active: false, coordinates: coordinates } };
+		it('renders the view for profile id', async () => {
+			const state = { elevationProfile: { active: false, id } };
 			const element = await setup(state);
 
 			expect(element.isVisible()).toBeTrue();
 		});
 
 		it('renders the view with local coordinates', async () => {
-			const element = await setup(defaultState);
-
-			const unsubscribeSpy = spyOn(element, '_unsubscribeFromStore').and.callThrough();
-			element.coordinates = [
+			const coordinates = [
 				[2, 0],
 				[1, 0]
 			];
+			const element = await setup(defaultState);
+			const unsubscribeSpy = spyOn(element, '_unsubscribeFromStore').and.callThrough();
+
+			element.coordinates = coordinates;
 
 			expect(element.isVisible()).toBeTrue();
 			expect(unsubscribeSpy).toHaveBeenCalled();
@@ -85,22 +88,19 @@ describe('ElevationProfileChip', () => {
 				[2, 0],
 				[1, 0]
 			];
-			updateCoordinates([]);
+			indicateChange(id);
 
 			expect(element.isVisible()).toBeTrue();
 			expect(unsubscribeSpy).toHaveBeenCalled();
 			unsubscribeSpy.calls.reset();
 
 			element.coordinates = [];
-			updateCoordinates([
-				[2, 0],
-				[1, 0]
-			]);
+			indicateChange(id);
 
 			expect(element.isVisible()).toBeFalse();
 		});
 
-		it('renders nothing when no coordinates for elevationProfile exists', async () => {
+		it('renders nothing when no coordinates for elevationProfile exists at all', async () => {
 			const element = await setup();
 
 			expect(element.isVisible()).toBeFalse();
@@ -113,19 +113,19 @@ describe('ElevationProfileChip', () => {
 
 			expect(element.isVisible()).toBeFalse();
 
-			updateCoordinates(coordinates);
+			indicateChange(id);
 
 			expect(element.isVisible()).toBeTrue();
 
-			updateCoordinates([]);
+			indicateChange(null);
 
 			expect(element.isVisible()).toBeFalse();
 		});
 	});
 
 	describe('when chip is clicked', () => {
-		it('changes store on click', async () => {
-			const state = { elevationProfile: { active: false, coordinates: coordinates } };
+		it('opens the elevation profile', async () => {
+			const state = { elevationProfile: { active: false, id } };
 			const element = await setup(state);
 			const button = element.shadowRoot.querySelector('button');
 
@@ -136,25 +136,25 @@ describe('ElevationProfileChip', () => {
 			expect(store.getState().elevationProfile.active).toBeTrue();
 		});
 
-		it('changes store on click with local coordinates', async () => {
-			const state = { elevationProfile: { active: false, coordinates: [] } };
-			const element = await setup(state);
+		describe('and it has own coordinates', () => {
+			it('requests a profile and opens the elevation profile', async () => {
+				const coordinates = [
+					[2, 0],
+					[1, 0]
+				];
+				const elevationServiceSpy = spyOn(elevationService, 'requestProfile').withArgs(coordinates).and.resolveTo();
+				const state = { elevationProfile: { active: false } };
+				const element = await setup(state);
 
-			expect(store.getState().elevationProfile.active).toBeFalse();
-			expect(store.getState().elevationProfile.coordinates).toEqual([]);
+				expect(store.getState().elevationProfile.active).toBeFalse();
 
-			element.coordinates = [
-				[2, 0],
-				[1, 0]
-			];
-			const button = element.shadowRoot.querySelector('button');
-			button.click();
+				element.coordinates = coordinates;
+				const button = element.shadowRoot.querySelector('button');
+				button.click();
 
-			expect(store.getState().elevationProfile.active).toBeTrue();
-			expect(store.getState().elevationProfile.coordinates).toEqual([
-				[2, 0],
-				[1, 0]
-			]);
+				expect(store.getState().elevationProfile.active).toBeTrue();
+				expect(elevationServiceSpy).toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
+++ b/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
@@ -7,16 +7,14 @@ import {
 	SoterSlopeClasses
 } from '../../../../../src/modules/elevationProfile/components/panel/ElevationProfile.js';
 import { elevationProfileReducer } from '../../../../../src/store/elevationProfile/elevationProfile.reducer.js';
-import { updateCoordinates } from '../../../../../src/store/elevationProfile/elevationProfile.action.js';
+import { indicateChange } from '../../../../../src/store/elevationProfile/elevationProfile.action.js';
 import { createNoInitialStateMediaReducer } from '../../../../../src/store/media/media.reducer.js';
 
 import { TestUtils } from '../../../../test-utils.js';
 import { setIsDarkSchema } from '../../../../../src/store/media/media.action.js';
 import { HighlightFeatureType } from '../../../../../src/store/highlight/highlight.action.js';
 import { highlightReducer } from '../../../../../src/store/highlight/highlight.reducer.js';
-import { fromLonLat } from 'ol/proj.js';
 import { notificationReducer } from '../../../../../src/store/notifications/notifications.reducer.js';
-import { LevelTypes } from '../../../../../src/store/notifications/notifications.action.js';
 import { Chart } from 'chart.js';
 
 window.customElements.define(ElevationProfile.tag, ElevationProfile);
@@ -219,7 +217,7 @@ describe('ElevationProfile', () => {
 	};
 
 	const elevationServiceMock = {
-		getProfile() {}
+		fetchProfile() {}
 	};
 
 	const configServiceMock = {
@@ -233,6 +231,8 @@ describe('ElevationProfile', () => {
 	};
 
 	const elevationData = profileSlopeSteep();
+
+	const id = 'profileReferenceId';
 
 	let store;
 
@@ -263,23 +263,15 @@ describe('ElevationProfile', () => {
 		return TestUtils.render(ElevationProfile.tag);
 	};
 
-	describe('when using ElevationService', () => {
-		const coordinates = [
-			[0, 1],
-			[2, 3]
-		];
-		it('logs an error when getProfile fails', async () => {
-			const message = 'error message';
-			const getProfileSpy = spyOn(elevationServiceMock, 'getProfile').and.rejectWith(new Error(message));
-			const errorSpy = spyOn(console, 'error');
+	describe('ElevationService returns NULL', () => {
+		it('resets the profile property of the model', async () => {
+			const getProfileSpy = spyOn(elevationServiceMock, 'fetchProfile').and.returnValue(null);
 			const element = await setup();
 
-			await element._getElevationProfile(coordinates);
+			await element._getElevationProfile(id);
 
 			expect(getProfileSpy).toHaveBeenCalled();
-			expect(errorSpy).toHaveBeenCalledWith(new Error(message));
-			expect(store.getState().notifications.latest.payload.content).toBe('elevationProfile_could_not_load');
-			expect(store.getState().notifications.latest.payload.level).toEqual(LevelTypes.ERROR);
+			expect(element.getModel().profile).toEqual(Empty_Profile_Data);
 		});
 	});
 
@@ -324,7 +316,7 @@ describe('ElevationProfile', () => {
 			const config = chart.config;
 			const datasetZero = config.data.datasets[0];
 
-			// assert
+			// // assert
 			expect(element.shadowRoot.children.length).toBe(3);
 			expect(datasetZero.data).toEqual([]);
 			expect(config.data.labels).toEqual([]);
@@ -332,18 +324,14 @@ describe('ElevationProfile', () => {
 
 		it('renders the view when a profile is available', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					darkSchema: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const chart = element._chart;
@@ -416,18 +404,15 @@ describe('ElevationProfile', () => {
 
 		it('uses refSystem if provided', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profileSlopeSteep());
+
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profileSlopeSteep());
 			const element = await setup({
 				media: {
 					darkSchema: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const chart = element._chart;
@@ -440,20 +425,16 @@ describe('ElevationProfile', () => {
 	});
 
 	describe('when tooltip callback "title" is called', () => {
-		const coordinates = [
-			[0, 1],
-			[2, 3]
-		];
 		it('returns a valid distance', async () => {
 			// arrange
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					darkSchema: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const config = element._chart.config;
@@ -468,14 +449,14 @@ describe('ElevationProfile', () => {
 
 		it('calls setCoordinates() with valid coordinates', async () => {
 			// arrange
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					darkSchema: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 
@@ -493,20 +474,16 @@ describe('ElevationProfile', () => {
 	});
 
 	describe('when tooltip callback "label" is called', () => {
-		const coordinates = [
-			[0, 1],
-			[2, 3]
-		];
 		it('returns a valid elevation', async () => {
 			// arrange
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					darkSchema: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const config = element._chart.config;
@@ -523,16 +500,12 @@ describe('ElevationProfile', () => {
 	describe('when tooltip callback "label" is called for attribute slope', () => {
 		it('uses attributes prefix and unit', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profile();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 
@@ -556,16 +529,12 @@ describe('ElevationProfile', () => {
 	describe('when tooltip callback "label" is called for attribute surface', () => {
 		it('only shows the surface, no prefix or unit', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profile();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 
@@ -589,16 +558,12 @@ describe('ElevationProfile', () => {
 	describe('when _getBackground() is called', () => {
 		it('returns a valid background for "selectedAttribute alt"', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profile();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const attrs = element.shadowRoot.getElementById('attrs');
@@ -617,16 +582,12 @@ describe('ElevationProfile', () => {
 	describe('when _getBorder() is called', () => {
 		it('executes the branch "slope" for "selectedAttribute slope"', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profile();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const attrs = element.shadowRoot.getElementById('attrs');
@@ -644,16 +605,13 @@ describe('ElevationProfile', () => {
 
 		it('returns a gradient that ends in steep ', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
+
 			const elevationData = profileSlopeSteep();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const attrs = element.shadowRoot.getElementById('attrs');
@@ -671,16 +629,12 @@ describe('ElevationProfile', () => {
 
 		it('returns a gradient that uses SOTER-classification ', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profileSlopeSteep();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 
@@ -699,16 +653,12 @@ describe('ElevationProfile', () => {
 
 		it('executes the branch "TextType" for "selectedAttribute surface"', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profile();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const attrs = element.shadowRoot.getElementById('attrs');
@@ -783,15 +733,11 @@ describe('ElevationProfile', () => {
 	describe('when attribute changes several times', () => {
 		it('should update the view', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const destroyChartJsSpy = spyOn(element._chart, 'destroy').and.callThrough();
@@ -843,18 +789,13 @@ describe('ElevationProfile', () => {
 	});
 
 	describe('when attribute changes', () => {
-		const coordinates = [
-			[0, 1],
-			[2, 3]
-		];
-
 		it('should change _noAnimation', async () => {
 			// arrange
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			const noAnimationSpy = spyOnProperty(element, '_noAnimation', 'set').and.callThrough();
@@ -870,11 +811,11 @@ describe('ElevationProfile', () => {
 
 		it('should reset _noAnimation afterwards', async () => {
 			// arrange
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 
@@ -891,50 +832,39 @@ describe('ElevationProfile', () => {
 	describe('when coordinates (slice-of-state) changes (from no coordinates)', () => {
 		it('calls _getElevationProfile with coordinates', async () => {
 			// arrange
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
 			const elevationData = profileSlopeSteep();
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(elevationData);
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
 			const element = await setup();
 			const getElevationProfileSpy = spyOn(element, '_getElevationProfile').and.callThrough();
 
 			//act
-			updateCoordinates(coordinates);
+			indicateChange(id);
 
 			// assert
 			expect(getElevationProfileSpy).toHaveBeenCalledTimes(1);
-			expect(getElevationProfileSpy).toHaveBeenCalledWith(coordinates);
+			expect(getElevationProfileSpy).toHaveBeenCalledWith(id);
 		});
 	});
 
 	describe('when coordinates (slice-of-state) changes (from some coordinates)', () => {
 		it('calls _getElevationProfile with new coordinates', async () => {
 			// arrange
-			const initialCoordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			const secondCoordinates = [
-				[4, 5],
-				[6, 7]
-			];
-			spyOn(elevationServiceMock, 'getProfile').and.returnValues(profile(), profileWithoutSlope());
+			const id2 = 'profileReferenceId2';
+			spyOn(elevationServiceMock, 'fetchProfile').and.returnValues(profile(), profileWithoutSlope());
 
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: initialCoordinates
+					id
 				}
 			});
 			const getElevationProfileSpy = spyOn(element, '_getElevationProfile').and.callThrough();
 
 			//act
-			updateCoordinates(secondCoordinates);
+			indicateChange(id2);
 
 			// assert
-			expect(getElevationProfileSpy).toHaveBeenCalledWith(secondCoordinates);
+			expect(getElevationProfileSpy).toHaveBeenCalledWith(id2);
 		});
 	});
 
@@ -1109,11 +1039,8 @@ describe('ElevationProfile', () => {
 				// arrange
 				const spy = jasmine.createSpy();
 				window.addEventListener('chartJsAfterRender', spy);
-				const coordinates = [
-					[0, 1],
-					[2, 3]
-				];
-				spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+
+				spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 
 				//act
 				await setup({
@@ -1122,7 +1049,7 @@ describe('ElevationProfile', () => {
 					},
 					elevationProfile: {
 						active: true,
-						coordinates: coordinates
+						id
 					}
 				});
 
@@ -1134,13 +1061,11 @@ describe('ElevationProfile', () => {
 		describe('on pointermove', () => {
 			it('places a highlight feature within the store', async () => {
 				// arrange
-				const coordinates = fromLonLat([11, 48]);
-
-				spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+				spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 				const element = await setup({
 					elevationProfile: {
 						active: true,
-						coordinates: coordinates
+						id
 					}
 				});
 				const setCoordinatesSpy = spyOn(element, 'setCoordinates').and.callThrough();
@@ -1168,13 +1093,11 @@ describe('ElevationProfile', () => {
 		describe('on mouseout', () => {
 			it('removes the highlight feature from the store', async () => {
 				// arrange
-				const coordinates = fromLonLat([11, 48]);
-
-				spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+				spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 				const element = await setup({
 					elevationProfile: {
 						active: true,
-						coordinates: coordinates
+						id
 					},
 					highlight: {
 						features: [{ id: ElevationProfile.HIGHLIGHT_FEATURE_ID, data: [21, 41] }]
@@ -1195,13 +1118,11 @@ describe('ElevationProfile', () => {
 		describe('on pointerup', () => {
 			it('removes the highlight feature from the store', async () => {
 				// arrange
-				const coordinates = fromLonLat([11, 48]);
-
-				spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+				spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 				const element = await setup({
 					elevationProfile: {
 						active: true,
-						coordinates: coordinates
+						id
 					},
 					highlight: {
 						features: [{ id: ElevationProfile.HIGHLIGHT_FEATURE_ID, data: [21, 41] }]
@@ -1222,18 +1143,14 @@ describe('ElevationProfile', () => {
 
 	describe('responsive layout ', () => {
 		it('layouts for landscape', async () => {
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					portrait: false
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			expect(element.shadowRoot.querySelectorAll('.is-landscape')).toHaveSize(1);
@@ -1241,18 +1158,14 @@ describe('ElevationProfile', () => {
 		});
 
 		it('layouts for portrait', async () => {
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					portrait: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			expect(element.shadowRoot.querySelectorAll('.is-landscape')).toHaveSize(0);
@@ -1260,18 +1173,14 @@ describe('ElevationProfile', () => {
 		});
 
 		it('layouts for desktop', async () => {
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					minWidth: true
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			expect(element.shadowRoot.querySelectorAll('.is-tablet')).toHaveSize(0);
@@ -1279,18 +1188,14 @@ describe('ElevationProfile', () => {
 		});
 
 		it('layouts for tablet', async () => {
-			const coordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				media: {
 					minWidth: false
 				},
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				}
 			});
 			expect(element.shadowRoot.querySelectorAll('.is-tablet')).toHaveSize(1);
@@ -1301,12 +1206,11 @@ describe('ElevationProfile', () => {
 	describe('when disconnected', () => {
 		it('removes an existing highlight feature', async () => {
 			// arrange
-			const coordinates = fromLonLat([11, 48]);
-			spyOn(elevationServiceMock, 'getProfile').withArgs(coordinates).and.resolveTo(profile());
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(profile());
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: coordinates
+					id
 				},
 				highlight: {
 					features: [{ id: ElevationProfile.HIGHLIGHT_FEATURE_ID, data: [21, 41] }]
@@ -1324,20 +1228,13 @@ describe('ElevationProfile', () => {
 	describe('when a profile with attribute slope (selected), is replaced by another without slope', () => {
 		it('should use the Default_Selected_Attribute instead', async () => {
 			// arrange
-			const initialCoordinates = [
-				[0, 1],
-				[2, 3]
-			];
-			const secondCoordinates = [
-				[4, 5],
-				[6, 7]
-			];
-			spyOn(elevationServiceMock, 'getProfile').and.returnValues(profile(), profileWithoutSlope());
+			const id2 = 'profileReferenceId2';
+			spyOn(elevationServiceMock, 'fetchProfile').and.returnValues(profile(), profileWithoutSlope());
 
 			const element = await setup({
 				elevationProfile: {
 					active: true,
-					coordinates: initialCoordinates
+					id
 				}
 			});
 			const destroyChartJsSpy = spyOn(element._chart, 'destroy').and.callThrough();
@@ -1348,7 +1245,7 @@ describe('ElevationProfile', () => {
 			const attrs = element.shadowRoot.getElementById('attrs');
 			attrs.value = 'slope';
 			attrs.dispatchEvent(new Event('change'));
-			updateCoordinates(secondCoordinates);
+			indicateChange(id2);
 			await TestUtils.timeout();
 
 			// assert

--- a/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
+++ b/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
@@ -316,7 +316,7 @@ describe('ElevationProfile', () => {
 			const config = chart.config;
 			const datasetZero = config.data.datasets[0];
 
-			// // assert
+			// assert
 			expect(element.shadowRoot.children.length).toBe(3);
 			expect(datasetZero.data).toEqual([]);
 			expect(config.data.labels).toEqual([]);
@@ -419,7 +419,6 @@ describe('ElevationProfile', () => {
 			const config = chart.config;
 
 			// assert
-			// config.options.plugins.title
 			expect(config.options.plugins.title.text).toBe('DGM 25 / DHHN2016');
 		});
 	});

--- a/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
+++ b/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
@@ -93,7 +93,7 @@ describe('OlRoutingHandler', () => {
 		isTouch() {}
 	};
 	const elevationServiceMock = {
-		getProfile() {}
+		requestProfile() {}
 	};
 	const geoResourceServiceMock = {
 		byId() {},
@@ -751,12 +751,11 @@ describe('OlRoutingHandler', () => {
 				const mockRouteStatsProvider = jasmine.createSpy().withArgs(mockGhRoute, mockProfile.stats).and.returnValue(mockStats);
 				const { instanceUnderTest, store } = await newTestInstance({}, mockRouteStatsProvider);
 				const mapServiceSpy = spyOn(mapServiceMock, 'getSrid').and.returnValue(3857);
-				spyOn(elevationServiceMock, 'getProfile').withArgs(jasmine.any(Array)).and.resolveTo(mockProfile);
+				spyOn(elevationServiceMock, 'requestProfile').withArgs(jasmine.any(Array)).and.resolveTo(mockProfile);
 
 				await instanceUnderTest._updateStore(mockGhRoute);
 
 				expect(store.getState().routing.stats).toEqual(mockStats);
-				expect(store.getState().elevationProfile.coordinates.length).toBe(57);
 				expect(store.getState().routing.route.type.name).toBe(SourceTypeName.GEOJSON);
 				expect(store.getState().routing.route.data).toContain('LineString');
 				expect(mapServiceSpy).toHaveBeenCalled();
@@ -785,7 +784,7 @@ describe('OlRoutingHandler', () => {
 					);
 
 					const clearRouteFeaturesSpy = spyOn(instanceUnderTest, '_clearRouteFeatures');
-					spyOn(elevationServiceMock, 'getProfile').withArgs(jasmine.any(Array)).and.rejectWith(message);
+					spyOn(elevationServiceMock, 'requestProfile').withArgs(jasmine.any(Array)).and.rejectWith(message);
 					const errorSpy = spyOn(console, 'error');
 
 					await instanceUnderTest._updateStore(mockGhRoute);

--- a/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
+++ b/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
@@ -8,18 +8,12 @@ import { EventLike } from '../../../../../src/utils/storeUtils';
 import { modalReducer } from '../../../../../src/store/modal/modal.reducer';
 import { IconResult } from '../../../../../src/services/IconService';
 import { IconSelect } from '../../../../../src/modules/iconSelect/components/IconSelect';
-import { Icon } from '../../../../../src/modules/commons/components/icon/Icon';
 import { createNoInitialStateMediaReducer } from '../../../../../src/store/media/media.reducer';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
-import { ElevationProfileChip } from '../../../../../src/modules/chips/components/assistChips/ElevationProfileChip';
-import { ExportVectorDataChip } from '../../../../../src/modules/chips/components/assistChips/ExportVectorDataChip';
 import { elevationProfileReducer } from '../../../../../src/store/elevationProfile/elevationProfile.reducer';
 
-window.customElements.define(Icon.tag, Icon);
-window.customElements.define(IconSelect.tag, IconSelect);
 window.customElements.define(DrawToolContent.tag, DrawToolContent);
-window.customElements.define(ElevationProfileChip.tag, ElevationProfileChip);
-window.customElements.define(ExportVectorDataChip.tag, ExportVectorDataChip);
+window.customElements.define(IconSelect.tag, IconSelect);
 
 describe('DrawToolContent', () => {
 	let store;
@@ -34,12 +28,6 @@ describe('DrawToolContent', () => {
 	};
 
 	const iconServiceMock = { default: () => new IconResult('marker', 'foo'), all: () => [], getIconResult: () => {} };
-
-	const geoResourceServiceMock = {
-		async init() {},
-		all() {},
-		byId() {}
-	};
 
 	const drawDefaultState = {
 		active: false,
@@ -84,7 +72,6 @@ describe('DrawToolContent', () => {
 			})
 			.registerSingleton('TranslationService', { translate: (key) => key })
 			.registerSingleton('IconService', iconServiceMock)
-			.registerSingleton('GeoResourceService', geoResourceServiceMock)
 			.registerSingleton('SecurityService', securityServiceMock);
 		return TestUtils.render(DrawToolContent.tag);
 	};
@@ -684,9 +671,8 @@ describe('DrawToolContent', () => {
 				fileSaveResult: new EventLike({ fileSaveResult: 'foo', content: exportData })
 			});
 			const chipElement = element.shadowRoot.querySelector('ba-export-vector-data-chip');
-			const chipModel = chipElement.getModel();
 
-			expect(chipModel.data).toBe(exportData);
+			expect(chipElement.exportData).toBe(exportData);
 		});
 
 		it('finishes the drawing', async () => {

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -1,14 +1,10 @@
 import { TestUtils } from '../../../../test-utils';
 import { $injector } from '../../../../../src/injection';
 import { MeasureToolContent } from '../../../../../src/modules/toolbox/components/measureToolContent/MeasureToolContent';
-import { Checkbox } from '../../../../../src/modules/commons/components/checkbox/Checkbox';
 import { EventLike } from '../../../../../src/utils/storeUtils';
-import { Icon } from '../../../../../src/modules/commons/components/icon/Icon';
 import { AbstractToolContent } from '../../../../../src/modules/toolbox/components/toolContainer/AbstractToolContent';
 import { modalReducer } from '../../../../../src/store/modal/modal.reducer';
 import { measurementReducer } from '../../../../../src/store/measurement/measurement.reducer';
-import { ElevationProfileChip } from '../../../../../src/modules/chips/components/assistChips/ElevationProfileChip';
-import { ExportVectorDataChip } from '../../../../../src/modules/chips/components/assistChips/ExportVectorDataChip';
 import { notificationReducer } from '../../../../../src/store/notifications/notifications.reducer';
 import { LevelTypes } from '../../../../../src/store/notifications/notifications.action';
 import { isString } from '../../../../../src/utils/checks';
@@ -16,10 +12,6 @@ import { TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
 import { elevationProfileReducer } from '../../../../../src/store/elevationProfile/elevationProfile.reducer';
 
 window.customElements.define(MeasureToolContent.tag, MeasureToolContent);
-window.customElements.define(Checkbox.tag, Checkbox);
-window.customElements.define(ElevationProfileChip.tag, ElevationProfileChip);
-window.customElements.define(ExportVectorDataChip.tag, ExportVectorDataChip);
-window.customElements.define(Icon.tag, Icon);
 
 describe('MeasureToolContent', () => {
 	let store;
@@ -303,9 +295,8 @@ describe('MeasureToolContent', () => {
 			};
 			const element = await setup(state);
 			const chipElement = element.shadowRoot.querySelector('ba-export-vector-data-chip');
-			const chipModel = chipElement.getModel();
 
-			expect(chipModel.data).toBe(exportData);
+			expect(chipElement.exportData).toBe(exportData);
 		});
 
 		it('shows only the length measurement statistics', async () => {

--- a/test/plugins/ElevationProfilePlugin.test.js
+++ b/test/plugins/ElevationProfilePlugin.test.js
@@ -2,8 +2,10 @@ import { ElevationProfilePlugin } from '../../src/plugins/ElevationProfilePlugin
 import { closeProfile, openProfile } from '../../src/store/elevationProfile/elevationProfile.action';
 import { elevationProfileReducer, initialState as elevationProfileInitialState } from '../../src/store/elevationProfile/elevationProfile.reducer';
 import { bottomSheetReducer, initialState as bottomSheetInitialState } from '../../src/store/bottomSheet/bottomSheet.reducer';
+import { featureInfoReducer, initialState as featureInfoInitialState } from '../../src/store/featureInfo/featureInfo.reducer';
 import { TestUtils } from '../test-utils';
 import { closeBottomSheet } from '../../src/store/bottomSheet/bottomSheet.action';
+import { addFeatureInfoItems } from '../../src/store/featureInfo/featureInfo.action';
 import { drawReducer, initialState as drawInitialState } from '../../src/store/draw/draw.reducer';
 import { measurementReducer, initialState as measurementInitialState } from '../../src/store/measurement/measurement.reducer';
 import { deactivate as deactivateDraw } from '../../src/store/draw/draw.action';
@@ -18,6 +20,7 @@ describe('ElevationProfilePlugin', () => {
 			bottomSheet: bottomSheetInitialState,
 			draw: drawInitialState,
 			measurement: measurementInitialState,
+			featureInfo: featureInfoInitialState,
 			...state
 		};
 
@@ -25,7 +28,8 @@ describe('ElevationProfilePlugin', () => {
 			elevationProfile: elevationProfileReducer,
 			bottomSheet: bottomSheetReducer,
 			draw: drawReducer,
-			measurement: measurementReducer
+			measurement: measurementReducer,
+			featureInfo: featureInfoReducer
 		});
 		return store;
 	};
@@ -133,6 +137,25 @@ describe('ElevationProfilePlugin', () => {
 
 			expect(store.getState().elevationProfile.active).toBeFalse();
 			expect(bottomSheetUnsubscribeFnSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('when property `current` of slice-of-state `featureInfo` changes', () => {
+		it('resets the profile id', async () => {
+			const store = setup({
+				elevationProfile: {
+					active: false,
+					id: 'profielId'
+				}
+			});
+			const instanceUnderTest = new ElevationProfilePlugin();
+			await instanceUnderTest.register(store);
+
+			expect(store.getState().elevationProfile.id).not.toBeNull();
+
+			addFeatureInfoItems({});
+
+			expect(store.getState().elevationProfile.id).toBeNull();
 		});
 	});
 });

--- a/test/service/ElevationService.test.js
+++ b/test/service/ElevationService.test.js
@@ -2,13 +2,24 @@ import { $injector } from '../../src/injection';
 import { ElevationService } from '../../src/services/ElevationService';
 import { loadBvvElevation } from '../../src/services/provider/elevation.provider';
 import { getBvvProfile } from '../../src/services/provider/profile.provider';
+import { elevationProfileReducer } from '../../src/store/elevationProfile/elevationProfile.reducer';
+import { hashCode } from '../../src/utils/hashCode';
+import { TestUtils } from '../test-utils';
 
 describe('ElevationService', () => {
 	const environmentService = {
 		isStandalone: () => false
 	};
 
+	let store;
+
 	const setup = (elevationProvider = loadBvvElevation, profileProvider = getBvvProfile) => {
+		store = TestUtils.setupStoreAndDi(
+			{},
+			{
+				elevationProfile: elevationProfileReducer
+			}
+		);
 		$injector.registerSingleton('EnvironmentService', environmentService);
 		return new ElevationService(elevationProvider, profileProvider);
 	};
@@ -90,8 +101,9 @@ describe('ElevationService', () => {
 		});
 	});
 
-	describe('getProfile', () => {
+	describe('_prepareProfile', () => {
 		it('provides a profile', async () => {
+			const id = 'id';
 			const mockProfile = { result: 42 };
 			const instanceUnderTest = setup(null, async () => {
 				return mockProfile;
@@ -101,7 +113,7 @@ describe('ElevationService', () => {
 				[2, 3]
 			];
 
-			const result = await instanceUnderTest.getProfile(mockCoordinates);
+			const result = await instanceUnderTest._prepareProfile(id, mockCoordinates);
 
 			expect(result).toEqual(mockProfile);
 			// results should be always a deep copy
@@ -109,6 +121,7 @@ describe('ElevationService', () => {
 		});
 
 		it('provides a profile from cache', async () => {
+			const id = 'id';
 			const mockProfile = { result: 42 };
 
 			const providerSpy = jasmine.createSpy().and.resolveTo(mockProfile);
@@ -119,8 +132,8 @@ describe('ElevationService', () => {
 				[2, 3]
 			];
 
-			const result0 = await instanceUnderTest.getProfile(mockCoordinates);
-			const result1 = await instanceUnderTest.getProfile(mockCoordinates);
+			const result0 = await instanceUnderTest._prepareProfile(id, mockCoordinates);
+			const result1 = await instanceUnderTest._prepareProfile(id, mockCoordinates);
 
 			expect(result0).toEqual(mockProfile);
 			expect(result1).toEqual(mockProfile);
@@ -129,7 +142,9 @@ describe('ElevationService', () => {
 			expect(result0 === result1).toBeFalse();
 		});
 
-		it('clear the cache', async () => {
+		it('clears the cache', async () => {
+			const id = 'id';
+			const otherId = 'otherId';
 			const mockProfile = { result: 42 };
 
 			const providerSpy = jasmine.createSpy().and.resolveTo(mockProfile);
@@ -144,55 +159,16 @@ describe('ElevationService', () => {
 				[6, 7]
 			];
 
-			await instanceUnderTest.getProfile(mockCoordinates);
-			await instanceUnderTest.getProfile(otherMockCoordinates);
-			await instanceUnderTest.getProfile(mockCoordinates);
+			await instanceUnderTest._prepareProfile(id, mockCoordinates);
+			await instanceUnderTest._prepareProfile(otherId, otherMockCoordinates);
+			await instanceUnderTest._prepareProfile(id, mockCoordinates);
 
 			expect(providerSpy).toHaveBeenCalledTimes(3);
 		});
 
-		it('rejects when backend is not available', async () => {
-			const providerError = new Error('Something got wrong');
-			const instanceUnderTest = setup(null, async () => {
-				throw providerError;
-			});
-			const mockCoordinates = [
-				[0, 1],
-				[2, 3]
-			];
-
-			await expectAsync(instanceUnderTest.getProfile(mockCoordinates)).toBeRejectedWith(
-				jasmine.objectContaining({
-					message: 'Could not load an elevation profile from provider',
-					cause: providerError
-				})
-			);
-		});
-
-		it('rejects when argument is not an Array or does not contain at least two coordinates', async () => {
-			const instanceUnderTest = setup();
-
-			await expectAsync(instanceUnderTest.getProfile('foo')).toBeRejectedWithError(
-				TypeError,
-				"Parameter 'coordinates3857' must be an array containing at least two coordinates"
-			);
-			await expectAsync(instanceUnderTest.getProfile([[0, 1]])).toBeRejectedWithError(
-				TypeError,
-				"Parameter 'coordinates3857' must be an array containing at least two coordinates"
-			);
-		});
-
-		it('rejects when argument contains not only coordinated', async () => {
-			const instanceUnderTest = setup();
-
-			await expectAsync(instanceUnderTest.getProfile([[0, 1], 'foo'])).toBeRejectedWithError(
-				TypeError,
-				"Parameter 'coordinates3857' contains invalid coordinates"
-			);
-		});
-
 		describe('in standalone mode', () => {
 			it('provides a mocked profile', async () => {
+				const id = 'id';
 				const warnSpy = spyOn(console, 'warn');
 				spyOn(environmentService, 'isStandalone').and.returnValue(true);
 				const instanceUnderTest = setup();
@@ -202,7 +178,7 @@ describe('ElevationService', () => {
 					[4, 5]
 				];
 
-				const { elevations, stats, attrs } = await instanceUnderTest.getProfile(mockCoordinates);
+				const { elevations, stats, attrs } = await instanceUnderTest._prepareProfile(id, mockCoordinates);
 
 				expect(elevations).toHaveSize(3);
 				elevations.forEach((el, i) => {
@@ -221,6 +197,97 @@ describe('ElevationService', () => {
 				expect(attrs).toHaveSize(0);
 				expect(warnSpy).toHaveBeenCalledWith('Could not fetch an elevation profile from backend. Returning a mocked profile ...');
 			});
+		});
+	});
+
+	describe('requestProfile', () => {
+		it('rejects when backend is not available', async () => {
+			const providerError = new Error('Something got wrong');
+			const instanceUnderTest = setup(null, async () => {
+				throw providerError;
+			});
+			const mockCoordinates = [
+				[0, 1],
+				[2, 3]
+			];
+
+			await expectAsync(instanceUnderTest.requestProfile(mockCoordinates)).toBeRejectedWith(
+				jasmine.objectContaining({
+					message: 'Could not load an elevation profile from provider',
+					cause: providerError
+				})
+			);
+		});
+
+		it('rejects when argument is not an Array or does not contain at least two coordinates', async () => {
+			const instanceUnderTest = setup();
+
+			await expectAsync(instanceUnderTest.requestProfile('foo')).toBeRejectedWithError(
+				TypeError,
+				"Parameter 'coordinates3857' must be an array containing at least two coordinates"
+			);
+			await expectAsync(instanceUnderTest.requestProfile([[0, 1]])).toBeRejectedWithError(
+				TypeError,
+				"Parameter 'coordinates3857' must be an array containing at least two coordinates"
+			);
+		});
+
+		it('rejects when argument contains not only coordinated', async () => {
+			const instanceUnderTest = setup();
+
+			await expectAsync(instanceUnderTest.requestProfile([[0, 1], 'foo'])).toBeRejectedWithError(
+				TypeError,
+				"Parameter 'coordinates3857' contains invalid coordinates"
+			);
+		});
+
+		it('calls _prepareProfile and updates the elevationProfile s-o-s', async () => {
+			const mockProfile = { result: 42 };
+			const instanceUnderTest = setup(null, async () => {
+				return mockProfile;
+			});
+			const mockCoordinates = [
+				[0, 1],
+				[2, 3]
+			];
+			const id = `${hashCode(mockCoordinates)}`;
+			spyOn(instanceUnderTest, '_prepareProfile').withArgs(id, mockCoordinates).and.resolveTo(mockProfile);
+
+			const result = await instanceUnderTest.requestProfile(mockCoordinates);
+
+			expect(result).toEqual(mockProfile);
+			expect(store.getState().elevationProfile.id).toBe(id);
+		});
+	});
+
+	describe('fetchProfile', () => {
+		it('returns an existing profile result', async () => {
+			const id = 'id';
+			const mockProfile = { result: 42 };
+			const instanceUnderTest = setup(null, async () => {
+				return mockProfile;
+			});
+			const mockCoordinates = [
+				[0, 1],
+				[2, 3]
+			];
+			// cache the profile
+			await instanceUnderTest._prepareProfile(id, mockCoordinates);
+
+			const result = instanceUnderTest.fetchProfile(id);
+
+			expect(result).toEqual(mockProfile);
+			// results should be always a deep copy
+			expect(result === mockProfile).toBeFalse();
+		});
+
+		it('returns NULL when not available', async () => {
+			const id = 'id';
+			const instanceUnderTest = setup();
+
+			const result = instanceUnderTest.fetchProfile(id);
+
+			expect(result).toBeNull();
 		});
 	});
 });

--- a/test/store/evelationProfile/elevationProfile.reducer.test.js
+++ b/test/store/evelationProfile/elevationProfile.reducer.test.js
@@ -1,8 +1,6 @@
-import { closeProfile, indicateChange, openProfile, updateCoordinates } from '../../../src/store/elevationProfile/elevationProfile.action.js';
+import { closeProfile, indicateChange, openProfile } from '../../../src/store/elevationProfile/elevationProfile.action.js';
 import { elevationProfileReducer } from '../../../src/store/elevationProfile/elevationProfile.reducer.js';
-import { EventLike } from '../../../src/utils/storeUtils.js';
 import { TestUtils } from '../../test-utils.js';
-import { hashCode } from '../../../src/utils/hashCode';
 
 describe('elevationProfileReducer', () => {
 	const setup = (state) => {

--- a/test/store/evelationProfile/elevationProfile.reducer.test.js
+++ b/test/store/evelationProfile/elevationProfile.reducer.test.js
@@ -1,6 +1,8 @@
-import { closeProfile, openProfile, updateCoordinates } from '../../../src/store/elevationProfile/elevationProfile.action.js';
+import { closeProfile, indicateChange, openProfile, updateCoordinates } from '../../../src/store/elevationProfile/elevationProfile.action.js';
 import { elevationProfileReducer } from '../../../src/store/elevationProfile/elevationProfile.reducer.js';
+import { EventLike } from '../../../src/utils/storeUtils.js';
 import { TestUtils } from '../../test-utils.js';
+import { hashCode } from '../../../src/utils/hashCode';
 
 describe('elevationProfileReducer', () => {
 	const setup = (state) => {
@@ -12,49 +14,27 @@ describe('elevationProfileReducer', () => {
 	it('initializes the store with default values', () => {
 		const store = setup();
 		expect(store.getState().elevationProfile.active).toBeFalse();
-		expect(store.getState().elevationProfile.coordinates).toEqual([]);
+		expect(store.getState().elevationProfile.id).toBeNull();
 	});
 
-	it("updates the 'active' and optionally the 'coordinates' property", () => {
+	it("updates the 'active'", () => {
 		const store = setup();
 
 		openProfile();
 
 		expect(store.getState().elevationProfile.active).toBeTrue();
-		expect(store.getState().elevationProfile.coordinates).toEqual([]);
 
 		closeProfile();
 
 		expect(store.getState().elevationProfile.active).toBeFalse();
-		expect(store.getState().elevationProfile.coordinates).toEqual([]);
-
-		openProfile([[21]]); //invalid coordinate
-
-		expect(store.getState().elevationProfile.active).toBeFalse();
-		expect(store.getState().elevationProfile.coordinates).toEqual([]);
-
-		openProfile([[21, 42]]);
-
-		expect(store.getState().elevationProfile.active).toBeTrue();
-		expect(store.getState().elevationProfile.coordinates).toEqual([[21, 42]]);
-
-		closeProfile();
-
-		expect(store.getState().elevationProfile.active).toBeFalse();
-		expect(store.getState().elevationProfile.coordinates).toEqual([[21, 42]]);
 	});
 
-	it("updates the 'coordinates' property", () => {
+	it('updates the `changed` property', () => {
 		const store = setup();
+		const id = 'jkhasdu';
 
-		updateCoordinates([[21]]); // invalid coordinate
+		indicateChange(id);
 
-		expect(store.getState().elevationProfile.active).toBeFalse();
-		expect(store.getState().elevationProfile.coordinates).toEqual([]);
-
-		updateCoordinates([[21, 42]]);
-
-		expect(store.getState().elevationProfile.active).toBeFalse();
-		expect(store.getState().elevationProfile.coordinates).toEqual([[21, 42]]);
+		expect(store.getState().elevationProfile.id).toBe(id);
 	});
 });


### PR DESCRIPTION
We avoid pushing huge arrays of coordinates to the store. Detecting changes can be expensive in that case. Instead, we reference them by an identifier and push this identifier to the store.

Fixes #2270