### PR TITLE
add RtVectorGeoResource

### DIFF
--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -37,6 +37,7 @@ export const GeoResourceTypes = Object.freeze({
 	WMS: Symbol.for('wms'),
 	XYZ: Symbol.for('xyz'),
 	VECTOR: Symbol.for('vector'),
+	RT_VECTOR: Symbol.for('rtvector'),
 	VT: Symbol.for('vt'),
 	AGGREGATE: Symbol.for('aggregate'),
 	FUTURE: Symbol.for('future')
@@ -494,7 +495,6 @@ export const VectorSourceType = Object.freeze({
 
 /**
  * GeoResource for vector data.
- * Data could be either loaded externally by Url or internally from a string.
  * @class
  */
 export class VectorGeoResource extends GeoResource {
@@ -600,6 +600,56 @@ export class VectorGeoResource extends GeoResource {
 			.onResolve((resolved, future) => {
 				resolved.copyPropertiesFrom(future);
 			});
+	}
+}
+
+/**
+ * GeoResource for real-time vector data.
+ * @class
+ */
+export class RtVectorGeoResource extends GeoResource {
+	/**
+	 * @param {string} id
+	 * @param {String} label
+	 * @param {String} url
+	 * @param {VectorSourceType} sourceType
+	 */
+	constructor(id, label, url, sourceType) {
+		super(id, label);
+		this._url = url;
+		this._sourceType = sourceType;
+		this._clusterParams = {};
+	}
+
+	get url() {
+		return this._url;
+	}
+
+	get sourceType() {
+		return this._sourceType;
+	}
+
+	get clusterParams() {
+		return { ...this._clusterParams };
+	}
+
+	setClusterParams(clusterParams) {
+		this._clusterParams = { ...clusterParams };
+		return this;
+	}
+
+	/**
+	 * @returns `true` if this RtVectorGeoResource should be displayed clustered
+	 */
+	isClustered() {
+		return !!Object.keys(this._clusterParams).length;
+	}
+
+	/**
+	 * @override
+	 */
+	getType() {
+		return GeoResourceTypes.RT_VECTOR;
 	}
 }
 

--- a/src/modules/olMap/injection/index.js
+++ b/src/modules/olMap/injection/index.js
@@ -21,6 +21,7 @@ export const mapModule = ($injector) => {
 		.register('OlGeolocationHandler', OlGeolocationHandler)
 		.register('OlHighlightLayerHandler', OlHighlightLayerHandler)
 		.register('VectorLayerService', VectorLayerService)
+		.register('RtVectorLayerService', class {}) /**TODO: It's a mock, replace it by the real RtVectorLayerService*/
 		.register('LayerService', LayerService)
 		.register('InteractionStorageService', InteractionStorageService)
 		.register('OverlayService', OverlayService)

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -53,8 +53,9 @@ export class LayerService {
 		const {
 			GeoResourceService: geoResourceService,
 			VectorLayerService: vectorLayerService,
+			RtVectorLayerService: rtVectorLayerService,
 			BaaCredentialService: baaCredentialService
-		} = $injector.inject('GeoResourceService', 'VectorLayerService', 'BaaCredentialService');
+		} = $injector.inject('GeoResourceService', 'VectorLayerService', 'BaaCredentialService', 'RtVectorLayerService');
 
 		const { minZoom, maxZoom, opacity } = geoResource;
 
@@ -136,6 +137,9 @@ export class LayerService {
 
 			case GeoResourceTypes.VECTOR: {
 				return vectorLayerService.createVectorLayer(id, geoResource, olMap);
+			}
+			case GeoResourceTypes.RT_VECTOR: {
+				return rtVectorLayerService.createLayer(id, geoResource, olMap);
 			}
 
 			case GeoResourceTypes.VT: {

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -171,6 +171,6 @@ export class LayerService {
 				return layerGroup;
 			}
 		}
-		throw new Error(geoResource.getType() + ' currently not supported');
+		throw new Error(`GeoResource type "${geoResource.getType().description}" currently not supported`);
 	}
 }

--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -136,7 +136,7 @@ export class LayerService {
 			}
 
 			case GeoResourceTypes.VECTOR: {
-				return vectorLayerService.createVectorLayer(id, geoResource, olMap);
+				return vectorLayerService.createLayer(id, geoResource, olMap);
 			}
 			case GeoResourceTypes.RT_VECTOR: {
 				return rtVectorLayerService.createLayer(id, geoResource, olMap);

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -159,7 +159,7 @@ export class VectorLayerService {
 	 * @param {OlMap} olMap
 	 * @returns olVectorLayer
 	 */
-	createVectorLayer(id, vectorGeoResource, olMap) {
+	createLayer(id, vectorGeoResource, olMap) {
 		const { minZoom, maxZoom, opacity } = vectorGeoResource;
 		const vectorLayer = new VectorLayer({
 			id: id,

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -2,7 +2,15 @@
  * @module services/provider/geoResource_provider
  */
 import { UnavailableGeoResourceError } from '../../domain/errors';
-import { AggregateGeoResource, VectorGeoResource, WmsGeoResource, XyzGeoResource, GeoResourceFuture, VTGeoResource } from '../../domain/geoResources';
+import {
+	AggregateGeoResource,
+	VectorGeoResource,
+	WmsGeoResource,
+	XyzGeoResource,
+	GeoResourceFuture,
+	VTGeoResource,
+	RtVectorGeoResource
+} from '../../domain/geoResources';
 import { SourceTypeName, SourceTypeResultStatus } from '../../domain/sourceType';
 import { $injector } from '../../injection';
 import { isExternalGeoResourceId } from '../../utils/checks';
@@ -34,6 +42,13 @@ export const _definitionToGeoResource = (definition) => {
 				).onResolve((resolved) => {
 					setPropertiesAndProviders(resolved.setClusterParams(def.clusterParams ?? {}));
 				});
+			}
+			case 'rtvector': {
+				return (
+					new RtVectorGeoResource(def.id, def.label, def.url, Symbol.for(def.sourceType))
+						//set specific optional values
+						.setClusterParams(def.clusterParams ?? {})
+				);
 			}
 			case 'aggregate':
 				return new AggregateGeoResource(def.id, def.label, def.geoResourceIds);

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -10,7 +10,8 @@ import {
 	GeoResourceFuture,
 	observable,
 	GeoResourceAuthenticationType,
-	VTGeoResource
+	VTGeoResource,
+	RtVectorGeoResource
 } from '../../src/domain/geoResources';
 import { $injector } from '../../src/injection';
 import { getDefaultAttribution, getMinimalAttribution } from '../../src/services/provider/attribution.provider';
@@ -38,11 +39,12 @@ describe('GeoResource', () => {
 
 	describe('GeoResourceTypes', () => {
 		it('provides an enum of all available types', () => {
-			expect(Object.entries(GeoResourceTypes).length).toBe(6);
+			expect(Object.entries(GeoResourceTypes).length).toBe(7);
 			expect(Object.isFrozen(GeoResourceTypes)).toBeTrue();
 			expect(GeoResourceTypes.WMS.description).toBe('wms');
 			expect(GeoResourceTypes.XYZ.description).toBe('xyz');
 			expect(GeoResourceTypes.VECTOR.description).toBe('vector');
+			expect(GeoResourceTypes.RT_VECTOR.description).toBe('rtvector');
 			expect(GeoResourceTypes.VT.description).toBe('vt');
 			expect(GeoResourceTypes.AGGREGATE.description).toBe('aggregate');
 			expect(GeoResourceTypes.FUTURE.description).toBe('future');
@@ -512,6 +514,31 @@ describe('GeoResource', () => {
 				expect(vectorGeoResource.id).toBe('id');
 				expect(vectorGeoResource.label).toBe(label);
 				expect(vectorGeoResource.data).toBe(data);
+			});
+		});
+	});
+
+	describe('RtVectorGeoResource', () => {
+		it('instantiates a RtVectorGeoResource', () => {
+			const rtVectorGeoResource = new RtVectorGeoResource('id', 'label', 'url', VectorSourceType.KML);
+
+			expect(rtVectorGeoResource.getType()).toEqual(GeoResourceTypes.RT_VECTOR);
+			expect(rtVectorGeoResource.id).toBe('id');
+			expect(rtVectorGeoResource.label).toBe('label');
+			expect(rtVectorGeoResource.url).toBe('url');
+			expect(rtVectorGeoResource.sourceType).toEqual(VectorSourceType.KML);
+		});
+
+		it('provides default properties', () => {
+			const rtVectorGeoResource = new RtVectorGeoResource('id', 'label', VectorSourceType.KML);
+
+			expect(rtVectorGeoResource.clusterParams).toEqual({});
+		});
+
+		describe('methods', () => {
+			it('provides a check for containing a non-default value as clusterParam', () => {
+				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).isClustered()).toBeFalse();
+				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams({ foo: 'bar' }).isClustered()).toBeTrue();
 			});
 		});
 	});

--- a/test/injection/config.test.js
+++ b/test/injection/config.test.js
@@ -6,7 +6,7 @@ import { Injector } from '../../src/injection/core/injector.js';
 describe('injector configuration', () => {
 	it('registers the expected dependencies', () => {
 		expect($injector.isReady()).toBeTrue();
-		expect($injector.count()).toBe(76);
+		expect($injector.count()).toBe(77);
 
 		expect($injector.getScope('ProjectionService')).toBe(Injector.SCOPE_SINGLETON);
 		expect($injector.getScope('ConfigService')).toBe(Injector.SCOPE_SINGLETON);
@@ -78,6 +78,7 @@ describe('injector configuration', () => {
 		expect($injector.getScope('OlGeolocationHandler')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('OlHighlightLayerHandler')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('VectorLayerService')).toBe(Injector.SCOPE_PERLOOKUP);
+		expect($injector.getScope('RtVectorLayerService')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('LayerService')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('InteractionStorageService')).toBe(Injector.SCOPE_PERLOOKUP);
 		expect($injector.getScope('OverlayService')).toBe(Injector.SCOPE_PERLOOKUP);

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -22,7 +22,7 @@ import supported from 'mapbox-gl-supported';
 
 describe('LayerService', () => {
 	const vectorLayerService = {
-		createVectorLayer: () => {}
+		createLayer: () => {}
 	};
 	const rtVectorLayerService = {
 		createLayer: () => {}
@@ -89,7 +89,7 @@ describe('LayerService', () => {
 				const olMap = new Map();
 				const olLayer = new VectorLayer();
 				const vectorGeoResource = new VectorGeoResource('geoResourceId', 'label', VectorSourceType.KML);
-				const vectorLayerServiceSpy = spyOn(vectorLayerService, 'createVectorLayer').and.returnValue(olLayer);
+				const vectorLayerServiceSpy = spyOn(vectorLayerService, 'createLayer').and.returnValue(olLayer);
 
 				instanceUnderTest.toOlLayer(id, vectorGeoResource, olMap);
 

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -3,6 +3,7 @@ import {
 	AggregateGeoResource,
 	GeoResourceAuthenticationType,
 	GeoResourceFuture,
+	RtVectorGeoResource,
 	VectorGeoResource,
 	VectorSourceType,
 	VTGeoResource,
@@ -23,6 +24,9 @@ describe('LayerService', () => {
 	const vectorLayerService = {
 		createVectorLayer: () => {}
 	};
+	const rtVectorLayerService = {
+		createLayer: () => {}
+	};
 	const geoResourceService = {
 		byId: () => {}
 	};
@@ -38,6 +42,7 @@ describe('LayerService', () => {
 		TestUtils.setupStoreAndDi({});
 		$injector
 			.registerSingleton('VectorLayerService', vectorLayerService)
+			.registerSingleton('RtVectorLayerService', rtVectorLayerService)
 			.registerSingleton('GeoResourceService', geoResourceService)
 			.registerSingleton('BaaCredentialService', baaCredentialService);
 	});
@@ -84,11 +89,26 @@ describe('LayerService', () => {
 				const olMap = new Map();
 				const olLayer = new VectorLayer();
 				const vectorGeoResource = new VectorGeoResource('geoResourceId', 'label', VectorSourceType.KML);
-				const vectorSourceForUrlSpy = spyOn(vectorLayerService, 'createVectorLayer').and.returnValue(olLayer);
+				const vectorLayerServiceSpy = spyOn(vectorLayerService, 'createVectorLayer').and.returnValue(olLayer);
 
 				instanceUnderTest.toOlLayer(id, vectorGeoResource, olMap);
 
-				expect(vectorSourceForUrlSpy).toHaveBeenCalledWith(id, vectorGeoResource, olMap);
+				expect(vectorLayerServiceSpy).toHaveBeenCalledWith(id, vectorGeoResource, olMap);
+			});
+		});
+
+		describe('RtVectorGeoResource', () => {
+			it('calls the RtVectorLayerService', () => {
+				const instanceUnderTest = setup();
+				const id = 'id';
+				const olMap = new Map();
+				const olLayer = new VectorLayer();
+				const rtVectorGeoResource = new RtVectorGeoResource('geoResourceId', 'label', 'url', VectorSourceType.KML);
+				const rtVectorLayerServiceSpy = spyOn(rtVectorLayerService, 'createLayer').and.returnValue(olLayer);
+
+				instanceUnderTest.toOlLayer(id, rtVectorGeoResource, olMap);
+
+				expect(rtVectorLayerServiceSpy).toHaveBeenCalledWith(id, rtVectorGeoResource, olMap);
 			});
 		});
 

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -433,10 +433,10 @@ describe('LayerService', () => {
 			expect(() => {
 				instanceUnderTest.toOlLayer(id, {
 					getType() {
-						return 'Unknown';
+						return Symbol.for('Unknown');
 					}
 				});
-			}).toThrowError(/Unknown currently not supported/);
+			}).toThrowError('GeoResource type "Unknown" currently not supported');
 		});
 	});
 });

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -127,7 +127,7 @@ describe('VectorLayerService', () => {
 			instanceUnderTest = new VectorLayerService();
 		};
 
-		describe('createVectorLayer', () => {
+		describe('createLayer', () => {
 			it('returns an ol vector layer for a data based VectorGeoResource', () => {
 				setup();
 				const id = 'id';
@@ -146,7 +146,7 @@ describe('VectorLayerService', () => {
 					.withArgs(jasmine.anything(), olMap)
 					.and.callFake((layer) => layer);
 
-				const olVectorLayer = instanceUnderTest.createVectorLayer(id, vectorGeoresource, olMap);
+				const olVectorLayer = instanceUnderTest.createLayer(id, vectorGeoresource, olMap);
 
 				expect(sanitizeSpy).toHaveBeenCalledWith(olVectorLayer);
 
@@ -175,7 +175,7 @@ describe('VectorLayerService', () => {
 					.withArgs(jasmine.anything())
 					.and.callFake((layer) => layer);
 
-				const olVectorLayer = instanceUnderTest.createVectorLayer(id, vectorGeoresource, olMap);
+				const olVectorLayer = instanceUnderTest.createLayer(id, vectorGeoresource, olMap);
 
 				expect(olVectorLayer.get('id')).toBe(id);
 				expect(olVectorLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -204,7 +204,7 @@ describe('VectorLayerService', () => {
 					.withArgs(jasmine.anything(), olMap)
 					.and.callFake((layer) => layer);
 
-				const olVectorLayer = instanceUnderTest.createVectorLayer(id, vectorGeoResource, olMap);
+				const olVectorLayer = instanceUnderTest.createLayer(id, vectorGeoResource, olMap);
 
 				expect(olVectorLayer.get('id')).toBe(id);
 				expect(olVectorLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -234,7 +234,7 @@ describe('VectorLayerService', () => {
 					.withArgs(jasmine.anything())
 					.and.callFake((layer) => layer);
 
-				const olVectorLayer = instanceUnderTest.createVectorLayer(id, vectorGeoResource, olMap);
+				const olVectorLayer = instanceUnderTest.createLayer(id, vectorGeoResource, olMap);
 
 				expect(olVectorLayer.get('id')).toBe(id);
 				expect(olVectorLayer.get('geoResourceId')).toBe(geoResourceId);

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -102,7 +102,7 @@ describe('GeoResource provider', () => {
 		...vtDefinition
 	};
 	const vectorDefinition = {
-		id: 'xyzId',
+		id: 'vectorId',
 		label: 'vectorLabel',
 		url: 'vectorUrl',
 		sourceType: 'kml',
@@ -120,6 +120,26 @@ describe('GeoResource provider', () => {
 		exportable: false,
 		authRoles: ['TEST'],
 		...vectorDefinition
+	};
+	const rtVectorDefinition = {
+		id: 'rtVectorId',
+		label: 'rtVectorLabel',
+		url: 'rtVectorUrl',
+		sourceType: 'kml',
+		type: 'rtvector',
+		attribution: basicAttribution
+	};
+	const rtVectorDefinitionOptionalProperties = {
+		clusterParams: { foo: 'bar' },
+		background: true,
+		opacity: 0.5,
+		hidden: true,
+		minZoom: 5,
+		maxZoom: 19,
+		queryable: false,
+		exportable: false,
+		authRoles: ['TEST'],
+		...rtVectorDefinition
 	};
 	const aggregateDefinition = {
 		id: 'xyzId',
@@ -271,6 +291,29 @@ describe('GeoResource provider', () => {
 			await expectAsync(_definitionToGeoResource(vectorDefinition).get()).toBeRejectedWith(
 				new UnavailableGeoResourceError(`VectorGeoResource for '${vectorDefinition.url}' could not be loaded`, vectorDefinition.id, 404)
 			);
+		});
+
+		it('maps a RTVectorFile BVV definition to a corresponding GeoResource instance', () => {
+			const rtVectorGeoResource = _definitionToGeoResource(rtVectorDefinition);
+
+			validateGeoResourceProperties(rtVectorGeoResource, rtVectorDefinition);
+			expect(rtVectorGeoResource.url).toBe(rtVectorDefinition.url);
+			expect(rtVectorGeoResource.sourceType).toBe(Symbol.for(vectorDefinition.sourceType));
+			expect(rtVectorGeoResource._attributionProvider).toBe(getBvvAttribution);
+			expect(rtVectorGeoResource._attribution).not.toBeNull();
+		});
+
+		it('maps a RTVectorFile BVV definition with optional properties to a corresponding GeoResource instance',  () => {
+			const rtVectorGeoResource = _definitionToGeoResource(rtVectorDefinitionOptionalProperties)
+
+			expect(rtVectorGeoResource.opacity).toBe(0.5);
+			expect(rtVectorGeoResource.hidden).toBeTrue();
+			expect(rtVectorGeoResource.minZoom).toBe(5);
+			expect(rtVectorGeoResource.maxZoom).toBe(19);
+			expect(rtVectorGeoResource.clusterParams).toEqual({ foo: 'bar' });
+			expect(rtVectorGeoResource.queryable).toBeFalse();
+			expect(rtVectorGeoResource.exportable).toBeFalse();
+			expect(rtVectorGeoResource.authRoles).toEqual(['TEST']);
 		});
 
 		it('maps a aggregate BVV definition to a corresponding GeoResource instance', () => {

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -303,8 +303,8 @@ describe('GeoResource provider', () => {
 			expect(rtVectorGeoResource._attribution).not.toBeNull();
 		});
 
-		it('maps a RTVectorFile BVV definition with optional properties to a corresponding GeoResource instance',  () => {
-			const rtVectorGeoResource = _definitionToGeoResource(rtVectorDefinitionOptionalProperties)
+		it('maps a RTVectorFile BVV definition with optional properties to a corresponding GeoResource instance', () => {
+			const rtVectorGeoResource = _definitionToGeoResource(rtVectorDefinitionOptionalProperties);
 
 			expect(rtVectorGeoResource.opacity).toBe(0.5);
 			expect(rtVectorGeoResource.hidden).toBeTrue();


### PR DESCRIPTION
Add support for `RtVectorGeoresources`

- [x] parse the `RtVectorGeoresource`  definition served by the backend
- [x] call the #2275 from the `LayersService`