### PR TITLE
remove non-allowed GeoResources on sign-out only when initiated by the user

### DIFF
--- a/src/plugins/AuthPlugin.js
+++ b/src/plugins/AuthPlugin.js
@@ -50,7 +50,7 @@ export class AuthPlugin extends BaPlugin {
 		}
 
 		const onSignOut = (signedIn, state) => {
-			if (!signedIn) {
+			if (!signedIn && state.auth.byUser) {
 				state.layers.active.forEach((l) => {
 					if (!this.#geoResourceService.isAllowed(l.geoResourceId)) {
 						removeLayer(l.id);

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -112,7 +112,7 @@ export class AuthService {
 			const result = await this._singOutProvider();
 			if (result) {
 				this._roles = [];
-				setSignedOut();
+				setSignedOut(true);
 			}
 			return result;
 		}
@@ -126,7 +126,7 @@ export class AuthService {
 	invalidate() {
 		if (this.isSignedIn()) {
 			this._roles = [];
-			setSignedOut();
+			setSignedOut(false);
 			return true;
 		}
 		return false;

--- a/src/store/auth/auth.action.js
+++ b/src/store/auth/auth.action.js
@@ -15,17 +15,17 @@ const getStore = () => {
 export const setSignedIn = () => {
 	getStore().dispatch({
 		type: AUTH_STATUS_CHANGED,
-		payload: true
+		payload: { signedIn: true, byUser: true }
 	});
 };
 
 /**
- *
  * Changes the auth status to signed out
+ * @param {boolean} byUser `true` if the User requested a sign out
  */
-export const setSignedOut = () => {
+export const setSignedOut = (byUser) => {
 	getStore().dispatch({
 		type: AUTH_STATUS_CHANGED,
-		payload: false
+		payload: { signedIn: false, byUser }
 	});
 };

--- a/src/store/auth/auth.reducer.js
+++ b/src/store/auth/auth.reducer.js
@@ -1,16 +1,25 @@
 export const AUTH_STATUS_CHANGED = 'auth/statusChanged';
 
 export const initialState = {
-	signedIn: false
+	/**
+	 * @param {boolen} signedIn The current status, `true if the User is authenticated
+	 */
+	signedIn: false,
+	/**
+	 * @param {boolean} byUser `true` if the current status was triggered by the User (e.g. clicks the sign-out button)
+	 */
+	byUser: false
 };
 
 export const authReducer = (state = initialState, action) => {
 	const { type, payload } = action;
 	switch (type) {
 		case AUTH_STATUS_CHANGED: {
+			const { signedIn, byUser } = payload;
 			return {
 				...state,
-				signedIn: payload
+				signedIn,
+				byUser
 			};
 		}
 	}

--- a/test/plugins/AuthPlugin.test.js
+++ b/test/plugins/AuthPlugin.test.js
@@ -98,7 +98,7 @@ describe('AuthPlugin', () => {
 				expect(store.getState().layers.active[0].id).toBe(layer0.id);
 			});
 		});
-		
+
 		describe('NOT triggered by the user', () => {
 			it('does nothing', async () => {
 				const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };

--- a/test/plugins/AuthPlugin.test.js
+++ b/test/plugins/AuthPlugin.test.js
@@ -74,28 +74,52 @@ describe('AuthPlugin', () => {
 	});
 
 	describe('when auth "signedIn" property changes', () => {
-		it('removes now non-accessible layers', async () => {
-			const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };
-			const layer1 = { ...createDefaultLayerProperties(), id: 'id1', geoResourceId: 'geoResourceId1' };
-			const store = setup({
-				auth: {
-					signedIn: true
-				},
-				layers: {
-					active: [layer0, layer1]
-				}
-			});
-			spyOn(geoResourceService, 'isAllowed').and.callFake((geoResourceId) => {
-				return geoResourceId === layer1.geoResourceId ? false : true;
-			});
-			const instanceUnderTest = new AuthPlugin();
-			await instanceUnderTest.register(store);
+		describe('triggered by the user', () => {
+			it('removes now non-accessible layers', async () => {
+				const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };
+				const layer1 = { ...createDefaultLayerProperties(), id: 'id1', geoResourceId: 'geoResourceId1' };
+				const store = setup({
+					auth: {
+						signedIn: true
+					},
+					layers: {
+						active: [layer0, layer1]
+					}
+				});
+				spyOn(geoResourceService, 'isAllowed').and.callFake((geoResourceId) => {
+					return geoResourceId === layer1.geoResourceId ? false : true;
+				});
+				const instanceUnderTest = new AuthPlugin();
+				await instanceUnderTest.register(store);
 
-			setSignedOut();
+				setSignedOut(true);
 
-			expect(store.getState().layers.active.length).toBe(1);
-			expect(store.getState().layers.active[0].id).toBe(layer0.id);
+				expect(store.getState().layers.active.length).toBe(1);
+				expect(store.getState().layers.active[0].id).toBe(layer0.id);
+			});
 		});
+		
+		describe('NOT triggered by the user', () => {
+			it('does nothing', async () => {
+				const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };
+				const layer1 = { ...createDefaultLayerProperties(), id: 'id1', geoResourceId: 'geoResourceId1' };
+				const store = setup({
+					auth: {
+						signedIn: true
+					},
+					layers: {
+						active: [layer0, layer1]
+					}
+				});
+				const instanceUnderTest = new AuthPlugin();
+				await instanceUnderTest.register(store);
+
+				setSignedOut(false);
+
+				expect(store.getState().layers.active.length).toBe(2);
+			});
+		});
+
 		it('does nothing on sign-in', async () => {
 			const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };
 			const layer1 = { ...createDefaultLayerProperties(), id: 'id1', geoResourceId: 'geoResourceId1' };

--- a/test/service/AuthService.test.js
+++ b/test/service/AuthService.test.js
@@ -155,6 +155,7 @@ describe('AuthService', () => {
 					await expectAsync(instanceUnderTest.signOut()).toBeResolvedTo(true);
 					expect(instanceUnderTest.getRoles()).toEqual([]);
 					expect(store.getState().auth.signedIn).toBeFalse();
+					expect(store.getState().auth.byUser).toBeTrue();
 				});
 			});
 
@@ -207,6 +208,7 @@ describe('AuthService', () => {
 				expect(result).toBeTrue();
 				expect(instanceUnderTest.getRoles()).toEqual([]);
 				expect(store.getState().auth.signedIn).toBeFalse();
+				expect(store.getState().auth.byUser).toBeFalse();
 			});
 		});
 		describe('the user is NOT signed in', () => {

--- a/test/store/auth/auth.reducer.test.js
+++ b/test/store/auth/auth.reducer.test.js
@@ -12,6 +12,7 @@ describe('authReducer', () => {
 	it('initializes the store with default values', () => {
 		const store = setup();
 		expect(store.getState().auth.signedIn).toBeFalse();
+		expect(store.getState().auth.byUser).toBeFalse();
 	});
 
 	it('updates the stores properties', () => {
@@ -20,9 +21,18 @@ describe('authReducer', () => {
 		setSignedIn();
 
 		expect(store.getState().auth.signedIn).toBeTrue();
+		expect(store.getState().auth.byUser).toBeTrue();
 
-		setSignedOut();
+		setSignedOut(true);
 
 		expect(store.getState().auth.signedIn).toBeFalse();
+		expect(store.getState().auth.byUser).toBeTrue();
+
+		setSignedIn();
+
+		setSignedOut(false);
+
+		expect(store.getState().auth.signedIn).toBeFalse();
+		expect(store.getState().auth.byUser).toBeFalse();
 	});
 });


### PR DESCRIPTION
Session invalidation due to session timeout should keep the active GeoResources, so the user can continue without re-selecting them