### PR TITLE
OlStyleUtils: remove tests with ol image load

### DIFF
--- a/test/modules/olMap/util/olStyleUtils.test.js
+++ b/test/modules/olMap/util/olStyleUtils.test.js
@@ -433,7 +433,6 @@ describe('defaultStyleFunction', () => {
 });
 
 describe('markerStyleFunction', () => {
-	const imageLoadDelayTime = 80;
 	it('should return a style', () => {
 		const styles = markerStyleFunction();
 
@@ -461,40 +460,6 @@ describe('markerStyleFunction', () => {
 		expect(image.getColor()).toEqual([190, 218, 85, 1]);
 		expect(image.getScale()).toBe(0.5);
 		expect(styles[0].getImage().getSrc()).toBe(markerIcon);
-	});
-
-	it('should return a style with a default anchor', async () => {
-		const styleOption = { color: '#BEDA55', scale: 'small', anchor: null };
-		spyOn(environmentService, 'isStandalone').and.returnValue(() => true);
-		const styles = markerStyleFunction(styleOption);
-
-		expect(styles).toBeDefined();
-		const iconStyle = styles[0].getImage();
-		expect(iconStyle).toBeTruthy();
-
-		// we must preload the IconImage and wait until the image-resource is loaded, to get valid
-		// a normalized anchor
-		iconStyle.load();
-		await TestUtils.timeout(imageLoadDelayTime);
-
-		expect(iconStyle.getAnchor()).toEqual([16, 16]); // the default markerIcon have a size of 32x32 px
-	});
-
-	it('should return a style with a specific anchor', async () => {
-		const styleOption = { color: '#BEDA55', scale: 'large', anchor: [1, 1] };
-		spyOn(environmentService, 'isStandalone').and.returnValue(() => true);
-		const styles = markerStyleFunction(styleOption);
-
-		expect(styles).toBeDefined();
-		const iconStyle = styles[0].getImage();
-		expect(iconStyle).toBeTruthy();
-
-		// we must preload the IconImage and wait until the image-resource is loaded, to get valid
-		// a normalized anchor
-		iconStyle.load();
-		await TestUtils.timeout(imageLoadDelayTime);
-
-		expect(iconStyle.getAnchor()).toEqual([32, 32]); // the default markerIcon have a size of 32x32 px
 	});
 
 	it('should return a style with a Text', () => {
@@ -563,6 +528,17 @@ describe('markerStyleFunction', () => {
 
 		expect(image.getColor()).toEqual([190, 218, 85, 1]);
 		expect(image.getScale()).toBe(0.75);
+	});
+
+	it('should return a style specified as remote raster icon', () => {
+		const styleOption = { symbolSrc: 'http://url.to/raster.resource', color: '#BEDA55', scale: 0.75 };
+		const styles = markerStyleFunction(styleOption);
+
+		expect(styles).toBeDefined();
+		const image = styles[0].getImage();
+		expect(image).toBeTruthy();
+
+		expect(styles[0].getImage().getSrc()).toBe(styleOption.symbolSrc);
 	});
 });
 


### PR DESCRIPTION
remove flaky tests and replace with a test which tests the usage of a raster image source for the IconStyle