### PR TITLE
OlMap: remove obsolete network s-o-s update

### DIFF
--- a/src/modules/olMap/components/OlMap.js
+++ b/src/modules/olMap/components/OlMap.js
@@ -17,7 +17,6 @@ import { setBeingMoved, setMoveEnd, setMoveStart } from '../../../store/map/map.
 import VectorSource from 'ol/source/Vector';
 import { Group as LayerGroup } from 'ol/layer';
 import { GeoResourceFuture, GeoResourceTypes } from '../../../domain/geoResources';
-import { setFetching } from '../../../store/network/network.action';
 import { emitNotification, LevelTypes } from '../../../store/notifications/notifications.action';
 import { equals } from '../../../utils/storeUtils';
 import { roundCenter, roundRotation, roundZoomLevel } from '../../../utils/mapUtils';
@@ -228,9 +227,6 @@ export class OlMap extends MvuElement {
 		this._map.on('pointerdrag', () => {
 			setBeingDragged(true);
 		});
-
-		this._map.on('loadstart', () => setFetching(true));
-		this._map.on('loadend', () => setFetching(false));
 
 		this._mapHandler.forEach((handler) => {
 			handler.register(this._map);

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -354,20 +354,6 @@ describe('OlMap', () => {
 		});
 	});
 
-	describe('map load events', () => {
-		it("updates the 'fetching' property in network store", async () => {
-			const element = await setup();
-
-			simulateMapEvent(element._map, MapEventType.LOADSTART);
-
-			expect(store.getState().network.fetching).toBeTrue();
-
-			simulateMapEvent(element._map, MapEventType.LOADEND);
-
-			expect(store.getState().network.fetching).toBeFalse();
-		});
-	});
-
 	describe('map move events', () => {
 		describe('movestart', () => {
 			it("updates the 'movestart' property in map store", async () => {


### PR DESCRIPTION
Almost all GeoResources(except for the VtGeoResources) are loaded via the NetworkStateSyncHttpService now so there's no need for the ol.Map to update the network s-o-s itsself.

Fixes #2346