### PR TITLE
olGeometryUtils: update behavior of multiLineStringToLineString

### DIFF
--- a/src/modules/olMap/utils/olGeometryUtils.js
+++ b/src/modules/olMap/utils/olGeometryUtils.js
@@ -33,13 +33,19 @@ export const getLineString = (geometry) => {
 };
 
 /**
+ * Creates a LineString form the parts of the MultiLineString.
+ *
+ * Limitation:
+ * - geometry MUST be a MultiLineString
+ * - all parts must be connected by its start and end nodes
+ *
  * @function
  * @param {MultiLineString} multiLineString
- * @returns {LineString} ol LineString
+ * @returns {Geometry | null} the coerced LineString or null
  */
 export const multiLineStringToLineString = (multiLineString) => {
 	if (!(multiLineString instanceof MultiLineString)) {
-		return multiLineString;
+		return null;
 	}
 
 	const isConnected = (a, b) => {
@@ -62,7 +68,7 @@ export const multiLineStringToLineString = (multiLineString) => {
 			break;
 		}
 	}
-	return coordinates.length === 0 ? multiLineString : new LineString(coordinates);
+	return coordinates.length === 0 ? null : new LineString(coordinates);
 };
 
 /**

--- a/test/modules/olMap/util/olGeometryUtils.test.js
+++ b/test/modules/olMap/util/olGeometryUtils.test.js
@@ -924,12 +924,13 @@ describe('getBoundingBoxFrom', () => {
 				[7, 1]
 			])
 		]);
+
 		it('does NOT create a LineString', () => {
-			expect(multiLineStringToLineString(point)).toBe(point);
-			expect(multiLineStringToLineString(lineString)).toBe(lineString);
-			expect(multiLineStringToLineString(linearRing)).toBe(linearRing);
-			expect(multiLineStringToLineString(polygon)).toBe(polygon);
-			expect(multiLineStringToLineString(disconnectedMultLineString)).toBe(disconnectedMultLineString);
+			expect(multiLineStringToLineString(point)).toBeNull();
+			expect(multiLineStringToLineString(lineString)).toBeNull();
+			expect(multiLineStringToLineString(linearRing)).toBeNull();
+			expect(multiLineStringToLineString(polygon)).toBeNull();
+			expect(multiLineStringToLineString(disconnectedMultLineString)).toBeNull();
 		});
 
 		it('creates a LineString', () => {

--- a/test/modules/olMap/util/olGeometryUtils.test.js
+++ b/test/modules/olMap/util/olGeometryUtils.test.js
@@ -805,7 +805,7 @@ describe('getBoundingBoxFrom', () => {
 			])
 		]);
 
-		const multLineString = new MultiLineString([
+		const multiLineString = new MultiLineString([
 			new LineString([
 				[0, 0],
 				[42, 42],
@@ -815,6 +815,23 @@ describe('getBoundingBoxFrom', () => {
 				[3, 5],
 				[21, 21],
 				[1, 1]
+			])
+		]);
+		const disconnectedMultiLineString = new MultiLineString([
+			new LineString([
+				[0, 0],
+				[42, 42],
+				[3, 5]
+			]),
+			new LineString([
+				[3, 5],
+				[21, 21],
+				[1, 1]
+			]),
+			new LineString([
+				[4, 1],
+				[12, 12],
+				[7, 1]
 			])
 		]);
 
@@ -845,7 +862,7 @@ describe('getBoundingBoxFrom', () => {
 				[3, 5]
 			]);
 
-			const fromMultiLineString = getLineString(multLineString);
+			const fromMultiLineString = getLineString(multiLineString);
 			expect(fromMultiLineString).toBeInstanceOf(LineString);
 			expect(fromMultiLineString.getCoordinates()).toEqual([
 				[0, 0],
@@ -859,6 +876,7 @@ describe('getBoundingBoxFrom', () => {
 
 		it('does NOT create a LineString', () => {
 			expect(getLineString(point)).toBeNull();
+			expect(getLineString(disconnectedMultiLineString)).toBeNull();
 		});
 	});
 
@@ -881,7 +899,7 @@ describe('getBoundingBoxFrom', () => {
 				[0, 0]
 			]
 		]);
-		const pseudoMultLineString = new MultiLineString([
+		const pseudoMultiLineString = new MultiLineString([
 			new LineString([
 				[0, 0],
 				[42, 42],
@@ -889,7 +907,7 @@ describe('getBoundingBoxFrom', () => {
 			])
 		]);
 
-		const connectedMultLineString = new MultiLineString([
+		const connectedMultiLineString = new MultiLineString([
 			new LineString([
 				[0, 0],
 				[42, 42],
@@ -907,7 +925,7 @@ describe('getBoundingBoxFrom', () => {
 			])
 		]);
 
-		const disconnectedMultLineString = new MultiLineString([
+		const disconnectedMultiLineString = new MultiLineString([
 			new LineString([
 				[0, 0],
 				[42, 42],
@@ -930,11 +948,11 @@ describe('getBoundingBoxFrom', () => {
 			expect(multiLineStringToLineString(lineString)).toBeNull();
 			expect(multiLineStringToLineString(linearRing)).toBeNull();
 			expect(multiLineStringToLineString(polygon)).toBeNull();
-			expect(multiLineStringToLineString(disconnectedMultLineString)).toBeNull();
+			expect(multiLineStringToLineString(disconnectedMultiLineString)).toBeNull();
 		});
 
 		it('creates a LineString', () => {
-			const fromPseudoMultiLineString = getLineString(pseudoMultLineString);
+			const fromPseudoMultiLineString = getLineString(pseudoMultiLineString);
 			expect(fromPseudoMultiLineString).toBeInstanceOf(LineString);
 			expect(fromPseudoMultiLineString.getCoordinates()).toEqual([
 				[0, 0],
@@ -942,7 +960,7 @@ describe('getBoundingBoxFrom', () => {
 				[3, 5]
 			]);
 
-			const fromConnectedMultiLineString = getLineString(connectedMultLineString);
+			const fromConnectedMultiLineString = getLineString(connectedMultiLineString);
 			expect(fromConnectedMultiLineString).toBeInstanceOf(LineString);
 			expect(fromConnectedMultiLineString.getCoordinates()).toEqual([
 				[0, 0],


### PR DESCRIPTION
fixes #2368

Updates the behavior of multiLineStringToLineString to return null, when the given geometry did not match the geometry validation.

Valid geometry is:
- GeometryType -> MultiLineString
- all parts must be connected by its start and end nodes
