### PR TITLE
ElevationProfile: fix gradient calculation 

### DIFF
--- a/src/modules/elevationProfile/components/panel/ElevationProfile.js
+++ b/src/modules/elevationProfile/components/panel/ElevationProfile.js
@@ -455,14 +455,18 @@ export class ElevationProfile extends MvuElement {
 	}
 
 	_getSlopeGradient(chart, elevationData) {
+		/** Elevation data points should come with equal distances by interpolation, but in some edge cases
+		 *  (i. e. from routing results), the equality of distance is broken up on connection points.
+		 *
+		 * Thats why we rely on the elevation-element 'dist' property to calculate always a valid xPoint.
+		 * */
 		const { ctx, chartArea } = chart;
 		const gradientBg = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0);
-		const numberOfPoints = elevationData.elevations.length;
-		const xPointWidth = chartArea.width / numberOfPoints;
+		const distance = elevationData.elevations.at(-1).dist; // the dist-property contains ascending values, starting by ZERO to the final distance of the elevation profile
 
-		elevationData?.elevations.forEach((element, index) => {
-			if (isNumber(element.slope)) {
-				const xPoint = (xPointWidth / chartArea.width) * index;
+		elevationData?.elevations.forEach((element) => {
+			if (isNumber(element.slope) && isNumber(element.dist)) {
+				const xPoint = element.dist / distance;
 				const slopeValue = Math.abs(element.slope);
 				const slopeClass = SoterSlopeClasses.find((c) => c.min <= slopeValue && c.max > slopeValue);
 

--- a/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
+++ b/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
@@ -650,6 +650,64 @@ describe('ElevationProfile', () => {
 			expect(gradientSpy).toHaveBeenCalledWith(jasmine.any(Number), '#d23600');
 		});
 
+		it('returns a gradient that uses the elevation dist property to place the color stop', async () => {
+			// arrange
+			const unequalElevations = [
+				{
+					dist: 0,
+					z: 0,
+					e: 40,
+					n: 50,
+					slope: 0
+				},
+				{
+					dist: 1,
+					z: 10,
+					e: 41,
+					n: 51,
+					slope: 0
+				},
+				{
+					dist: 4,
+					z: 20,
+					e: 42,
+					n: 52,
+					slope: 1
+				},
+				{
+					dist: 10,
+					z: 30,
+					e: 43,
+					n: 53,
+					slope: 7
+				}
+			];
+			const elevationData = { ...profileSlopeSteep(), elevations: unequalElevations };
+			spyOn(elevationServiceMock, 'fetchProfile').withArgs(id).and.resolveTo(elevationData);
+			const element = await setup({
+				elevationProfile: {
+					active: true,
+					id
+				}
+			});
+
+			const gradientMock = {
+				addColorStop: () => {}
+			};
+			const ctxMock = { createLinearGradient: () => gradientMock };
+			const chartMock = { ctx: ctxMock, chartArea: { left: 1, right: 1, width: 1, height: 1 } };
+			const gradientSpy = spyOn(gradientMock, 'addColorStop').and.callThrough();
+
+			// act
+			element._getSlopeGradient(chartMock, elevationData);
+
+			// assert
+			expect(gradientSpy).toHaveBeenCalledWith(0, jasmine.any(String));
+			expect(gradientSpy).toHaveBeenCalledWith(0.1, jasmine.any(String));
+			expect(gradientSpy).toHaveBeenCalledWith(0.4, jasmine.any(String));
+			expect(gradientSpy).toHaveBeenCalledWith(1, jasmine.any(String));
+		});
+
 		it('executes the branch "TextType" for "selectedAttribute surface"', async () => {
 			// arrange
 			const elevationData = profile();


### PR DESCRIPTION
Fix the calculation of gradiant colorstops to maintain correct x-coordinate relative to the elements distance from profile start.