### PR TITLE
optimize routing-related query parameter handling

### DIFF
--- a/src/plugins/RoutingPlugin.js
+++ b/src/plugins/RoutingPlugin.js
@@ -62,30 +62,35 @@ export class RoutingPlugin extends BaPlugin {
 		this.#routingService = routingService;
 	}
 
+	async _lazyInitialize() {
+		if (!this._initialized) {
+			// let's initial the routing service
+			try {
+				await this.#routingService.init();
+				setCategory(this.#routingService.getCategories()[0]?.id);
+				// parse query parameters if available
+				this._parseRouteFromQueryParams(this.#environmentService.getQueryParams());
+				return (this._initialized = true);
+			} catch (ex) {
+				console.error('Routing service could not be initialized', ex);
+				emitNotification(`${this.#translationService.translate('global_routingService_init_exception')}`, LevelTypes.ERROR);
+			}
+			return false;
+		}
+		return true;
+	}
+
 	/**
 	 * @override
 	 */
 	async register(store) {
-		const lazyInitialize = async () => {
-			if (!this._initialized) {
-				// let's initial the routing service
-				try {
-					await this.#routingService.init();
-					setCategory(this.#routingService.getCategories()[0]?.id);
-					// parse query parameters if available
-					this._parseRouteFromQueryParams(this.#environmentService.getQueryParams());
-					return (this._initialized = true);
-				} catch (ex) {
-					console.error('Routing service could not be initialized', ex);
-					emitNotification(`${this.#translationService.translate('global_routingService_init_exception')}`, LevelTypes.ERROR);
-				}
-				return false;
-			}
-			return true;
-		};
-
 		if (!this.#environmentService.isEmbedded() && this.#environmentService.getQueryParams().has(QueryParameters.ROUTE_WAYPOINTS)) {
-			setCurrentTool(Tools.ROUTING); // implicitly calls onToolChanged()
+			if (await this._lazyInitialize()) {
+				// we activate the tool after another possible active tool was deactivated
+				setTimeout(() => {
+					activate();
+				});
+			}
 		}
 
 		const onToolChanged = async (toolId) => {
@@ -94,7 +99,7 @@ export class RoutingPlugin extends BaPlugin {
 				closeBottomSheet();
 				deactivate();
 			} else {
-				if (await lazyInitialize()) {
+				if (await this._lazyInitialize()) {
 					// we activate the tool after another possible active tool was deactivated
 					setTimeout(() => {
 						activate();

--- a/src/plugins/ToolsPlugin.js
+++ b/src/plugins/ToolsPlugin.js
@@ -27,7 +27,7 @@ export class ToolsPlugin extends BaPlugin {
 		// check if we have a query parameter defining the tool id
 		const toolId = environmentService.getQueryParams().get(QueryParameters.TOOL_ID);
 		if (
-			Object.values(Tools).includes(toolId) &&
+			(Object.values(Tools).includes(toolId) || environmentService.getQueryParams().has(QueryParameters.ROUTE_WAYPOINTS)) &&
 			/**in embed mode we check the list of allowed tools*/ (!environmentService.isEmbedded() || WcTools.includes(toolId))
 		) {
 			/**

--- a/src/plugins/ToolsPlugin.js
+++ b/src/plugins/ToolsPlugin.js
@@ -6,7 +6,7 @@ import { setCurrentTool } from '../store/tools/tools.action';
 import { QueryParameters } from '../domain/queryParameters';
 import { $injector } from '../injection';
 import { WcTools, Tools } from '../domain/tools';
-import { observe } from '../utils/storeUtils';
+import { observe, observeOnce } from '../utils/storeUtils';
 
 /**
  * This plugin checks for the presence of the query parameter `TOOL_ID` (see {@link QueryParameters})
@@ -24,13 +24,24 @@ export class ToolsPlugin extends BaPlugin {
 	async register(store) {
 		const { EnvironmentService: environmentService } = $injector.inject('EnvironmentService');
 
-		// check if we have a query parameter defining the tab id
+		// check if we have a query parameter defining the tool id
 		const toolId = environmentService.getQueryParams().get(QueryParameters.TOOL_ID);
 		if (
 			Object.values(Tools).includes(toolId) &&
 			/**in embed mode we check the list of allowed tools*/ (!environmentService.isEmbedded() || WcTools.includes(toolId))
 		) {
-			setCurrentTool(toolId);
+			/**
+			 * When we have route waypoint we activate the current tool after the route was loaded
+			 */
+			if (environmentService.getQueryParams().has(QueryParameters.ROUTE_WAYPOINTS)) {
+				observeOnce(
+					store,
+					(state) => state.routing.route,
+					() => setCurrentTool(toolId)
+				);
+			} else {
+				setCurrentTool(toolId);
+			}
 		}
 
 		if (environmentService.isEmbeddedAsWC()) {

--- a/test/plugins/RoutingPlugin.test.js
+++ b/test/plugins/RoutingPlugin.test.js
@@ -20,6 +20,8 @@ import { closeBottomSheet } from '../../src/store/bottomSheet/bottomSheet.action
 import { mapContextMenuReducer } from '../../src/store/mapContextMenu/mapContextMenu.reducer.js';
 import { QueryParameters } from '../../src/domain/queryParameters.js';
 import { removeLayer } from '../../src/store/layers/layers.action.js';
+import { TabIds } from '../../src/domain/mainMenu.js';
+import { createNoInitialStateMainMenuReducer } from '../../src/store/mainMenu/mainMenu.reducer.js';
 
 describe('RoutingPlugin', () => {
 	const routingService = {
@@ -44,7 +46,8 @@ describe('RoutingPlugin', () => {
 			notifications: notificationReducer,
 			bottomSheet: bottomSheetReducer,
 			highlight: highlightReducer,
-			mapContextMenu: mapContextMenuReducer
+			mapContextMenu: mapContextMenuReducer,
+			mainMenu: createNoInitialStateMainMenuReducer()
 		});
 		$injector
 			.registerSingleton('RoutingService', routingService)
@@ -61,14 +64,36 @@ describe('RoutingPlugin', () => {
 
 	describe('register', () => {
 		describe('when routing related query params are available', () => {
-			it('sets "ROUTING" as the current active tool', async () => {
+			it('calls _lazyInitialize and updates the active property', async () => {
 				const store = setup();
 				const queryParams = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1,2`);
 				const instanceUnderTest = new RoutingPlugin();
 				spyOn(environmentService, 'getQueryParams').and.returnValue(queryParams);
+				const lazyInitializeSpy = spyOn(instanceUnderTest, '_lazyInitialize').and.resolveTo(true);
+
 				await instanceUnderTest.register(store);
 
-				expect(store.getState().tools.current).toBe(Tools.ROUTING);
+				await TestUtils.timeout();
+				await TestUtils.timeout();
+				expect(store.getState().routing.active).toBeTrue();
+				expect(lazyInitializeSpy).toHaveBeenCalled();
+			});
+
+			describe('_lazyInitialize returns "false"', () => {
+				it('does NOT update the active property', async () => {
+					const store = setup();
+					const queryParams = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1,2`);
+					const instanceUnderTest = new RoutingPlugin();
+					spyOn(environmentService, 'getQueryParams').and.returnValue(queryParams);
+					const lazyInitializeSpy = spyOn(instanceUnderTest, '_lazyInitialize').and.resolveTo(false);
+
+					await instanceUnderTest.register(store);
+
+					await TestUtils.timeout();
+					await TestUtils.timeout();
+					expect(store.getState().routing.active).toBeFalse();
+					expect(lazyInitializeSpy).toHaveBeenCalled();
+				});
 			});
 
 			it('does nothing when embedded', async () => {
@@ -84,66 +109,82 @@ describe('RoutingPlugin', () => {
 		});
 	});
 
+	describe('_lazyInitialize', () => {
+		it('initializes the routing service and sets the default routing category', async () => {
+			const store = setup({ routing: initialRoutingState });
+			const instanceUnderTest = new RoutingPlugin();
+			await instanceUnderTest.register(store);
+			const routingServiceSpy = spyOn(routingService, 'init').and.resolveTo([]);
+			const categoryId = 'catId';
+			spyOn(routingService, 'getCategories').and.returnValue([{ id: categoryId }]);
+
+			instanceUnderTest._lazyInitialize();
+
+			// we have to wait for two async operations
+			await TestUtils.timeout();
+			expect(routingServiceSpy).toHaveBeenCalled();
+			await TestUtils.timeout();
+			expect(store.getState().routing.categoryId).toBe(categoryId);
+		});
+
+		it('parses the query parameters', async () => {
+			const queryParams = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1,2`);
+			const store = setup({ routing: initialRoutingState });
+			const instanceUnderTest = new RoutingPlugin();
+			const parseRouteFromQueryParamsSpy = spyOn(instanceUnderTest, '_parseRouteFromQueryParams');
+			await instanceUnderTest.register(store);
+			spyOn(routingService, 'init').and.resolveTo([]);
+			spyOn(routingService, 'getCategories').and.returnValue([{ id: 'catId' }]);
+			spyOn(environmentService, 'getQueryParams').and.returnValue(queryParams);
+
+			setCurrentTool(Tools.ROUTING);
+
+			// we have to wait for two async operations
+			await TestUtils.timeout();
+			await TestUtils.timeout();
+			expect(parseRouteFromQueryParamsSpy).toHaveBeenCalledOnceWith(queryParams);
+		});
+
+		it('emits a notification when RoutingService#init throws an error', async () => {
+			const message = 'something got wrong';
+			const store = setup();
+			const instanceUnderTest = new RoutingPlugin();
+			await instanceUnderTest.register(store);
+			spyOn(routingService, 'init').and.rejectWith(new Error(message));
+			const errorSpy = spyOn(console, 'error');
+
+			setCurrentTool(Tools.ROUTING);
+
+			// we have to wait for two async operations
+			await TestUtils.timeout();
+			expect(store.getState().notifications.latest.payload.content).toBe('global_routingService_init_exception');
+			expect(store.getState().notifications.latest.payload.level).toBe(LevelTypes.ERROR);
+			expect(errorSpy).toHaveBeenCalledWith('Routing service could not be initialized', new Error(message));
+			await TestUtils.timeout();
+			expect(store.getState().routing.active).toBeFalse();
+		});
+	});
+
 	describe('when tools "current" property changes', () => {
 		describe('and not yet initialized ', () => {
-			it('initializes the routing service, sets the default routing category and updates the active property', async () => {
+			it('calls _lazyInitialize and updates the active property', async () => {
 				const store = setup({ routing: initialRoutingState });
 				const instanceUnderTest = new RoutingPlugin();
 				await instanceUnderTest.register(store);
-				const routingServiceSpy = spyOn(routingService, 'init').and.resolveTo([]);
-				const categoryId = 'catId';
-				spyOn(routingService, 'getCategories').and.returnValue([{ id: categoryId }]);
+				const lazyInitializeSpy = spyOn(instanceUnderTest, '_lazyInitialize').and.resolveTo(true);
 
 				setCurrentTool(Tools.ROUTING);
 
 				// we have to wait for two async operations
 				await TestUtils.timeout();
-				expect(routingServiceSpy).toHaveBeenCalled();
 				await TestUtils.timeout();
 				expect(store.getState().routing.active).toBeTrue();
-				expect(store.getState().routing.categoryId).toBe(categoryId);
-			});
-
-			it('parses the query parameters', async () => {
-				const queryParams = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1,2`);
-				const store = setup({ routing: initialRoutingState });
-				const instanceUnderTest = new RoutingPlugin();
-				const parseRouteFromQueryParamsSpy = spyOn(instanceUnderTest, '_parseRouteFromQueryParams');
-				await instanceUnderTest.register(store);
-				spyOn(routingService, 'init').and.resolveTo([]);
-				spyOn(routingService, 'getCategories').and.returnValue([{ id: 'catId' }]);
-				spyOn(environmentService, 'getQueryParams').and.returnValue(queryParams);
-
-				setCurrentTool(Tools.ROUTING);
-
-				// we have to wait for two async operations
-				await TestUtils.timeout();
-				await TestUtils.timeout();
-				expect(parseRouteFromQueryParamsSpy).toHaveBeenCalledOnceWith(queryParams);
-			});
-
-			it('emits a notification when RoutingService#init throws an error', async () => {
-				const message = 'something got wrong';
-				const store = setup();
-				const instanceUnderTest = new RoutingPlugin();
-				await instanceUnderTest.register(store);
-				spyOn(routingService, 'init').and.rejectWith(new Error(message));
-				const errorSpy = spyOn(console, 'error');
-
-				setCurrentTool(Tools.ROUTING);
-
-				// we have to wait for two async operations
-				await TestUtils.timeout();
-				expect(store.getState().notifications.latest.payload.content).toBe('global_routingService_init_exception');
-				expect(store.getState().notifications.latest.payload.level).toBe(LevelTypes.ERROR);
-				expect(errorSpy).toHaveBeenCalledWith('Routing service could not be initialized', new Error(message));
-				await TestUtils.timeout();
-				expect(store.getState().routing.active).toBeFalse();
+				expect(lazyInitializeSpy).toHaveBeenCalled();
 			});
 		});
 
 		describe('activation', () => {
-			it('updates the active property', async () => {
+			it('updates the active property and sets the correct MainMenu tab', async () => {
 				const store = setup();
 				const instanceUnderTest = new RoutingPlugin();
 				instanceUnderTest._initialized = true;
@@ -155,6 +196,8 @@ describe('RoutingPlugin', () => {
 				await TestUtils.timeout();
 				await TestUtils.timeout();
 				expect(store.getState().routing.active).toBeTrue();
+				expect(store.getState().routing.active).toBeTrue();
+				expect(store.getState().mainMenu.tab).toBe(TabIds.ROUTING);
 			});
 		});
 

--- a/test/plugins/ToolsPlugin.test.js
+++ b/test/plugins/ToolsPlugin.test.js
@@ -8,6 +8,7 @@ import { indicateAttributeChange } from '../../src/store/wcAttribute/wcAttribute
 import { wcAttributeReducer } from '../../src/store/wcAttribute/wcAttribute.reducer.js';
 import { setRoute } from '../../src/store/routing/routing.action.js';
 import { routingReducer } from '../../src/store/routing/routing.reducer.js';
+import { setCurrentTool } from '../../src/store/tools/tools.action.js';
 
 describe('ToolsPlugin', () => {
 	const environmentServiceMock = {
@@ -31,20 +32,22 @@ describe('ToolsPlugin', () => {
 	};
 
 	describe('register', () => {
-		describe('in default mode', () => {
-			describe('route waypoints are available', () => {
-				it('updates the "tools" slice-of-state after the route was fetched', async () => {
-					const store = setup();
-					const queryParam = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1.1,2.2,3.3,4.4&${QueryParameters.TOOL_ID}=${Tools.EXPORT}`);
-					const instanceUnderTest = new ToolsPlugin();
-					spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(queryParam);
-					await instanceUnderTest.register(store);
+		describe('route waypoints are available', () => {
+			it('updates the "tools" slice-of-state after the route was fetched', async () => {
+				const store = setup();
+				setCurrentTool(Tools.ROUTING);
+				const queryParam = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1.1,2.2,3.3,4.4`);
+				const instanceUnderTest = new ToolsPlugin();
+				spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(queryParam);
+				await instanceUnderTest.register(store);
 
-					setRoute({ foo: 'bar' });
+				setRoute({ foo: 'bar' });
 
-					expect(store.getState().tools.current).toBe(Tools.EXPORT);
-				});
+				expect(store.getState().tools.current).toBeNull();
 			});
+		});
+
+		describe('tool id is available', () => {
 			it('updates the "tools" slice-of-state', async () => {
 				const store = setup();
 				const queryParam = new URLSearchParams(`${QueryParameters.TOOL_ID}=${Tools.EXPORT}`);

--- a/test/plugins/ToolsPlugin.test.js
+++ b/test/plugins/ToolsPlugin.test.js
@@ -6,6 +6,8 @@ import { ToolsPlugin } from '../../src/plugins/ToolsPlugin';
 import { Tools } from '../../src/domain/tools.js';
 import { indicateAttributeChange } from '../../src/store/wcAttribute/wcAttribute.action.js';
 import { wcAttributeReducer } from '../../src/store/wcAttribute/wcAttribute.reducer.js';
+import { setRoute } from '../../src/store/routing/routing.action.js';
+import { routingReducer } from '../../src/store/routing/routing.reducer.js';
 
 describe('ToolsPlugin', () => {
 	const environmentServiceMock = {
@@ -19,7 +21,8 @@ describe('ToolsPlugin', () => {
 			{},
 			{
 				tools: toolsReducer,
-				wcAttribute: wcAttributeReducer
+				wcAttribute: wcAttributeReducer,
+				routing: routingReducer
 			}
 		);
 		$injector.registerSingleton('EnvironmentService', environmentServiceMock);
@@ -29,6 +32,19 @@ describe('ToolsPlugin', () => {
 
 	describe('register', () => {
 		describe('in default mode', () => {
+			describe('route waypoints are available', () => {
+				it('updates the "tools" slice-of-state after the route was fetched', async () => {
+					const store = setup();
+					const queryParam = new URLSearchParams(`${QueryParameters.ROUTE_WAYPOINTS}=1.1,2.2,3.3,4.4&${QueryParameters.TOOL_ID}=${Tools.EXPORT}`);
+					const instanceUnderTest = new ToolsPlugin();
+					spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(queryParam);
+					await instanceUnderTest.register(store);
+
+					setRoute({ foo: 'bar' });
+
+					expect(store.getState().tools.current).toBe(Tools.EXPORT);
+				});
+			});
 			it('updates the "tools" slice-of-state', async () => {
 				const store = setup();
 				const queryParam = new URLSearchParams(`${QueryParameters.TOOL_ID}=${Tools.EXPORT}`);


### PR DESCRIPTION
Please compare

- Active _Routing_ tool:  http://localhost:8080/?c=677751,5422939&z=8&r=0&l=atkis&t=ba&rtwp=1198066.0865566935,6267614.751015566,1311804.3846450357,6468797.00946215&rtc=bvv-hike&tid=routing

- Route is shown but no tool is  active; http://localhost:8080/?c=677751,5422939&z=8&r=0&l=atkis&t=ba&rtwp=1198066.0865566935,6267614.751015566,1311804.3846450357,6468797.00946215&rtc=bvv-hike&tid=

- Active _Export_ tool: http://localhost:8080/?c=677751,5422939&z=8&r=0&l=atkis&t=ba&rtwp=1198066.0865566935,6267614.751015566,1311804.3846450357,6468797.00946215&rtc=bvv-hike&tid=export
