### PR TITLE
SharePlugin: ignore hidden routing -related GeoResource (Ticket#45104510)

### DIFF
--- a/src/modules/olMap/handler/routing/OlRoutingHandler.js
+++ b/src/modules/olMap/handler/routing/OlRoutingHandler.js
@@ -3,7 +3,7 @@
  */
 import { $injector } from '../../../../injection';
 import { OlLayerHandler } from '../OlLayerHandler';
-import { PERMANENT_ROUTE_LAYER_ID, PERMANENT_WP_LAYER_ID, ROUTING_LAYER_ID } from '../../../../plugins/RoutingPlugin';
+import { PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID, ROUTING_LAYER_ID } from '../../../../plugins/RoutingPlugin';
 import LayerGroup from 'ol/layer/Group';
 import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
@@ -787,19 +787,19 @@ export class OlRoutingHandler extends OlLayerHandler {
 				const fromService = this._geoResourceService.byId(id);
 				return fromService ? fromService : new VectorGeoResource(id, label, VectorSourceType.KML);
 			};
-			const vgrRoute = getOrCreateVectorGeoResource(PERMANENT_ROUTE_LAYER_ID, labelRtLayer)
+			const vgrRoute = getOrCreateVectorGeoResource(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, labelRtLayer)
 				.setSource(routeKML, 4326)
 				.setHidden(true)
 				.setAttributionProvider(this._attributionProvider);
-			const vgrInteraction = getOrCreateVectorGeoResource(PERMANENT_WP_LAYER_ID, labelWpLayer)
+			const vgrInteraction = getOrCreateVectorGeoResource(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID, labelWpLayer)
 				.setSource(interactionKML, 4326)
 				.setHidden(true)
 				.setAttributionProvider(getAttributionForLocallyImportedOrCreatedGeoResource);
 
 			this._geoResourceService.addOrReplace(vgrRoute);
 			this._geoResourceService.addOrReplace(vgrInteraction);
-			addLayer(PERMANENT_ROUTE_LAYER_ID, { constraints: { metaData: false } });
-			addLayer(PERMANENT_WP_LAYER_ID, { constraints: { metaData: false } });
+			addLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, { constraints: { metaData: false } });
+			addLayer(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID, { constraints: { metaData: false } });
 		}
 	}
 }

--- a/src/plugins/RoutingPlugin.js
+++ b/src/plugins/RoutingPlugin.js
@@ -26,12 +26,14 @@ import { isCoordinate } from '../utils/checks';
 export const ROUTING_LAYER_ID = 'routing_layer';
 /**
  * Id of a permanent layer used for displaying a route.
+ * It is also the id of the referenced GeoResource.
  */
-export const PERMANENT_ROUTE_LAYER_ID = 'perm_rt_layer';
+export const PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID = 'perm_rt_layer';
 /**
  * Id of a permanent layer used for displaying the waypoints of a route.
+ * It is also the id of the referenced GeoResource.
  */
-export const PERMANENT_WP_LAYER_ID = 'perm_wp_layer';
+export const PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID = 'perm_wp_layer';
 
 /**
  * This plugin observes the 'active' property of the routing store.
@@ -114,8 +116,8 @@ export class RoutingPlugin extends BaPlugin {
 				clearHighlightFeatures();
 				closeContextMenu();
 				addLayer(ROUTING_LAYER_ID, { constraints: { hidden: true, alwaysTop: true } });
-				removeLayer(PERMANENT_ROUTE_LAYER_ID);
-				removeLayer(PERMANENT_WP_LAYER_ID);
+				removeLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID);
+				removeLayer(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID);
 			} else {
 				removeLayer(ROUTING_LAYER_ID);
 			}
@@ -162,7 +164,10 @@ export class RoutingPlugin extends BaPlugin {
 			}
 		};
 		const onLayerRemoved = (eventLike, state) => {
-			if (!state.routing.active && [PERMANENT_ROUTE_LAYER_ID, PERMANENT_WP_LAYER_ID].some((id) => eventLike.payload.includes(id))) {
+			if (
+				!state.routing.active &&
+				[PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID].some((id) => eventLike.payload.includes(id))
+			) {
 				reset();
 			}
 		};

--- a/src/plugins/SharePlugin.js
+++ b/src/plugins/SharePlugin.js
@@ -7,6 +7,7 @@ import { $injector } from '../injection';
 import { emitNotification, LevelTypes } from '../store/notifications/notifications.action';
 import { observe } from '../utils/storeUtils';
 import { BaPlugin } from './BaPlugin';
+import { PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID } from './RoutingPlugin';
 
 /**
  * Checks if the current map contains layers that cannot be shared, e.g. locally imported data like KML, and GPX files.
@@ -40,6 +41,10 @@ export class SharePlugin extends BaPlugin {
 				.filter((l) => !l.constraints.hidden)
 				.map((l) => this._geoResourceService.byId(l.geoResourceId))
 				.filter((gr) => gr.hidden)
+				/**
+				 * Routing -related GeoResources are marked as hidden because they are shared by the ROUTE_WAYPOINTS query parameter. Therefore we can ignore them here.
+				 */
+				.filter((gr) => ![PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID, PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID].includes(gr.id))
 				.map((gr) => gr.label);
 
 			if (grLabels.length) {

--- a/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
+++ b/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
@@ -43,7 +43,7 @@ import {
 } from '../../../../../src/services/provider/attribution.provider';
 import { layersReducer } from '../../../../../src/store/layers/layers.reducer';
 import { VectorGeoResource, VectorSourceType } from '../../../../../src/domain/geoResources';
-import { PERMANENT_ROUTE_LAYER_ID, PERMANENT_WP_LAYER_ID } from '../../../../../src/plugins/RoutingPlugin';
+import { PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID } from '../../../../../src/plugins/RoutingPlugin';
 import { StyleTypes } from '../../../../../src/modules/olMap/services/StyleService';
 import { simulateMapBrowserEvent } from '../../mapTestUtils';
 
@@ -1767,7 +1767,7 @@ describe('OlRoutingHandler', () => {
 				expect(geoResources).toHaveSize(2);
 
 				//first vgr and layer
-				expect(store.getState().layers.active[0].id).toBe(PERMANENT_ROUTE_LAYER_ID);
+				expect(store.getState().layers.active[0].id).toBe(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID);
 				expect(geoResources[0].label).toBe('olMap_handler_routing_rt_layer_label - someCatLabel');
 				expect(geoResources[0].hidden).toBeTrue();
 				expect(geoResources[0].attributionProvider).toEqual(getBvvAttributionForRoutingResult);
@@ -1775,7 +1775,7 @@ describe('OlRoutingHandler', () => {
 				expect(geoResources[0].srid).toEqual(4326);
 				expect(geoResources[1].data).toContain('<Document><Placemark><Style/><Point><coordinates>');
 				//second vgr and layer
-				expect(store.getState().layers.active[1].id).toBe(PERMANENT_WP_LAYER_ID);
+				expect(store.getState().layers.active[1].id).toBe(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID);
 				expect(geoResources[1].label).toBe('olMap_handler_routing_wp_layer_label - someCatLabel');
 				expect(geoResources[1].hidden).toBeTrue();
 				expect(geoResources[1].attributionProvider).toEqual(getAttributionForLocallyImportedOrCreatedGeoResource);
@@ -1813,11 +1813,11 @@ describe('OlRoutingHandler', () => {
 				expect(geoResources).toHaveSize(2);
 
 				//first vgr and layer
-				expect(store.getState().layers.active[0].id).toBe(PERMANENT_ROUTE_LAYER_ID);
+				expect(store.getState().layers.active[0].id).toBe(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID);
 				expect(geoResources[1].data).toContain('<Document><Placemark><Style/>');
 				expect(geoResources[1].data).toContain('<Point><coordinates>');
 				//second vgr and layer
-				expect(store.getState().layers.active[1].id).toBe(PERMANENT_WP_LAYER_ID);
+				expect(store.getState().layers.active[1].id).toBe(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID);
 				expect(geoResources[0].data).toContain('<Document><Placemark><Style/>');
 				expect(geoResources[0].data).toContain('<Point><coordinates>');
 

--- a/test/plugins/RoutingPlugin.test.js
+++ b/test/plugins/RoutingPlugin.test.js
@@ -1,4 +1,9 @@
-import { RoutingPlugin, ROUTING_LAYER_ID, PERMANENT_ROUTE_LAYER_ID, PERMANENT_WP_LAYER_ID } from '../../src/plugins/RoutingPlugin';
+import {
+	RoutingPlugin,
+	ROUTING_LAYER_ID,
+	PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID,
+	PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID
+} from '../../src/plugins/RoutingPlugin';
 
 import { TestUtils } from '../test-utils.js';
 import { createDefaultLayer, layersReducer } from '../../src/store/layers/layers.reducer';
@@ -246,7 +251,7 @@ describe('RoutingPlugin', () => {
 
 		it('removes the permanent layers', async () => {
 			const store = setup({
-				layers: { active: [createDefaultLayer(PERMANENT_ROUTE_LAYER_ID), createDefaultLayer(PERMANENT_WP_LAYER_ID)] }
+				layers: { active: [createDefaultLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID), createDefaultLayer(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID)] }
 			});
 			const instanceUnderTest = new RoutingPlugin();
 			instanceUnderTest._initialized = true;
@@ -450,14 +455,14 @@ describe('RoutingPlugin', () => {
 			it('resets the waypoint s-o-s when PERMANENT_ROUTE_LAYER_ID layer was removed', async () => {
 				const store = setup({
 					routing: { ...initialRoutingState, waypoints: [[0, 1]] },
-					layers: { ...initialLayersState, active: [createDefaultLayer(PERMANENT_ROUTE_LAYER_ID)] }
+					layers: { ...initialLayersState, active: [createDefaultLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID)] }
 				});
 				const instanceUnderTest = new RoutingPlugin();
 				instanceUnderTest._initialized = true;
 				await instanceUnderTest.register(store);
 				deactivate();
 
-				removeLayer(PERMANENT_ROUTE_LAYER_ID);
+				removeLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID);
 
 				expect(store.getState().routing.waypoints).toHaveSize(0);
 			});
@@ -465,14 +470,14 @@ describe('RoutingPlugin', () => {
 			it('resets the waypoint s-o-s when PERMANENT_WP_LAYER_ID layer was removed', async () => {
 				const store = setup({
 					routing: { ...initialRoutingState, waypoints: [[0, 1]] },
-					layers: { ...initialLayersState, active: [createDefaultLayer(PERMANENT_WP_LAYER_ID)] }
+					layers: { ...initialLayersState, active: [createDefaultLayer(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID)] }
 				});
 				const instanceUnderTest = new RoutingPlugin();
 				instanceUnderTest._initialized = true;
 				await instanceUnderTest.register(store);
 				deactivate();
 
-				removeLayer(PERMANENT_WP_LAYER_ID);
+				removeLayer(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID);
 
 				expect(store.getState().routing.waypoints).toHaveSize(0);
 			});
@@ -481,14 +486,14 @@ describe('RoutingPlugin', () => {
 		it('does noting when routing is currently active', async () => {
 			const store = setup({
 				routing: { ...initialRoutingState, waypoints: [[0, 1]] },
-				layers: { ...initialLayersState, active: [createDefaultLayer(PERMANENT_ROUTE_LAYER_ID)] }
+				layers: { ...initialLayersState, active: [createDefaultLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID)] }
 			});
 			const instanceUnderTest = new RoutingPlugin();
 			instanceUnderTest._initialized = true;
 			await instanceUnderTest.register(store);
 			activate();
 
-			removeLayer(PERMANENT_ROUTE_LAYER_ID);
+			removeLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID);
 
 			expect(store.getState().routing.waypoints).toHaveSize(1);
 		});

--- a/test/plugins/SharePlugin.test.js
+++ b/test/plugins/SharePlugin.test.js
@@ -9,6 +9,7 @@ import { XyzGeoResource } from '../../src/domain/geoResources.js';
 import { notificationReducer } from '../../src/store/notifications/notifications.reducer.js';
 import { LevelTypes } from '../../src/store/notifications/notifications.action.js';
 import { Tools } from '../../src/domain/tools.js';
+import { PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID, PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID } from '../../src/plugins/RoutingPlugin.js';
 
 describe('SharePlugin', () => {
 	const geoResourceService = {
@@ -34,9 +35,11 @@ describe('SharePlugin', () => {
 			it('emits an notification', async () => {
 				const store = setup();
 				addLayer('id0');
-				addLayer('id1');
+				addLayer('id1'); //should be filtered out
 				addLayer('id2');
 				addLayer('id3', { constraints: { hidden: true } }); //should be filtered out
+				addLayer(PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID); //should be filtered out
+				addLayer(PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID); //should be filtered out
 				spyOn(geoResourceService, 'byId').and.callFake((id) => {
 					const gr = new XyzGeoResource(id, id, '');
 					if (id === 'id1') {
@@ -55,6 +58,12 @@ describe('SharePlugin', () => {
 				expect(TestUtils.renderTemplateResult(store.getState().notifications.latest.payload.content).textContent).toContain('id0');
 				expect(TestUtils.renderTemplateResult(store.getState().notifications.latest.payload.content).textContent).toContain('id2');
 				expect(TestUtils.renderTemplateResult(store.getState().notifications.latest.payload.content).textContent).not.toContain('id1');
+				expect(TestUtils.renderTemplateResult(store.getState().notifications.latest.payload.content).textContent).not.toContain(
+					PERMANENT_ROUTE_LAYER_OR_GEO_RESOURCE_ID
+				);
+				expect(TestUtils.renderTemplateResult(store.getState().notifications.latest.payload.content).textContent).not.toContain(
+					PERMANENT_WP_LAYER_OR_GEO_RESOURCE_ID
+				);
 				expect(store.getState().notifications.latest.payload.level).toBe(LevelTypes.WARN);
 			});
 		});


### PR DESCRIPTION
This PR avoids the following wrong notification:
![grafik](https://github.com/ldbv-by/bav4/assets/49945713/ded70606-d64a-4c92-b80e-e164c0af1ddf)
