### PR TITLE
FeatureInfoItem: remove simplify of elevation profile coordinates [Ticket#45104576]

### DIFF
--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -3,13 +3,7 @@
  */
 import { FeatureInfoGeometryTypes } from '../../../../store/featureInfo/featureInfo.action';
 import GeoJSON from 'ol/format/GeoJSON';
-import {
-	getLineString,
-	getStats,
-	PROFILE_GEOMETRY_SIMPLIFY_MAX_COUNT_COORDINATES,
-	PROFILE_GEOMETRY_SIMPLIFY_DISTANCE_TOLERANCE_3857,
-	simplify
-} from '../../utils/olGeometryUtils';
+import { getLineString, getStats } from '../../utils/olGeometryUtils';
 import { $injector } from '../../../../injection';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';

--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -33,12 +33,7 @@ export const getBvvFeatureInfo = (olFeature, layerProperties) => {
 		GeoResourceService: geoResourceService
 	} = $injector.inject('MapService', 'SecurityService', 'GeoResourceService');
 	const stats = getStats(olFeature.getGeometry());
-	const elevationProfileCoordinates =
-		simplify(
-			getLineString(olFeature.getGeometry()),
-			PROFILE_GEOMETRY_SIMPLIFY_MAX_COUNT_COORDINATES,
-			PROFILE_GEOMETRY_SIMPLIFY_DISTANCE_TOLERANCE_3857
-		)?.getCoordinates() ?? [];
+	const elevationProfileCoordinates = getLineString(olFeature.getGeometry())?.getCoordinates() ?? [];
 	const exportData = new KML().writeFeatures([olFeature], { featureProjection: 'EPSG:' + mapService.getSrid() });
 
 	const getContent = () => {


### PR DESCRIPTION
Remove the process step of simplifying coordinates for the elevation profile, due to the fact that the profile provider does this implicit now. Any simplification beforehand is unnecessary.