### PR TITLE
Add style just for open data links

### DIFF
--- a/src/modules/featureInfo/components/featureInfoIframePanel/featureInfoIframePanel.css
+++ b/src/modules/featureInfo/components/featureInfoIframePanel/featureInfoIframePanel.css
@@ -211,6 +211,7 @@ h5 {
 	border: none;
 	font-weight: bold;
 	transition: all var(--animation-duration-medium-open) var(--animation-easing-linear);
+	display: inline-block;
 }
 .primary {
 	background-color: var(--primary-color);
@@ -240,5 +241,26 @@ h5 {
 .secondary:hover {
 	background: var(--primary-color);
 	color: var(--text3);
+	text-decoration: none;
+}
+
+/* temp: just for Open-Data */
+a[href^="https://geodaten.bayern.de/odd/"]
+{
+	cursor: pointer;
+	padding: 0.8em 1em;
+	background: transparent;
+	border: none;
+	font-weight: bold;
+	transition: all var(--animation-duration-medium-open) var(--animation-easing-linear);
+	background-color: var(--primary-color);
+	color: var(--text3);
+	opacity: 0.8;
+	display: block;
+	text-align: center;
+}
+a[href^="https://geodaten.bayern.de/odd/"]:hover
+{
+	opacity: 1;
 	text-decoration: none;
 }

--- a/src/modules/featureInfo/components/featureInfoIframePanel/featureInfoIframePanel.css
+++ b/src/modules/featureInfo/components/featureInfoIframePanel/featureInfoIframePanel.css
@@ -244,7 +244,7 @@ h5 {
 	text-decoration: none;
 }
 
-/* temp: just for Open-Data */
+/*Fixme: remove temporary workaround for OpenData*/
 a[href^="https://geodaten.bayern.de/odd/"]
 {
 	cursor: pointer;

--- a/src/modules/featureInfo/components/featureInfoPanel/featureInfoPanel.css
+++ b/src/modules/featureInfo/components/featureInfoPanel/featureInfoPanel.css
@@ -226,7 +226,7 @@ h5 {
 	text-decoration: none;
 }
 
-/* temp just for Open-Data */
+/*Fixme: remove temporary workaround for OpenData*/
 a[href^="https://geodaten.bayern.de/odd/"]
 {
 	cursor: pointer;

--- a/src/modules/featureInfo/components/featureInfoPanel/featureInfoPanel.css
+++ b/src/modules/featureInfo/components/featureInfoPanel/featureInfoPanel.css
@@ -193,6 +193,7 @@ h5 {
 	border: none;
 	font-weight: bold;
 	transition: all var(--animation-duration-medium-open) var(--animation-easing-linear);
+	display: inline-block;
 }
 .primary {
 	background-color: var(--primary-color);
@@ -222,5 +223,26 @@ h5 {
 .secondary:hover {
 	background: var(--primary-color);
 	color: var(--text3);
+	text-decoration: none;
+}
+
+/* temp just for Open-Data */
+a[href^="https://geodaten.bayern.de/odd/"]
+{
+	cursor: pointer;
+	padding: 0.8em 1em;
+	background: transparent;
+	border: none;
+	font-weight: bold;
+	transition: all var(--animation-duration-medium-open) var(--animation-easing-linear);
+	background-color: var(--primary-color);
+	color: var(--text3);
+	opacity: 0.8;
+	display: block;
+	text-align: center;
+}
+a[href^="https://geodaten.bayern.de/odd/"]:hover
+{
+	opacity: 1;
 	text-decoration: none;
 }


### PR DESCRIPTION
style just works for links starts with "https://geodaten.bayern.de/odd/"


Test width:
?c=675914,5398336&z=11&r=0&l=atkis,https%3A%2F%2Fgeodaten.bayern.de%2Fodd%2Fa%2Flod2%2Fcitygml%2Fmeta%2Fkml%2Fgemeinde.kml&t=ba&tid=


![Screenshot](https://github.com/ldbv-by/bav4/assets/76113751/21c6455f-7acf-4cf2-b361-90028234db9b)
