### PR TITLE
v4.2: adding mapListener after old features are read

### DIFF
--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -228,8 +228,13 @@ export class OlDrawHandler extends OlLayerHandler {
 			};
 			if (this._storeService.getStore().getState().draw.createPermanentLayer) {
 				const oldLayer = getOldLayer(this._map);
-				// eslint-disable-next-line promise/prefer-await-to-then
-				addOldFeatures(layer, oldLayer).finally(() => registerListeners(layer));
+				addOldFeatures(layer, oldLayer)
+					// eslint-disable-next-line promise/prefer-await-to-then
+					.finally(() => {
+						this._storedContent = createKML(layer, 'EPSG:3857');
+						this._save();
+						registerListeners(layer);
+					});
 			} else {
 				registerListeners(layer);
 			}

--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -319,7 +319,6 @@ export class OlDrawHandler extends OlLayerHandler {
 
 		this._storedContent = null; // reset last saved content for new changes
 		this._updateDrawState();
-		console.log(this._vectorLayer);
 		return this._vectorLayer;
 	}
 

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -220,7 +220,13 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				this._mapListeners.push(this._map.getView().on('change:resolution', () => onResolutionChange(layer)));
 			};
 			// eslint-disable-next-line promise/prefer-await-to-then
-			addOldFeatures(layer, oldLayer).finally(() => registerListeners(layer));
+			addOldFeatures(layer, oldLayer)
+				// eslint-disable-next-line promise/prefer-await-to-then
+				.finally(() => {
+					this._storedContent = createKML(layer, 'EPSG:3857');
+					this._save();
+					registerListeners(layer);
+				});
 			return layer;
 		};
 
@@ -683,7 +689,6 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		if (!this._storageHandler.isValid()) {
 			await this._save();
 		}
-
 		if (this._storedContent) {
 			const id = this._storageHandler.getStorageId();
 			const getOrCreateVectorGeoResource = () => {

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -188,7 +188,6 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		const getOrCreateLayer = () => {
 			const oldLayer = getOldLayer(this._map);
 			const layer = createLayer();
-			addOldFeatures(layer, oldLayer);
 
 			const updateContent = () => {
 				const features = layer.getSource().getFeatures();
@@ -205,18 +204,23 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				this._storedContent = createKML(layer, 'EPSG:3857');
 				this._save();
 			};
-			this._mapListeners.push(layer.getSource().on('addfeature', setSelectedAndSave));
-			this._mapListeners.push(
-				layer.getSource().on('changefeature', () => {
-					updateContent();
-				})
-			);
-			this._mapListeners.push(
-				layer.getSource().on('removefeature', () => {
-					updateContent();
-				})
-			);
-			this._mapListeners.push(this._map.getView().on('change:resolution', () => onResolutionChange(layer)));
+
+			const registerListeners = (layer) => {
+				this._mapListeners.push(layer.getSource().on('addfeature', setSelectedAndSave));
+				this._mapListeners.push(
+					layer.getSource().on('changefeature', () => {
+						updateContent();
+					})
+				);
+				this._mapListeners.push(
+					layer.getSource().on('removefeature', () => {
+						updateContent();
+					})
+				);
+				this._mapListeners.push(this._map.getView().on('change:resolution', () => onResolutionChange(layer)));
+			};
+			// eslint-disable-next-line promise/prefer-await-to-then
+			addOldFeatures(layer, oldLayer).finally(() => registerListeners(layer));
 			return layer;
 		};
 

--- a/src/modules/olMap/services/StyleService.js
+++ b/src/modules/olMap/services/StyleService.js
@@ -371,7 +371,7 @@ export class StyleService {
 				const text = style.getText()?.getText();
 				return {
 					symbolSrc: symbolSrc,
-					color: rgbToHex(color ? color : style.getText().getFill().getColor()),
+					color: rgbToHex(color ? color : style.getText()?.getFill()?.getColor()),
 					scale: scale,
 					text: text,
 					anchor: size && pixelAnchor ? [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]] : null

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -327,6 +327,7 @@ describe('OlDrawHandler', () => {
 				const storageSpy = spyOn(interactionStorageServiceMock, 'store').and.resolveTo(fileSaveResultMock);
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature);
 				classUnderTest._save();
 
@@ -347,6 +348,7 @@ describe('OlDrawHandler', () => {
 				spyOn(interactionStorageServiceMock, 'store').and.resolveTo(null);
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature);
 				classUnderTest._save();
 
@@ -370,6 +372,7 @@ describe('OlDrawHandler', () => {
 				const saveSpy = spyOn(classUnderTest, '_save').and.callThrough();
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature);
 				classUnderTest._vectorLayer.getSource().removeFeature(feature);
 				classUnderTest._saveAndOptionallyConvertToPermanentLayer();
@@ -1119,7 +1122,7 @@ describe('OlDrawHandler', () => {
 			expect(updateStyleSpy).toHaveBeenCalledTimes(1);
 		});
 
-		it('adds a drawn feature to the selection, after adding to layer (on addFeature)', () => {
+		it('adds a drawn feature to the selection, after adding to layer (on addFeature)', async () => {
 			const geometry = new LineString([
 				[0, 0],
 				[500, 0],
@@ -1135,6 +1138,7 @@ describe('OlDrawHandler', () => {
 			const map = setupMap();
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			setType('marker');
 			classUnderTest._drawState.type = InteractionStateType.DRAW;
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
@@ -1218,6 +1222,7 @@ describe('OlDrawHandler', () => {
 			const storageSpy = spyOn(interactionStorageServiceMock, 'store').and.resolveTo(fileSaveResultMock);
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest.deactivate(map);
 
@@ -1227,7 +1232,7 @@ describe('OlDrawHandler', () => {
 			expect(store.getState().draw.fileSaveResult.payload.fileSaveResult).toEqual(fileSaveResultMock);
 		});
 
-		it('uses already written features for persisting purpose', () => {
+		it('uses already written features for persisting purpose', async () => {
 			setup();
 			const classUnderTest = new OlDrawHandler();
 			const map = setupMap();
@@ -1237,6 +1242,7 @@ describe('OlDrawHandler', () => {
 			spyOn(interactionStorageServiceMock, 'isValid').and.callFake(() => true);
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._vectorLayer.setSource(source);
 			classUnderTest.deactivate(map);
 
@@ -1253,6 +1259,7 @@ describe('OlDrawHandler', () => {
 			spyOn(interactionStorageServiceMock, 'getStorageId').and.returnValue('f_ooBarId');
 			const storageSpy = spyOn(interactionStorageServiceMock, 'store');
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest.deactivate(map);
 
@@ -1277,6 +1284,7 @@ describe('OlDrawHandler', () => {
 			spyOn(interactionStorageServiceMock, 'getStorageId').and.returnValue('f_ooBarId');
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			expect(classUnderTest._vectorLayer).toBeTruthy();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest.deactivate(map);
@@ -1293,6 +1301,7 @@ describe('OlDrawHandler', () => {
 			const map = setupMap();
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			expect(classUnderTest._vectorLayer).toBeTruthy();
 			classUnderTest.deactivate(map);
 
@@ -1306,6 +1315,7 @@ describe('OlDrawHandler', () => {
 			const map = setupMap();
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			setType('line');
 			classUnderTest.deactivate(map);
 
@@ -1325,6 +1335,7 @@ describe('OlDrawHandler', () => {
 			const map = setupMap();
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			setType('line');
 			classUnderTest.deactivate(map);
 			setType('marker');
@@ -1350,6 +1361,7 @@ describe('OlDrawHandler', () => {
 			const feature = new Feature({ geometry: geometry });
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			setType('line');
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 
@@ -1486,6 +1498,7 @@ describe('OlDrawHandler', () => {
 			};
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			setType('line');
 			const geometry = new Polygon([
 				[

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -364,23 +364,21 @@ describe('OlDrawHandler', () => {
 				const classUnderTest = new OlDrawHandler();
 				const map = setupMap();
 				const feature = createFeature();
+				classUnderTest.activate(map);
+				await TestUtils.timeout();
+				const saveSpy = spyOn(classUnderTest, '_save').and.callThrough();
 				const storageSpy = spyOn(interactionStorageServiceMock, 'store')
 					.withArgs(jasmine.any(String), FileStorageServiceDataTypes.KML)
 					.and.resolveTo(fileSaveResultMock)
 					.withArgs(undefined, FileStorageServiceDataTypes.KML)
 					.and.resolveTo(null);
-				const saveSpy = spyOn(classUnderTest, '_save').and.callThrough();
 
-				classUnderTest.activate(map);
-				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature);
 				classUnderTest._vectorLayer.getSource().removeFeature(feature);
 				classUnderTest._saveAndOptionallyConvertToPermanentLayer();
 
 				await TestUtils.timeout();
 				expect(storageSpy).toHaveBeenCalledWith(jasmine.any(String), FileStorageServiceDataTypes.KML);
-
-				await TestUtils.timeout();
 				expect(saveSpy).toHaveBeenCalledTimes(2);
 				expect(storageSpy).toHaveBeenCalledTimes(2);
 				expect(store.getState().draw.fileSaveResult.payload).toBeNull();
@@ -1238,11 +1236,11 @@ describe('OlDrawHandler', () => {
 			const map = setupMap();
 			const source = new VectorSource({ wrapX: false });
 			source.addFeature(createFeature());
-			const saveSpy = spyOn(classUnderTest, '_save');
 			spyOn(interactionStorageServiceMock, 'isValid').and.callFake(() => true);
-
 			classUnderTest.activate(map);
 			await TestUtils.timeout();
+			const saveSpy = spyOn(classUnderTest, '_save');
+
 			classUnderTest._vectorLayer.setSource(source);
 			classUnderTest.deactivate(map);
 

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -704,11 +704,11 @@ describe('OlMeasurementHandler', () => {
 			const map = setupMap();
 			const source = new VectorSource({ wrapX: false });
 			source.addFeature(createFeature());
-			const saveSpy = spyOn(classUnderTest, '_save');
 			spyOn(interactionStorageServiceMock, 'isValid').and.callFake(() => true);
-
 			classUnderTest.activate(map);
 			await TestUtils.timeout();
+			const saveSpy = spyOn(classUnderTest, '_save');
+
 			classUnderTest._vectorLayer.setSource(source);
 			classUnderTest.deactivate(map);
 
@@ -1097,7 +1097,7 @@ describe('OlMeasurementHandler', () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
@@ -1106,6 +1106,7 @@ describe('OlMeasurementHandler', () => {
 
 				classUnderTest.activate(map);
 				await TestUtils.timeout();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of _save, caused by vectorsource:addfeature-event
 				feature.getGeometry().dispatchEvent('change'); // -> first call of debounced _save, caused by vectorsource:changefeature-event
 				feature.getGeometry().dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
@@ -1117,7 +1118,7 @@ describe('OlMeasurementHandler', () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
@@ -1126,6 +1127,7 @@ describe('OlMeasurementHandler', () => {
 
 				classUnderTest.activate(map);
 				await TestUtils.timeout();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of _save, caused by vectorsource:addfeature-event
 				feature.getGeometry().dispatchEvent('change'); // -> first call of debounced _save, caused by vectorsource:changefeature-event
 				feature.getGeometry().dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
@@ -1138,16 +1140,17 @@ describe('OlMeasurementHandler', () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
 				]);
 				const feature = new Feature({ geometry: geometry });
 				feature.set('debug', 'stores once after a feature removed');
-
 				classUnderTest.activate(map);
 				await TestUtils.timeout();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of debounced _save, caused by vectorsource:addfeature-event
 				classUnderTest._vectorLayer.getSource().removeFeature(feature); // -> second call of debounced _save, caused by vectorsource:removefeature-event
 				await TestUtils.timeout(afterDebounceDelay);
@@ -1159,15 +1162,15 @@ describe('OlMeasurementHandler', () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
 				]);
 				const feature = new Feature({ geometry: geometry });
-
 				classUnderTest.activate(map);
 				await TestUtils.timeout();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> call of debounced _save, caused by vectorsource:addfeature-event
 				feature.dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
 				feature.dispatchEvent('change');
@@ -1185,15 +1188,15 @@ describe('OlMeasurementHandler', () => {
 					spyOn(environmentServiceMock, 'isEmbedded').and.returnValue(true);
 					const classUnderTest = new OlMeasurementHandler();
 					const map = setupMap();
-					const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 					const geometry = new LineString([
 						[0, 0],
 						[1, 0]
 					]);
 					const feature = new Feature({ geometry: geometry });
-
 					classUnderTest.activate(map);
 					await TestUtils.timeout();
+					const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+
 					classUnderTest._vectorLayer.getSource().addFeature(feature); // -> call of debounced _save, caused by vectorsource:addfeature-event
 					feature.dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
 					await TestUtils.timeout(withinDebounceDelay);

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -233,12 +233,13 @@ describe('OlMeasurementHandler', () => {
 			expect(documentSpy).toHaveBeenCalledWith('keyup', jasmine.any(Function));
 		});
 
-		it('removes a keyup-EventListener from the document', () => {
+		it('removes a keyup-EventListener from the document', async () => {
 			setup();
 			const documentSpy = spyOn(document, 'removeEventListener').and.callThrough();
 			const map = setupMap();
 			const classUnderTest = new OlMeasurementHandler();
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest.deactivate(map);
 
 			expect(documentSpy).toHaveBeenCalledWith('keyup', jasmine.any(Function));
@@ -320,6 +321,7 @@ describe('OlMeasurementHandler', () => {
 				const storageSpy = spyOn(interactionStorageServiceMock, 'store').and.resolveTo(fileSaveResultMock);
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature);
 				classUnderTest._save(map);
 
@@ -360,13 +362,14 @@ describe('OlMeasurementHandler', () => {
 				expect(map.addInteraction).toHaveBeenCalledTimes(4);
 			});
 
-			it('removes Interaction', () => {
+			it('removes Interaction', async () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
 				const layerStub = {};
 				map.removeInteraction = jasmine.createSpy();
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest.deactivate(map, layerStub);
 
 				// removes Interaction for select, draw, modify, snap
@@ -600,7 +603,7 @@ describe('OlMeasurementHandler', () => {
 			expect(updateOverlaysSpy).toHaveBeenCalledTimes(1);
 		});
 
-		it('adds a drawn feature to the selection, after adding to layer (on addFeature)', () => {
+		it('adds a drawn feature to the selection, after adding to layer (on addFeature)', async () => {
 			const geometry = new LineString([
 				[0, 0],
 				[500, 0],
@@ -615,6 +618,7 @@ describe('OlMeasurementHandler', () => {
 			const map = setupMap();
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._measureState.type = InteractionStateType.DRAW;
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 
@@ -683,6 +687,7 @@ describe('OlMeasurementHandler', () => {
 			const storageSpy = spyOn(interactionStorageServiceMock, 'store').and.resolveTo(fileSaveResultMock);
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest.deactivate(map);
 
@@ -693,7 +698,7 @@ describe('OlMeasurementHandler', () => {
 			expect(store.getState().measurement.fileSaveResult.payload.fileSaveResult).toEqual(fileSaveResultMock);
 		});
 
-		it('uses already written features for persisting purpose', () => {
+		it('uses already written features for persisting purpose', async () => {
 			setup();
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
@@ -703,6 +708,7 @@ describe('OlMeasurementHandler', () => {
 			spyOn(interactionStorageServiceMock, 'isValid').and.callFake(() => true);
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._vectorLayer.setSource(source);
 			classUnderTest.deactivate(map);
 
@@ -719,6 +725,7 @@ describe('OlMeasurementHandler', () => {
 			spyOn(interactionStorageServiceMock, 'getStorageId').and.returnValue('f_ooBarId');
 			const storageSpy = spyOn(interactionStorageServiceMock, 'store');
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest.deactivate(map);
 
@@ -743,6 +750,7 @@ describe('OlMeasurementHandler', () => {
 			spyOn(interactionStorageServiceMock, 'getStorageId').and.returnValue('f_ooBarId');
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			expect(classUnderTest._vectorLayer).toBeTruthy();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest.deactivate(map);
@@ -759,6 +767,7 @@ describe('OlMeasurementHandler', () => {
 			const map = setupMap();
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			expect(classUnderTest._vectorLayer).toBeTruthy();
 			classUnderTest.deactivate(map);
 
@@ -777,6 +786,7 @@ describe('OlMeasurementHandler', () => {
 			const feature = new Feature({ geometry: geometry });
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 
 			expect(classUnderTest._drawingListeners).toHaveSize(2);
@@ -1081,20 +1091,13 @@ describe('OlMeasurementHandler', () => {
 
 	describe('when storing layer', () => {
 		const afterDebounceDelay = OlMeasurementHandler.Debounce_Delay + 100;
-		describe('debouncing takes place', () => {
-			beforeEach(function () {
-				jasmine.clock().install();
-			});
 
-			afterEach(function () {
-				jasmine.clock().uninstall();
-			});
+		describe('debouncing takes place', () => {
 			it('stores once after a single change of a feature', async () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const storeSpy = spyOn(interactionStorageServiceMock, 'store');
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callThrough();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
@@ -1102,21 +1105,40 @@ describe('OlMeasurementHandler', () => {
 				const feature = new Feature({ geometry: geometry });
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of _save, caused by vectorsource:addfeature-event
 				feature.getGeometry().dispatchEvent('change'); // -> first call of debounced _save, caused by vectorsource:changefeature-event
 				feature.getGeometry().dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
-				jasmine.clock().tick(afterDebounceDelay);
+				await TestUtils.timeout(afterDebounceDelay);
+				expect(privateSaveSpy).toHaveBeenCalledTimes(2);
+			});
+
+			it('stores once after a single change of a feature', async () => {
+				setup();
+				const classUnderTest = new OlMeasurementHandler();
+				const map = setupMap();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
+				const geometry = new LineString([
+					[0, 0],
+					[1, 0]
+				]);
+				const feature = new Feature({ geometry: geometry });
+
+				classUnderTest.activate(map);
+				await TestUtils.timeout();
+				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of _save, caused by vectorsource:addfeature-event
+				feature.getGeometry().dispatchEvent('change'); // -> first call of debounced _save, caused by vectorsource:changefeature-event
+				feature.getGeometry().dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
+				await TestUtils.timeout(afterDebounceDelay);
 
 				expect(privateSaveSpy).toHaveBeenCalledTimes(2);
-				expect(storeSpy).toHaveBeenCalledTimes(2);
 			});
 
 			it('stores once after a feature removed', async () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const storeSpy = spyOn(interactionStorageServiceMock, 'store');
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callThrough();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
@@ -1125,20 +1147,19 @@ describe('OlMeasurementHandler', () => {
 				feature.set('debug', 'stores once after a feature removed');
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of debounced _save, caused by vectorsource:addfeature-event
 				classUnderTest._vectorLayer.getSource().removeFeature(feature); // -> second call of debounced _save, caused by vectorsource:removefeature-event
-				jasmine.clock().tick(afterDebounceDelay);
+				await TestUtils.timeout(afterDebounceDelay);
 
 				expect(privateSaveSpy).toHaveBeenCalledTimes(2);
-				expect(storeSpy).toHaveBeenCalledTimes(2);
 			});
 
 			it('stores only once after multiple changes of a feature', async () => {
 				setup();
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
-				const storeSpy = spyOn(interactionStorageServiceMock, 'store');
-				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callThrough();
+				const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 				const geometry = new LineString([
 					[0, 0],
 					[1, 0]
@@ -1146,15 +1167,15 @@ describe('OlMeasurementHandler', () => {
 				const feature = new Feature({ geometry: geometry });
 
 				classUnderTest.activate(map);
+				await TestUtils.timeout();
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> call of debounced _save, caused by vectorsource:addfeature-event
 				feature.dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
 				feature.dispatchEvent('change');
 				feature.dispatchEvent('change');
 				feature.dispatchEvent('change');
-				jasmine.clock().tick(afterDebounceDelay);
+				await TestUtils.timeout(afterDebounceDelay);
 
 				expect(privateSaveSpy).toHaveBeenCalledTimes(2);
-				expect(storeSpy).toHaveBeenCalledTimes(2);
 			});
 
 			describe('when in embedded mode', () => {
@@ -1164,8 +1185,7 @@ describe('OlMeasurementHandler', () => {
 					spyOn(environmentServiceMock, 'isEmbedded').and.returnValue(true);
 					const classUnderTest = new OlMeasurementHandler();
 					const map = setupMap();
-					const storeSpy = spyOn(interactionStorageServiceMock, 'store');
-					const privateSaveSpy = spyOn(classUnderTest, '_save').and.callThrough();
+					const privateSaveSpy = spyOn(classUnderTest, '_save').and.callFake(() => {});
 					const geometry = new LineString([
 						[0, 0],
 						[1, 0]
@@ -1173,18 +1193,18 @@ describe('OlMeasurementHandler', () => {
 					const feature = new Feature({ geometry: geometry });
 
 					classUnderTest.activate(map);
+					await TestUtils.timeout();
 					classUnderTest._vectorLayer.getSource().addFeature(feature); // -> call of debounced _save, caused by vectorsource:addfeature-event
 					feature.dispatchEvent('change'); // -> second call of debounced _save, caused by vectorsource:changefeature-event
-					jasmine.clock().tick(0);
+					await TestUtils.timeout(withinDebounceDelay);
 					feature.dispatchEvent('change');
-					jasmine.clock().tick(0);
+					await TestUtils.timeout(withinDebounceDelay);
 					feature.dispatchEvent('change');
-					jasmine.clock().tick(0);
+					await TestUtils.timeout(withinDebounceDelay);
 					feature.dispatchEvent('change');
-					jasmine.clock().tick(withinDebounceDelay);
+					await TestUtils.timeout(withinDebounceDelay);
 
 					expect(privateSaveSpy).toHaveBeenCalledTimes(5);
-					expect(storeSpy).toHaveBeenCalledTimes(5);
 				});
 			});
 		});
@@ -1196,6 +1216,7 @@ describe('OlMeasurementHandler', () => {
 			const storageSpy = spyOn(classUnderTest._storageHandler, 'store').and.callFake(() => {});
 
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			const feature = new Feature({
 				geometry: new LineString([
 					[0, 0],
@@ -1507,7 +1528,7 @@ describe('OlMeasurementHandler', () => {
 			expect(classUnderTest._draw.handleEvent).toHaveBeenCalledWith(jasmine.any(MapBrowserEvent));
 		});
 
-		it('add the drawn feature to select after drawends', () => {
+		it('add the drawn feature to select after drawends', async () => {
 			setup();
 			const geometry = new Polygon([
 				[
@@ -1524,6 +1545,7 @@ describe('OlMeasurementHandler', () => {
 			const map = setupMap();
 			const classUnderTest = new OlMeasurementHandler();
 			classUnderTest.activate(map);
+			await TestUtils.timeout();
 			classUnderTest._measureState.type = InteractionStateType.DRAW;
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 


### PR DESCRIPTION
update OlMeasurementHandler and OlDrawHandler, to prevent multiple unnecessary calls of _save/store

fixes #2477