### PR TITLE
always preseve the crosshair marker when sharing the map

### DIFF
--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -9,6 +9,7 @@ import { LevelTypes, emitNotification } from '../../../../store/notifications/no
 import { isCoordinate } from '../../../../utils/checks';
 import { AbstractAssistChip } from './AbstractAssistChip';
 import shareIcon from './assets/share.svg';
+import { setQueryParams } from '../../../../utils/urlUtils';
 
 const Update = 'update';
 
@@ -72,8 +73,8 @@ export class ShareChip extends AbstractAssistChip {
 
 	async _buildShareUrl(center) {
 		const getStateAndOverridePosition = () => {
-			const extraParams = { [QueryParameters.CROSSHAIR]: true };
-			return new URL(this._shareService.encodeStateForPosition({ center: center }, extraParams));
+			const url = setQueryParams(this._shareService.encodeStateForPosition({ center: center }), { [QueryParameters.CROSSHAIR]: 'true' });
+			return new URL(url);
 		};
 
 		const getState = () => {

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -1,7 +1,7 @@
 /**
  * @module plugins/HighlightPlugin
  */
-import { observe, observeOnce } from '../utils/storeUtils';
+import { observe } from '../utils/storeUtils';
 import { BaPlugin } from './BaPlugin';
 import { addLayer, removeLayer } from '../store/layers/layers.action';
 import { addHighlightFeatures, HighlightFeatureType, removeHighlightFeaturesById } from '../store/highlight/highlight.action';
@@ -9,6 +9,7 @@ import { TabIds } from '../domain/mainMenu';
 import { createUniqueId } from '../utils/numberUtils';
 import { $injector } from '../injection/index';
 import { QueryParameters } from '../domain/queryParameters';
+import { isCoordinate } from '../utils/checks';
 
 /**
  * Id of the layer used for highlight visualization.
@@ -106,35 +107,25 @@ export class HighlightPlugin extends BaPlugin {
 		};
 
 		const { EnvironmentService: environmentService } = $injector.inject('EnvironmentService');
-		const crosshair = environmentService.getQueryParams().get(QueryParameters.CROSSHAIR);
 
-		if (crosshair) {
+		if (environmentService.getQueryParams().get(QueryParameters.CROSSHAIR)) {
+			const crosshairValues = environmentService.getQueryParams().get(QueryParameters.CROSSHAIR).split(',');
 			setTimeout(() => {
-				const initialCoord = store.getState().position.center;
-				const type = HighlightFeatureType.MARKER;
-				addHighlightFeatures({
-					id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
-					label: translate('global_marker_symbol_label'),
-					data: { coordinate: initialCoord },
-					type
-				});
-				observeOnce(
-					store,
-					(state) => state.position.center,
-					() => {
-						/**
-						 * To avoid further state encoding (see ShareService) of the CROSSHAIR query param, we remove the CROSSHAIR_HIGHLIGHT_FEATURE_ID feature
-						 * after the map was relocated the first time and immediately add the optically same feature with a different id
-						 */
-						removeHighlightFeaturesById(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
-						addHighlightFeatures({
-							id: `${createUniqueId()}`,
-							label: translate('global_marker_symbol_label'),
-							data: { coordinate: initialCoord },
-							type
-						});
-					}
-				);
+				const crosshairCoordinate =
+					crosshairValues.length > 1
+						? isFinite(crosshairValues[1]) && isFinite(crosshairValues[2])
+							? [crosshairValues[1], crosshairValues[2]].map((v) => parseFloat(v))
+							: null
+						: store.getState().position.center;
+
+				if (isCoordinate(crosshairCoordinate)) {
+					addHighlightFeatures({
+						id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
+						label: translate('global_marker_symbol_label'),
+						data: { coordinate: crosshairCoordinate },
+						type: HighlightFeatureType.MARKER
+					});
+				}
 			});
 		}
 

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -110,16 +110,30 @@ export class HighlightPlugin extends BaPlugin {
 
 		if (crosshair) {
 			setTimeout(() => {
+				const initialCoord = store.getState().position.center;
+				const type = HighlightFeatureType.MARKER;
 				addHighlightFeatures({
 					id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
 					label: translate('global_marker_symbol_label'),
-					data: { coordinate: store.getState().position.center },
-					type: HighlightFeatureType.MARKER
+					data: { coordinate: initialCoord },
+					type
 				});
 				observeOnce(
 					store,
 					(state) => state.position.center,
-					() => removeHighlightFeaturesById(CROSSHAIR_HIGHLIGHT_FEATURE_ID)
+					() => {
+						/**
+						 * To avoid further state encoding (see ShareService) of the CROSSHAIR query param, we remove the CROSSHAIR_HIGHLIGHT_FEATURE_ID feature
+						 * after the map was relocated the first time and immediately add the optically same feature with a different id
+						 */
+						removeHighlightFeaturesById(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
+						addHighlightFeatures({
+							id: `${createUniqueId()}`,
+							label: translate('global_marker_symbol_label'),
+							data: { coordinate: initialCoord },
+							type
+						});
+					}
 				);
 			});
 		}

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -284,7 +284,8 @@ export class ShareService {
 		 * When we have exactly one highlight feature containing the CROSSHAIR_HIGHLIGHT_FEATURE_ID we add the CROSSHAIR query parameter.
 		 */
 		if (features.filter((hf) => hf.id === CROSSHAIR_HIGHLIGHT_FEATURE_ID).length === 1) {
-			extractedState[QueryParameters.CROSSHAIR] = true;
+			const feature = features.find((hf) => hf.id === CROSSHAIR_HIGHLIGHT_FEATURE_ID);
+			extractedState[QueryParameters.CROSSHAIR] = [true, ...feature.data.coordinate];
 		}
 
 		return extractedState;

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -242,7 +242,10 @@ export class ShareService {
 		} = state;
 
 		if (waypoints.length > 0) {
-			extractedState[QueryParameters.ROUTE_WAYPOINTS] = waypoints;
+			const { MapService: mapService } = $injector.inject('MapService');
+			// waypoints should be rounded according to the internal projection of the map
+			const { digits } = Object.values(GlobalCoordinateRepresentations).filter((cr) => cr.code === mapService.getSrid())[0];
+			extractedState[QueryParameters.ROUTE_WAYPOINTS] = waypoints.map((wp) => wp.map((n) => n.toFixed(digits)));
 			extractedState[QueryParameters.ROUTE_CATEGORY] = categoryId;
 		}
 		return extractedState;

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -71,7 +71,7 @@ export class ShareService {
 			...this._extractTopic(),
 			...this._extractRoute(),
 			...this._extractTool(),
-			...this._extractMarker()
+			...this._extractCrosshair()
 		};
 
 		return new Map(Object.entries(params));
@@ -114,7 +114,7 @@ export class ShareService {
 				...this._extractTopic(),
 				...this._extractRoute(),
 				...this._extractTool(),
-				...this._extractMarker()
+				...this._extractCrosshair()
 			},
 			extraParams
 		);
@@ -270,7 +270,7 @@ export class ShareService {
 	 * @private
 	 * @returns {object} extractedState
 	 */
-	_extractMarker() {
+	_extractCrosshair() {
 		const { StoreService: storeService } = $injector.inject('StoreService');
 
 		const state = storeService.getStore().getState();
@@ -284,8 +284,12 @@ export class ShareService {
 		 * When we have exactly one highlight feature containing the CROSSHAIR_HIGHLIGHT_FEATURE_ID we add the CROSSHAIR query parameter.
 		 */
 		if (features.filter((hf) => hf.id === CROSSHAIR_HIGHLIGHT_FEATURE_ID).length === 1) {
+			const { MapService: mapService } = $injector.inject('MapService');
+			// crosshair coordinate should be rounded according to the internal projection of the map
+			const { digits } = Object.values(GlobalCoordinateRepresentations).filter((cr) => cr.code === mapService.getSrid())[0];
 			const feature = features.find((hf) => hf.id === CROSSHAIR_HIGHLIGHT_FEATURE_ID);
-			extractedState[QueryParameters.CROSSHAIR] = [true, ...feature.data.coordinate];
+			const crosshairCoords = feature.data.coordinate.map((n) => n.toFixed(digits));
+			extractedState[QueryParameters.CROSSHAIR] = [true, ...crosshairCoords];
 		}
 
 		return extractedState;

--- a/test/modules/chips/components/ShareChip.test.js
+++ b/test/modules/chips/components/ShareChip.test.js
@@ -18,10 +18,10 @@ describe('ShareChip', () => {
 			return Promise.resolve();
 		},
 		encodeStateForPosition() {
-			return 'http://this.is.a.url?forTestCase';
+			return 'http://this.is.a.url?foo=bar';
 		},
 		encodeState() {
-			return 'http://this.is.a.url?forTestCase';
+			return 'http://this.is.a.url?foo=bar';
 		}
 	};
 
@@ -103,7 +103,8 @@ describe('ShareChip', () => {
 
 				await TestUtils.timeout();
 				expect(shortenerSpy).toHaveBeenCalledTimes(1);
-				expect(shareServiceSpy).toHaveBeenCalledWith({ center: [42, 21] }, { [QueryParameters.CROSSHAIR]: true });
+				expect(shortenerSpy.calls.all()[0].args[0]).toBe(`http://this.is.a.url/?foo=bar&${QueryParameters.CROSSHAIR}=true`);
+				expect(shareServiceSpy).toHaveBeenCalledWith({ center: [42, 21] });
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 			});
 
@@ -134,7 +135,7 @@ describe('ShareChip', () => {
 
 				await TestUtils.timeout();
 				expect(shortenerSpy).toHaveBeenCalledTimes(1);
-				expect(shareServiceSpy).toHaveBeenCalledWith({ center: [42, 21] }, { [QueryParameters.CROSSHAIR]: true });
+				expect(shareServiceSpy).toHaveBeenCalledTimes(1);
 
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -285,7 +285,7 @@ describe('HighlightPlugin', () => {
 			expect(store.getState().highlight.features[0].id).toBe(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
 		});
 
-		it('removes the highlight feature once on the first change of the `center` property of the position s-o-s', async () => {
+		it('replaces the highlight feature on the first change of the `center` property of the position s-o-s', async () => {
 			const coordinate0 = [42, 21];
 			const coordinate1 = [55, 22];
 			const coordinate2 = [99, 33];
@@ -304,15 +304,8 @@ describe('HighlightPlugin', () => {
 
 			changeCenter(coordinate1);
 
-			expect(store.getState().highlight.features).toHaveSize(0);
-
-			addHighlightFeatures({
-				id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
-				label: '',
-				data: { coordinate: coordinate1 },
-				type: HighlightFeatureType.MARKER
-			});
 			expect(store.getState().highlight.features).toHaveSize(1);
+			expect(store.getState().highlight.features.id).not.toBe(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
 
 			changeCenter(coordinate2);
 

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -14,7 +14,6 @@ import { layersReducer } from '../../src/store/layers/layers.reducer';
 import { pointerReducer } from '../../src/store/pointer/pointer.reducer';
 import { createNoInitialStateMainMenuReducer } from '../../src/store/mainMenu/mainMenu.reducer';
 import { setTab } from '../../src/store/mainMenu/mainMenu.action';
-import { changeCenter } from '../../src/store/position/position.action';
 import { TabIds } from '../../src/domain/mainMenu';
 import { setClick } from '../../src/store/pointer/pointer.action';
 import { featureInfoReducer } from '../../src/store/featureInfo/featureInfo.reducer';
@@ -285,31 +284,26 @@ describe('HighlightPlugin', () => {
 			expect(store.getState().highlight.features[0].id).toBe(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
 		});
 
-		it('replaces the highlight feature on the first change of the `center` property of the position s-o-s', async () => {
-			const coordinate0 = [42, 21];
-			const coordinate1 = [55, 22];
-			const coordinate2 = [99, 33];
-			const state = {
-				position: { center: coordinate0 }
-			};
-			const store = setup(state);
-			const queryParam = new URLSearchParams(QueryParameters.CROSSHAIR + '=some');
-			spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(queryParam);
-			const instanceUnderTest = new HighlightPlugin();
-			await instanceUnderTest.register(store);
+		describe("when search query parameter 'CROSSHAIR' has a value and valid coordinates", () => {
+			it('adds a highlight feature', async () => {
+				const coordinate = [42, 21];
+				const state = {
+					position: { center: coordinate }
+				};
+				const store = setup(state);
+				const queryParam = new URLSearchParams(`${QueryParameters.CROSSHAIR}=true,42,21`);
+				spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(queryParam);
+				const instanceUnderTest = new HighlightPlugin();
+				await instanceUnderTest.register(store);
 
-			await TestUtils.timeout();
+				await TestUtils.timeout();
 
-			expect(store.getState().highlight.features).toHaveSize(1);
-
-			changeCenter(coordinate1);
-
-			expect(store.getState().highlight.features).toHaveSize(1);
-			expect(store.getState().highlight.features.id).not.toBe(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
-
-			changeCenter(coordinate2);
-
-			expect(store.getState().highlight.features).toHaveSize(1);
+				expect(store.getState().highlight.features).toHaveSize(1);
+				expect(store.getState().highlight.features[0].data.coordinate).toEqual([42, 21]);
+				expect(store.getState().highlight.features[0].label).toBe('global_marker_symbol_label');
+				expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.MARKER);
+				expect(store.getState().highlight.features[0].id).toBe(CROSSHAIR_HIGHLIGHT_FEATURE_ID);
+			});
 		});
 	});
 
@@ -322,6 +316,24 @@ describe('HighlightPlugin', () => {
 			const store = setup(state);
 			const emptyQueryParam = new URLSearchParams(QueryParameters.CROSSHAIR + '=');
 			spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(emptyQueryParam);
+			const instanceUnderTest = new HighlightPlugin();
+			await instanceUnderTest.register(store);
+
+			await TestUtils.timeout();
+
+			expect(store.getState().highlight.features).toHaveSize(0);
+		});
+	});
+
+	describe("when search query parameter 'CROSSHAIR' contains invalid coordinates", () => {
+		it('does NOT add a highlight feature', async () => {
+			const coordinate = [42, 21];
+			const state = {
+				position: { center: coordinate }
+			};
+			const store = setup(state);
+			const queryParam = new URLSearchParams(`${QueryParameters.CROSSHAIR}="true,foo,bar"`);
+			spyOn(environmentServiceMock, 'getQueryParams').and.returnValue(queryParam);
 			const instanceUnderTest = new HighlightPlugin();
 			await instanceUnderTest.register(store);
 

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -315,6 +315,8 @@ describe('ShareService', () => {
 		describe('_extractRoute', () => {
 			it('extracts the current route', () => {
 				setup();
+				const mapSrid = 3857;
+				spyOn(mapService, 'getSrid').and.returnValue(mapSrid);
 				const categoryId = 'catId';
 				const waypoints = [
 					[1, 2],
@@ -328,7 +330,10 @@ describe('ShareService', () => {
 				const extract = instanceUnderTest._extractRoute();
 
 				expect(extract[QueryParameters.ROUTE_CATEGORY]).toBe(categoryId);
-				expect(extract[QueryParameters.ROUTE_WAYPOINTS]).toEqual(waypoints);
+				expect(extract[QueryParameters.ROUTE_WAYPOINTS]).toEqual([
+					['1.000000', '2.000000'],
+					['3.000000', '4.000000']
+				]);
 			});
 
 			it('does nothing when no waypoints are available', () => {
@@ -357,7 +362,7 @@ describe('ShareService', () => {
 						{
 							id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
 							type: HighlightFeatureType.MARKER,
-							data: { coordinate: [42.1234567, 21.1234567] }
+							data: { coordinate: [42, 21] }
 						},
 						{
 							id: 'hf_id1',
@@ -368,7 +373,7 @@ describe('ShareService', () => {
 
 					const extract = instanceUnderTest._extractCrosshair();
 
-					expect(extract[QueryParameters.CROSSHAIR]).toEqual([true, '42.123457', '21.123457']);
+					expect(extract[QueryParameters.CROSSHAIR]).toEqual([true, '42.000000', '21.000000']);
 				});
 			});
 

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -355,18 +355,18 @@ describe('ShareService', () => {
 						{
 							id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
 							type: HighlightFeatureType.MARKER,
-							data: {}
+							data: { coordinate: [42, 21] }
 						},
 						{
 							id: 'hf_id1',
 							type: HighlightFeatureType.DEFAULT,
-							data: {}
+							data: { coordinate: [77, 55] }
 						}
 					]);
 
 					const extract = instanceUnderTest._extractMarker();
 
-					expect(extract[QueryParameters.CROSSHAIR]).toBeTrue();
+					expect(extract[QueryParameters.CROSSHAIR]).toEqual([true, 42, 21]);
 				});
 			});
 
@@ -378,12 +378,12 @@ describe('ShareService', () => {
 						{
 							id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
 							type: HighlightFeatureType.MARKER,
-							data: {}
+							data: { coordinate: [42, 21] }
 						},
 						{
 							id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
 							type: HighlightFeatureType.MARKER,
-							data: {}
+							data: { coordinate: [77, 55] }
 						}
 					]);
 

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -346,16 +346,18 @@ describe('ShareService', () => {
 			});
 		});
 
-		describe('_extractMarker', () => {
+		describe('_extractCrosshair', () => {
 			describe('exactly one suitable highlight feature is available', () => {
 				it('sets the crosshair query parameter', () => {
 					setup();
+					const mapSrid = 3857;
+					spyOn(mapService, 'getSrid').and.returnValue(mapSrid);
 					const instanceUnderTest = new ShareService();
 					addHighlightFeatures([
 						{
 							id: CROSSHAIR_HIGHLIGHT_FEATURE_ID,
 							type: HighlightFeatureType.MARKER,
-							data: { coordinate: [42, 21] }
+							data: { coordinate: [42.1234567, 21.1234567] }
 						},
 						{
 							id: 'hf_id1',
@@ -364,9 +366,9 @@ describe('ShareService', () => {
 						}
 					]);
 
-					const extract = instanceUnderTest._extractMarker();
+					const extract = instanceUnderTest._extractCrosshair();
 
-					expect(extract[QueryParameters.CROSSHAIR]).toEqual([true, 42, 21]);
+					expect(extract[QueryParameters.CROSSHAIR]).toEqual([true, '42.123457', '21.123457']);
 				});
 			});
 
@@ -387,7 +389,7 @@ describe('ShareService', () => {
 						}
 					]);
 
-					const extract = instanceUnderTest._extractMarker();
+					const extract = instanceUnderTest._extractCrosshair();
 
 					expect(extract[QueryParameters.CROSSHAIR]).toBeUndefined();
 				});
@@ -398,7 +400,7 @@ describe('ShareService', () => {
 					setup();
 					const instanceUnderTest = new ShareService();
 
-					const extract = instanceUnderTest._extractMarker();
+					const extract = instanceUnderTest._extractCrosshair();
 
 					expect(extract[QueryParameters.CROSSHAIR]).toBeUndefined();
 				});
@@ -414,7 +416,7 @@ describe('ShareService', () => {
 						data: {}
 					});
 
-					const extract = instanceUnderTest._extractMarker();
+					const extract = instanceUnderTest._extractCrosshair();
 
 					expect(extract[QueryParameters.CROSSHAIR]).toBeUndefined();
 				});
@@ -523,7 +525,7 @@ describe('ShareService', () => {
 					spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
 					spyOn(instanceUnderTest, '_extractRoute').and.returnValue({ rtwp: '1,2', rtc: 'rtCatId' });
 					spyOn(instanceUnderTest, '_extractTool').and.returnValue({ tid: 'someTool' });
-					spyOn(instanceUnderTest, '_extractMarker').and.returnValue({ crh: 'true' });
+					spyOn(instanceUnderTest, '_extractCrosshair').and.returnValue({ crh: 'true' });
 					const _mergeExtraParamsSpy = spyOn(instanceUnderTest, '_mergeExtraParams').withArgs(jasmine.anything(), {}).and.callThrough();
 
 					const encoded = instanceUnderTest.encodeStateForPosition({ zoom: 5, center: [44.123, 88.123], rotation: 0.5 });
@@ -692,7 +694,7 @@ describe('ShareService', () => {
 			spyOn(instanceUnderTest, '_extractTopic').and.returnValue({ t: 'someTopic' });
 			spyOn(instanceUnderTest, '_extractRoute').and.returnValue({ rtwp: '1,2', rtc: 'rtCatId' });
 			spyOn(instanceUnderTest, '_extractTool').and.returnValue({ tid: 'someTool' });
-			spyOn(instanceUnderTest, '_extractMarker').and.returnValue({ crh: 'true' });
+			spyOn(instanceUnderTest, '_extractCrosshair').and.returnValue({ crh: 'true' });
 
 			const params = instanceUnderTest.getParameters();
 


### PR DESCRIPTION
This PR extends the CROSSHAIR query param by its coordinate to preserve the crosshair when shared after the map was relocated
```
http://localhost:8080/?crh=true,1340544.8149054,6318369.4588622
```
The coordinate is always in 3857.