### PR TITLE
rework file storage: adjust file result consumer

### DIFF
--- a/src/modules/public/components/PublicComponent.js
+++ b/src/modules/public/components/PublicComponent.js
@@ -37,12 +37,11 @@ export class PublicComponent extends MvuElement {
 		 * Publish public GEOMETRY_CHANGE event
 		 */
 		this.observe(
-			(state) => state.draw.fileSaveResult,
-			(fileSaveResult) => {
-				const { payload } = fileSaveResult;
+			(state) => state.fileStorage.data,
+			(data) => {
 				this.dispatchEvent(
 					new CustomEvent(WcEvents.GEOMETRY_CHANGE, {
-						detail: payload ? { data: payload.content, type: MediaType.KML } : null,
+						detail: data ? { data: data, type: MediaType.KML } : null,
 						bubbles: true,
 						composed: true
 					})

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -13,6 +13,7 @@ import { AbstractToolContent } from '../toolContainer/AbstractToolContent';
 import { emitNotification, LevelTypes } from '../../../../store/notifications/notifications.action';
 
 const Update = 'update';
+const Update_StoredContent = 'update_storedContent';
 
 /**
  * @class
@@ -24,7 +25,7 @@ export class MeasureToolContent extends AbstractToolContent {
 		super({
 			statistic: { length: null, area: null },
 			mode: null,
-			fileSaveResult: null
+			storedContent: null
 		});
 
 		const {
@@ -44,6 +45,10 @@ export class MeasureToolContent extends AbstractToolContent {
 			(state) => state.measurement,
 			(data) => this.signal(Update, data)
 		);
+		this.observe(
+			(state) => state.fileStorage.data,
+			(data) => this.signal(Update_StoredContent, data)
+		);
 	}
 
 	update(type, data, model) {
@@ -52,15 +57,16 @@ export class MeasureToolContent extends AbstractToolContent {
 				return {
 					...model,
 					statistic: data.statistic,
-					mode: data.mode,
-					fileSaveResult: data?.fileSaveResult?.payload ?? null
+					mode: data.mode
 				};
+			case Update_StoredContent:
+				return { ...model, storedContent: data };
 		}
 	}
 
 	createView(model) {
 		const translate = (key) => this._translationService.translate(key);
-		const { statistic, fileSaveResult } = model;
+		const { statistic, storedContent } = model;
 		const areaClasses = { 'is-area': statistic.area != null };
 
 		const buttons = this._getButtons(model);
@@ -116,7 +122,7 @@ export class MeasureToolContent extends AbstractToolContent {
 				<div class='chips__container'> 
 					<ba-profile-chip></ba-profile-chip>
 					<ba-share-data-chip></ba-share-data-chip>
-					<ba-export-vector-data-chip .exportData=${fileSaveResult?.content}></ba-export-vector-data-chip>
+					<ba-export-vector-data-chip .exportData=${storedContent}></ba-export-vector-data-chip>
 				</div>				
 				<div class="ba-tool-container__actions">                         						 
 					${buttons}					

--- a/src/plugins/IframeGeometryIdPlugin.js
+++ b/src/plugins/IframeGeometryIdPlugin.js
@@ -23,18 +23,11 @@ export class IframeGeometryIdPlugin extends BaPlugin {
 	 */
 	async register(store) {
 		if (this._environmentService.isEmbedded()) {
-			const update = (eventLike) => {
-				const { payload } = eventLike;
-				const getFileId = () => {
-					const {
-						fileSaveResult: { fileId }
-					} = payload;
-					return fileId;
-				};
-				this._updateAttribute(eventLike.payload ? getFileId() : null);
-			};
-
-			observe(store, (state) => state.draw.fileSaveResult, update);
+			observe(
+				store,
+				(state) => state.fileStorage.fileId,
+				(fileId) => this._updateAttribute(fileId ?? null)
+			);
 		}
 	}
 

--- a/src/store/fileStorage/fileStorage.action.js
+++ b/src/store/fileStorage/fileStorage.action.js
@@ -7,6 +7,7 @@ import { EventLike } from '../../utils/storeUtils';
 import {
 	ADMIN_ID_CHANGED,
 	DATA_CHANGED,
+	CLEARED,
 	LATEST_AND_ADMIN_AND_FILE_ID_CHANGED,
 	LATEST_AND_FILE_ID_CHANGED,
 	LATEST_CHANGED
@@ -49,6 +50,13 @@ export const setData = (data) => {
 			payload: data
 		});
 	}
+};
+
+export const clear = () => {
+	getStore().dispatch({
+		type: CLEARED,
+		payload: null
+	});
 };
 
 /**

--- a/src/store/fileStorage/fileStorage.action.js
+++ b/src/store/fileStorage/fileStorage.action.js
@@ -52,6 +52,10 @@ export const setData = (data) => {
 	}
 };
 
+/**
+ * Clears and resets the fileStorage to the default values
+ * @function
+ */
 export const clear = () => {
 	getStore().dispatch({
 		type: CLEARED,

--- a/src/store/fileStorage/fileStorage.action.js
+++ b/src/store/fileStorage/fileStorage.action.js
@@ -53,7 +53,7 @@ export const setData = (data) => {
 };
 
 /**
- * Clears and resets the fileStorage to the default values
+ * Clears and resets the fileStorage to the default values.
  * @function
  */
 export const clear = () => {

--- a/src/store/fileStorage/fileStorage.reducer.js
+++ b/src/store/fileStorage/fileStorage.reducer.js
@@ -25,7 +25,7 @@ export const initialState = {
 	/**
 	 * @property {EventLike<module:store/fileStorage/fileStorage_action~FileStorageResult|null>}
 	 */
-	latest: new EventLike(null)
+	latest: new EventLike({ success: false, created: null, lastSaved: null })
 };
 
 export const fileStorageReducer = (state = initialState, action) => {

--- a/src/store/fileStorage/fileStorage.reducer.js
+++ b/src/store/fileStorage/fileStorage.reducer.js
@@ -2,6 +2,7 @@ import { EventLike } from '../../utils/storeUtils';
 
 export const ADMIN_ID_CHANGED = 'fileStorage/adminId';
 export const ADMIN_AND_FILE_ID_CHANGED = 'fileStorage/adminAndFileId';
+export const CLEARED = 'fileStorage/clear';
 export const DATA_CHANGED = 'fileStorage/data';
 export const LATEST_CHANGED = 'fileStorage/latest';
 export const LATEST_AND_FILE_ID_CHANGED = 'fileStorage/latestAndFileId';
@@ -41,6 +42,9 @@ export const fileStorageReducer = (state = initialState, action) => {
 				...state,
 				data: payload
 			};
+		}
+		case CLEARED: {
+			return initialState;
 		}
 		case LATEST_CHANGED: {
 			return {

--- a/test/modules/chips/components/ShareDataChip.test.js
+++ b/test/modules/chips/components/ShareDataChip.test.js
@@ -13,12 +13,7 @@ window.customElements.define(ShareDialogContent.tag, ShareDialogContent);
 window.customElements.define(ShareDataChip.tag, ShareDataChip);
 
 describe('ShareDataChip', () => {
-	const defaultState = {
-		shared: {
-			fileSaveResult: null,
-			coordinates: []
-		}
-	};
+	const defaultState = { adminId: null, fileId: null, latest: new EventLike({ success: false }) };
 
 	let store;
 	const shareServiceMock = {
@@ -36,7 +31,7 @@ describe('ShareDataChip', () => {
 	};
 	const setup = async (state = defaultState) => {
 		const windowMock = { navigator: {}, open() {} };
-		store = TestUtils.setupStoreAndDi(state, { modal: modalReducer, shared: sharedReducer, fileStorage: fileStorageReducer });
+		store = TestUtils.setupStoreAndDi({ fileStorage: state }, { modal: modalReducer, shared: sharedReducer, fileStorage: fileStorageReducer });
 		$injector
 			.registerSingleton('EnvironmentService', {
 				getWindow: () => windowMock
@@ -65,7 +60,7 @@ describe('ShareDataChip', () => {
 
 	describe('when initialized', () => {
 		it('renders the view with given FileSaveResults', async () => {
-			const state = { ...defaultState, fileStorage: { adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) } };
+			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			expect(element.isVisible()).toBeTrue();
@@ -78,9 +73,7 @@ describe('ShareDataChip', () => {
 		});
 
 		it('does NOT render the view with invalid FileSaveResult', async () => {
-			const invalidFileStorage = { adminId: null, fileId: null, latest: new EventLike({ success: false }) };
-			const state = { ...defaultState, fileStorage: invalidFileStorage };
-			const element = await setup(state);
+			const element = await setup();
 
 			expect(element.isVisible()).toBeFalse();
 		});
@@ -88,9 +81,8 @@ describe('ShareDataChip', () => {
 
 	describe('when chip is clicked', () => {
 		it('opens the modal with shortened share-urls', async () => {
-			const fileStorageState = { adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const shortenerSpy = spyOn(urlServiceMock, 'shorten').and.callFake(() => Promise.resolve('http://shorten.foo'));
-			const state = { ...defaultState, fileStorage: fileStorageState };
+			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			const button = element.shadowRoot.querySelector('button');
@@ -106,10 +98,9 @@ describe('ShareDataChip', () => {
 		});
 
 		it('explicitly sets the TOOL_ID query parameter', async () => {
-			const fileStorageState = { adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const shortenerSpy = spyOn(urlServiceMock, 'shorten').and.callFake(() => Promise.resolve('http://shorten.foo'));
 			spyOn(shareServiceMock, 'encodeState').and.returnValue(`http://foo.bar?${QueryParameters.TOOL_ID}=someTool`);
-			const state = { ...defaultState, fileStorage: fileStorageState };
+			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			const button = element.shadowRoot.querySelector('button');
@@ -126,8 +117,7 @@ describe('ShareDataChip', () => {
 		it('logs a warning', async () => {
 			const shortenerSpy = spyOn(urlServiceMock, 'shorten').and.callFake(() => Promise.reject('not available'));
 			const warnSpy = spyOn(console, 'warn');
-			const fileStorageState = { adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
-			const state = { ...defaultState, fileStorage: fileStorageState };
+			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			const button = element.shadowRoot.querySelector('button');

--- a/test/modules/chips/components/ShareDataChip.test.js
+++ b/test/modules/chips/components/ShareDataChip.test.js
@@ -4,7 +4,7 @@ import { modalReducer } from '../../../../src/store/modal/modal.reducer';
 import { TestUtils } from '../../../test-utils';
 import shareSvg from '../../../../src/modules/chips/components/assistChips/assets/share.svg';
 import { sharedReducer } from '../../../../src/store/shared/shared.reducer';
-import { fileStorageReducer } from '../../../../src/store/fileStorage/fileStorage.reducer';
+import { fileStorageReducer, initialState } from '../../../../src/store/fileStorage/fileStorage.reducer';
 import { ShareDialogContent } from '../../../../src/modules/share/components/dialog/ShareDialogContent';
 import { QueryParameters } from '../../../../src/domain/queryParameters';
 import { EventLike } from '../../../../src/utils/storeUtils';
@@ -13,8 +13,6 @@ window.customElements.define(ShareDialogContent.tag, ShareDialogContent);
 window.customElements.define(ShareDataChip.tag, ShareDataChip);
 
 describe('ShareDataChip', () => {
-	const defaultState = { adminId: null, fileId: null, latest: new EventLike({ success: false }) };
-
 	let store;
 	const shareServiceMock = {
 		copyToClipboard() {
@@ -29,7 +27,7 @@ describe('ShareDataChip', () => {
 			return Promise.resolve('http://foo');
 		}
 	};
-	const setup = async (state = defaultState) => {
+	const setup = async (state = initialState) => {
 		const windowMock = { navigator: {}, open() {} };
 		store = TestUtils.setupStoreAndDi({ fileStorage: state }, { modal: modalReducer, shared: sharedReducer, fileStorage: fileStorageReducer });
 		$injector
@@ -60,7 +58,7 @@ describe('ShareDataChip', () => {
 
 	describe('when initialized', () => {
 		it('renders the view with given FileSaveResults', async () => {
-			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
+			const state = { ...initialState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			expect(element.isVisible()).toBeTrue();
@@ -82,7 +80,7 @@ describe('ShareDataChip', () => {
 	describe('when chip is clicked', () => {
 		it('opens the modal with shortened share-urls', async () => {
 			const shortenerSpy = spyOn(urlServiceMock, 'shorten').and.callFake(() => Promise.resolve('http://shorten.foo'));
-			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
+			const state = { ...initialState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			const button = element.shadowRoot.querySelector('button');
@@ -100,7 +98,7 @@ describe('ShareDataChip', () => {
 		it('explicitly sets the TOOL_ID query parameter', async () => {
 			const shortenerSpy = spyOn(urlServiceMock, 'shorten').and.callFake(() => Promise.resolve('http://shorten.foo'));
 			spyOn(shareServiceMock, 'encodeState').and.returnValue(`http://foo.bar?${QueryParameters.TOOL_ID}=someTool`);
-			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
+			const state = { ...initialState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			const button = element.shadowRoot.querySelector('button');
@@ -117,7 +115,7 @@ describe('ShareDataChip', () => {
 		it('logs a warning', async () => {
 			const shortenerSpy = spyOn(urlServiceMock, 'shorten').and.callFake(() => Promise.reject('not available'));
 			const warnSpy = spyOn(console, 'warn');
-			const state = { ...defaultState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
+			const state = { ...initialState, adminId: 'a_fooBar', fileId: 'f_fooBar', latest: new EventLike({ success: true }) };
 			const element = await setup(state);
 
 			const button = element.shadowRoot.querySelector('button');

--- a/test/modules/public/components/PublicComponent.test.js
+++ b/test/modules/public/components/PublicComponent.test.js
@@ -1,8 +1,8 @@
 import { WcEvents } from '../../../../src/domain/wcEvents';
 import { PublicComponent } from '../../../../src/modules/public/components/PublicComponent';
 import { TestUtils } from '../../../test-utils';
-import { setFileSaveResult } from '../../../../src/store/draw/draw.action';
-import { drawReducer } from '../../../../src/store/draw/draw.reducer';
+import { clear, setData } from '../../../../src/store/fileStorage/fileStorage.action';
+import { fileStorageReducer } from '../../../../src/store/fileStorage/fileStorage.reducer';
 import { featureInfoReducer } from '../../../../src/store/featureInfo/featureInfo.reducer';
 import { MediaType } from '../../../../src/domain/mediaTypes';
 import { addFeatureInfoItems, registerQuery, resolveQuery, startRequest } from '../../../../src/store/featureInfo/featureInfo.action';
@@ -20,7 +20,11 @@ describe('PublicComponent', () => {
 			...state
 		};
 
-		TestUtils.setupStoreAndDi(initialState, { draw: drawReducer, featureInfo: featureInfoReducer, media: createNoInitialStateMediaReducer() });
+		TestUtils.setupStoreAndDi(initialState, {
+			featureInfo: featureInfoReducer,
+			media: createNoInitialStateMediaReducer(),
+			fileStorage: fileStorageReducer
+		});
 		return TestUtils.render(PublicComponent.tag);
 	};
 
@@ -124,7 +128,7 @@ describe('PublicComponent', () => {
 			element.addEventListener(WcEvents.GEOMETRY_CHANGE, elementListener);
 			window.addEventListener(WcEvents.GEOMETRY_CHANGE, windowListener);
 
-			setFileSaveResult({ content, fileSaveResult: { adminId: 'adminId', fileId: 'fileId' } });
+			setData(content);
 
 			expect(elementListener).toHaveBeenCalledOnceWith(jasmine.objectContaining(expectedEventDetailConfiguration));
 			expect(windowListener).toHaveBeenCalledOnceWith(jasmine.objectContaining(expectedEventDetailConfiguration));
@@ -140,10 +144,13 @@ describe('PublicComponent', () => {
 			const elementListener = jasmine.createSpy();
 			const windowListener = jasmine.createSpy();
 			const element = await setup();
+
+			setData('someContent');
+
 			element.addEventListener(WcEvents.GEOMETRY_CHANGE, elementListener);
 			window.addEventListener(WcEvents.GEOMETRY_CHANGE, windowListener);
 
-			setFileSaveResult(null);
+			clear();
 
 			expect(elementListener).toHaveBeenCalledOnceWith(jasmine.objectContaining(expectedEventDetailConfiguration));
 			expect(windowListener).toHaveBeenCalledOnceWith(jasmine.objectContaining(expectedEventDetailConfiguration));

--- a/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
+++ b/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
@@ -11,6 +11,8 @@ import { IconSelect } from '../../../../../src/modules/iconSelect/components/Ico
 import { createNoInitialStateMediaReducer } from '../../../../../src/store/media/media.reducer';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
 import { elevationProfileReducer } from '../../../../../src/store/elevationProfile/elevationProfile.reducer';
+import { fileStorageReducer } from '../../../../../src/store/fileStorage/fileStorage.reducer.js';
+import { setData } from '../../../../../src/store/fileStorage/fileStorage.action.js';
 
 window.customElements.define(DrawToolContent.tag, DrawToolContent);
 window.customElements.define(IconSelect.tag, IconSelect);
@@ -62,7 +64,8 @@ describe('DrawToolContent', () => {
 			draw: drawReducer,
 			modal: modalReducer,
 			media: createNoInitialStateMediaReducer(),
-			elevationProfile: elevationProfileReducer
+			elevationProfile: elevationProfileReducer,
+			fileStorage: fileStorageReducer
 		});
 		$injector
 			.registerSingleton('EnvironmentService', {
@@ -98,7 +101,7 @@ describe('DrawToolContent', () => {
 				tools: jasmine.any(Array),
 				collapsedInfo: null,
 				collapsedStyle: null,
-				fileSaveResult: null
+				storedContent: null
 			});
 		});
 	});
@@ -667,9 +670,9 @@ describe('DrawToolContent', () => {
 				...drawDefaultState,
 				mode: 'draw',
 				type: 'polygon',
-				validGeometry: true,
-				fileSaveResult: new EventLike({ fileSaveResult: 'foo', content: exportData })
+				validGeometry: true
 			});
+			setData(exportData);
 			const chipElement = element.shadowRoot.querySelector('ba-export-vector-data-chip');
 
 			expect(chipElement.exportData).toBe(exportData);

--- a/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
+++ b/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
@@ -36,8 +36,7 @@ describe('DrawToolContent', () => {
 		style: null,
 		mode: null,
 		type: null,
-		reset: null,
-		fileSaveResult: null
+		reset: null
 	};
 
 	const StyleOptionTemplate = {

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -30,8 +30,7 @@ describe('MeasureToolContent', () => {
 			remove: null
 		},
 		shared: {
-			termsOfUseAcknowledged: false,
-			fileSaveResult: null
+			termsOfUseAcknowledged: false
 		}
 	};
 

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -10,6 +10,8 @@ import { LevelTypes } from '../../../../../src/store/notifications/notifications
 import { isString } from '../../../../../src/utils/checks';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
 import { elevationProfileReducer } from '../../../../../src/store/elevationProfile/elevationProfile.reducer';
+import { fileStorageReducer } from '../../../../../src/store/fileStorage/fileStorage.reducer.js';
+import { setData } from '../../../../../src/store/fileStorage/fileStorage.action.js';
 
 window.customElements.define(MeasureToolContent.tag, MeasureToolContent);
 
@@ -24,7 +26,6 @@ describe('MeasureToolContent', () => {
 			active: true,
 			statistic: { length: null, area: null },
 			mode: null,
-			fileSaveResult: null,
 			reset: null,
 			remove: null
 		},
@@ -71,7 +72,8 @@ describe('MeasureToolContent', () => {
 			measurement: measurementReducer,
 			modal: modalReducer,
 			notifications: notificationReducer,
-			elevationProfile: elevationProfileReducer
+			elevationProfile: elevationProfileReducer,
+			fileStorage: fileStorageReducer
 		});
 		$injector
 			.registerSingleton('EnvironmentService', {
@@ -99,7 +101,7 @@ describe('MeasureToolContent', () => {
 			await setup();
 			const model = new MeasureToolContent().getModel();
 
-			expect(model).toEqual({ statistic: { length: null, area: null }, mode: null, fileSaveResult: null });
+			expect(model).toEqual({ statistic: { length: null, area: null }, mode: null, storedContent: null });
 		});
 
 		it('displays the finish-button', async () => {
@@ -288,12 +290,12 @@ describe('MeasureToolContent', () => {
 			const state = {
 				measurement: {
 					statistic: { length: 42, area: 0 },
-					fileSaveResult: new EventLike({ fileSaveResult: 'foo', content: exportData }),
 					reset: null,
 					remove: null
 				}
 			};
 			const element = await setup(state);
+			setData(exportData);
 			const chipElement = element.shadowRoot.querySelector('ba-export-vector-data-chip');
 
 			expect(chipElement.exportData).toBe(exportData);

--- a/test/plugins/IframeGeometryIdPlugin.test.js
+++ b/test/plugins/IframeGeometryIdPlugin.test.js
@@ -2,10 +2,10 @@ import { html } from 'lit-html';
 import { $injector } from '../../src/injection';
 import { MvuElement } from '../../src/modules/MvuElement';
 import { IframeGeometryIdPlugin } from '../../src/plugins/IframeGeometryIdPlugin';
-import { setFileSaveResult } from '../../src/store/draw/draw.action';
-import { drawReducer } from '../../src/store/draw/draw.reducer';
 import { IFRAME_GEOMETRY_REFERENCE_ID } from '../../src/utils/markup';
 import { TestUtils } from '../test-utils';
+import { clear, setLatestStorageResultAndFileId } from '../../src/store/fileStorage/fileStorage.action';
+import { fileStorageReducer } from '../../src/store/fileStorage/fileStorage.reducer';
 
 class MvuElementParent extends MvuElement {
 	createView() {
@@ -32,14 +32,14 @@ describe('IframeGeometryIdPlugin', () => {
 		const store = TestUtils.setupStoreAndDi(
 			{},
 			{
-				draw: drawReducer
+				fileStorage: fileStorageReducer
 			}
 		);
 		$injector.registerSingleton('EnvironmentService', environmentService);
 		return store;
 	};
 
-	it('registers draw.fileSaveResult listeners and updates the iframes data attribute', async () => {
+	it('registers fileStorage.fileId listeners and updates the iframes data attribute', async () => {
 		const expectedGeometryId = 'foo';
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
 		const store = setup();
@@ -49,12 +49,12 @@ describe('IframeGeometryIdPlugin', () => {
 		await instanceUnderTest.register(store);
 
 		// drawing created
-		setFileSaveResult({ content: 'content', fileSaveResult: { adminId: 'adminId', fileId: expectedGeometryId } });
+		setLatestStorageResultAndFileId('content', expectedGeometryId);
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_GEOMETRY_REFERENCE_ID, expectedGeometryId);
 
 		// drawing deleted
-		setFileSaveResult(null);
+		clear();
 
 		expect(iframeSpy).toHaveBeenCalledWith(IFRAME_GEOMETRY_REFERENCE_ID, '');
 	});
@@ -66,7 +66,7 @@ describe('IframeGeometryIdPlugin', () => {
 		const updateAttributeSpy = spyOn(instanceUnderTest, '_updateAttribute');
 		await instanceUnderTest.register(store);
 
-		setFileSaveResult({ content: 'content', fileSaveResult: { adminId: 'adminId', fileId: 'fileId' } });
+		setLatestStorageResultAndFileId('content', 'fileId');
 
 		expect(updateAttributeSpy).not.toHaveBeenCalled();
 	});

--- a/test/store/fileStorage/fileStorage.reducer.test.js
+++ b/test/store/fileStorage/fileStorage.reducer.test.js
@@ -32,7 +32,7 @@ describe('fileStorageReducer', () => {
 		expect(store.getState().fileStorage.adminId).toBe('adminId');
 	});
 
-	it('clears the store and resets to default values', () => {
+	it('clears the store and resets to initial state', () => {
 		const store = setup();
 		const data = { foo: 'bar' };
 

--- a/test/store/fileStorage/fileStorage.reducer.test.js
+++ b/test/store/fileStorage/fileStorage.reducer.test.js
@@ -1,4 +1,5 @@
 import {
+	clear,
 	setAdminId,
 	setData,
 	setLatestStorageResult,
@@ -29,6 +30,20 @@ describe('fileStorageReducer', () => {
 		setAdminId('adminId');
 
 		expect(store.getState().fileStorage.adminId).toBe('adminId');
+	});
+
+	it('clears the store and resets to default values', () => {
+		const store = setup();
+		const data = { foo: 'bar' };
+
+		setData(data);
+
+		expect(store.getState().fileStorage.data).toEqual(data);
+
+		clear();
+
+		expect(store.getState().fileStorage.data).toBeNull();
+		expect(store.getState().fileStorage.data).toBeNull();
 	});
 
 	it('updates the `data` property', () => {

--- a/test/store/fileStorage/fileStorage.reducer.test.js
+++ b/test/store/fileStorage/fileStorage.reducer.test.js
@@ -36,14 +36,20 @@ describe('fileStorageReducer', () => {
 		const store = setup();
 		const data = { foo: 'bar' };
 
+		setLatestStorageResultAndAdminAndFileId({ success: true, created: 42, lastSaved: 21 }, 'a_fooBar', 'f_ooBar');
 		setData(data);
 
 		expect(store.getState().fileStorage.data).toEqual(data);
+		expect(store.getState().fileStorage.fileId).toBe('f_ooBar');
+		expect(store.getState().fileStorage.adminId).toBe('a_fooBar');
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: true, created: 42, lastSaved: 21 });
 
 		clear();
 
 		expect(store.getState().fileStorage.data).toBeNull();
-		expect(store.getState().fileStorage.data).toBeNull();
+		expect(store.getState().fileStorage.fileId).toBeNull();
+		expect(store.getState().fileStorage.adminId).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 	});
 
 	it('updates the `data` property', () => {

--- a/test/store/fileStorage/fileStorage.reducer.test.js
+++ b/test/store/fileStorage/fileStorage.reducer.test.js
@@ -21,7 +21,7 @@ describe('fileStorageReducer', () => {
 		expect(store.getState().fileStorage.adminId).toBeNull();
 		expect(store.getState().fileStorage.fileId).toBeNull();
 		expect(store.getState().fileStorage.data).toBeNull();
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 	});
 
 	it('updates the `adminId` property', () => {
@@ -65,7 +65,7 @@ describe('fileStorageReducer', () => {
 
 		setLatestStorageResult();
 
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 
 		setLatestStorageResult(result);
 
@@ -79,12 +79,12 @@ describe('fileStorageReducer', () => {
 
 		setLatestStorageResultAndFileId(result);
 
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.fileId).toBeNull();
 
 		setLatestStorageResultAndFileId(null, fileId);
 
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.fileId).toBeNull();
 
 		setLatestStorageResultAndFileId(result, fileId);
@@ -101,19 +101,19 @@ describe('fileStorageReducer', () => {
 
 		setLatestStorageResultAndAdminAndFileId(result);
 
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.adminId).toBeNull();
 		expect(store.getState().fileStorage.fileId).toBeNull();
 
 		setLatestStorageResultAndAdminAndFileId(null, adminId);
 
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.adminId).toBeNull();
 		expect(store.getState().fileStorage.fileId).toBeNull();
 
 		setLatestStorageResultAndAdminAndFileId(null, null);
 
-		expect(store.getState().fileStorage.latest.payload).toBeNull();
+		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.adminId).toBeNull();
 		expect(store.getState().fileStorage.fileId).toBeNull();
 


### PR DESCRIPTION
adjust all classes which consume the `fileResult` property of the `draw` or `mesurement` s-o-s:

- [x] MeasureToolContent
- [x] DrawToolContent
- [x] PublicComponent
- [x] IframeGeometryIdPlugin
- [x]  ShareDataChip