### PR TITLE
do not open the FeatureInfo tab when no result is available

### DIFF
--- a/src/plugins/MainMenuPlugin.js
+++ b/src/plugins/MainMenuPlugin.js
@@ -44,8 +44,8 @@ export class MainMenuPlugin extends BaPlugin {
 		this._open = store.getState().mainMenu.open;
 		this._previousTab = store.getState().mainMenu.tab;
 
-		const onFeatureInfoQueryingChanged = (querying) => {
-			if (!querying) {
+		const onFeatureInfoQueryingChanged = (querying, state) => {
+			if (!querying && state.featureInfo.current.length > 0) {
 				setTab(TabIds.FEATUREINFO);
 				open();
 			}

--- a/test/plugins/MainMenuPlugin.test.js
+++ b/test/plugins/MainMenuPlugin.test.js
@@ -171,6 +171,28 @@ describe('MainMenuPlugin', () => {
 				});
 			});
 		});
+
+		describe('and we have NO FeatureInfo items', () => {
+			describe('and MainMenu is initially closed', () => {
+				it('does nothing', async () => {
+					const queryId = 'foo';
+					const store = setup({
+						featureInfo: {
+							queries: [queryId],
+							querying: true,
+							current: []
+						}
+					});
+					const instanceUnderTest = new MainMenuPlugin();
+					await instanceUnderTest.register(store);
+
+					resolveQuery(queryId);
+
+					expect(store.getState().mainMenu.tab).toBe(defaultTabId);
+					expect(store.getState().mainMenu.open).toBeFalse();
+				});
+			});
+		});
 	});
 
 	describe('when featureInfo.aborted property changes', () => {


### PR DESCRIPTION
Avoid opening the FeatureInfo tab when it is closed and no feature info was found

![grafik](https://github.com/user-attachments/assets/303963e5-7842-4680-8bb8-18684ed3cecb)
