### PR TITLE
fix: icon size 45107039

### DIFF
--- a/src/modules/routing/components/waypoints/waypointItem.css
+++ b/src/modules/routing/components/waypoints/waypointItem.css
@@ -79,8 +79,8 @@
 
 ba-icon {
 	border-radius: 2.5em;
-	width: 2.6em;
-	height: 2.6em;
+	width: 2.6rem;
+	height: 2.6rem;
 	display: inline-block;
 }
 ba-icon:hover {


### PR DESCRIPTION
![nicht_zentriert](https://github.com/user-attachments/assets/39fab25c-8287-4230-98cb-317533d971db)
