### PR TITLE
rework the bottomSheet slice-of-state

### DIFF
--- a/src/plugins/ContextClickPlugin.js
+++ b/src/plugins/ContextClickPlugin.js
@@ -24,7 +24,7 @@ export class ContextClickPlugin extends BaPlugin {
 		const { EnvironmentService: environmentService } = $injector.inject('EnvironmentService');
 
 		const onBottomSheetChanged = (active) => {
-			if (active !== DEFAULT_BOTTOM_SHEET_ID) {
+			if (!active.includes(DEFAULT_BOTTOM_SHEET_ID)) {
 				bottomSheetOpenedFromHere = false;
 			}
 		};

--- a/src/plugins/ElevationProfilePlugin.js
+++ b/src/plugins/ElevationProfilePlugin.js
@@ -42,11 +42,11 @@ export class ElevationProfilePlugin extends BaPlugin {
 				this._bottomSheetUnsubscribeFn = observe(
 					store,
 					(state) => state.bottomSheet.active,
-					(activeId) => onActiveStateChanged(activeId === 'elevationProfile')
+					(activeIds) => onActiveStateChanged(activeIds.includes(ELEVATION_PROFILE_BOTTOM_SHEET_ID))
 				);
 				const content = html`<ba-elevation-profile></ba-elevation-profile>`;
 				const chunkName = 'elevation-profile';
-				openBottomSheet(html`<ba-lazy-load .chunkName=${chunkName} .content=${content}></ba-lazy-load>`, 'elevationProfile');
+				openBottomSheet(html`<ba-lazy-load .chunkName=${chunkName} .content=${content}></ba-lazy-load>`, ELEVATION_PROFILE_BOTTOM_SHEET_ID);
 			}
 		};
 
@@ -54,13 +54,15 @@ export class ElevationProfilePlugin extends BaPlugin {
 		observe(
 			store,
 			(state) => state.draw.active,
-			(active) => (active ? null : closeBottomSheet('elevationProfile'))
+			(active) => (active ? null : closeBottomSheet(ELEVATION_PROFILE_BOTTOM_SHEET_ID))
 		);
 		observe(
 			store,
 			(state) => state.measurement.active,
-			(active) => (active ? null : closeBottomSheet('elevationProfile'))
+			(active) => (active ? null : closeBottomSheet(ELEVATION_PROFILE_BOTTOM_SHEET_ID))
 		);
 		observe(store, (state) => state.featureInfo.current, onFeatureInfoSelected);
 	}
 }
+
+export const ELEVATION_PROFILE_BOTTOM_SHEET_ID = 'elevationProfile';

--- a/src/store/bottomSheet/bottomSheet.reducer.js
+++ b/src/store/bottomSheet/bottomSheet.reducer.js
@@ -49,6 +49,5 @@ export const bottomSheetReducer = (state = initialState, action) => {
 		}
 	}
 
-	console.log(state);
 	return state;
 };

--- a/src/store/bottomSheet/bottomSheet.reducer.js
+++ b/src/store/bottomSheet/bottomSheet.reducer.js
@@ -14,9 +14,10 @@ export const initialState = {
 	 */
 	data: [],
 	/**
-	 * @property {string| null}
+	 * The ids of all active sheets
+	 * @property {Array<String>}
 	 */
-	active: null
+	active: []
 };
 
 const addOrReplaceContent = (state, payload) => {
@@ -26,14 +27,13 @@ const addOrReplaceContent = (state, payload) => {
 		return content ? [payload, ...state.data] : state.data;
 	};
 	const replace = () => {
-		return content ? [payload, ...state.data.toSpliced(currentIndex, 1)] : state.data.with(currentIndex, { id, content: null });
+		return content ? [payload, ...state.data.toSpliced(currentIndex, 1)] : state.data.filter((btc) => btc.id !== id);
 	};
 	return currentIndex === -1 ? add() : replace();
 };
 
 const getActive = (bottomSheets) => {
-	const mostActiveBottomSheet = bottomSheets.find((b) => !!b.content);
-	return mostActiveBottomSheet ? mostActiveBottomSheet.id : null;
+	return bottomSheets.map((bts) => bts.id);
 };
 
 export const bottomSheetReducer = (state = initialState, action) => {
@@ -49,5 +49,6 @@ export const bottomSheetReducer = (state = initialState, action) => {
 		}
 	}
 
+	console.log(state);
 	return state;
 };

--- a/test/modules/commons/components/OverflowMenu.test.js
+++ b/test/modules/commons/components/OverflowMenu.test.js
@@ -311,7 +311,7 @@ describe('OverflowMenu', () => {
 			document.dispatchEvent(new Event('pointerdown'));
 
 			// menu is closed
-			expect(store.getState().bottomSheet.data).toEqual(jasmine.arrayWithExactContents([{ id: 'default', content: null }]));
+			expect(store.getState().bottomSheet.data).toEqual([]);
 		});
 
 		it('deregisters the document listener on pointerdown', async () => {

--- a/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
+++ b/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
@@ -574,7 +574,7 @@ describe('OlRoutingHandler', () => {
 					new TranslateEvent('translatestart', new Collection([feature]), [0, 0], [0, 0], new Event(MapBrowserEventType.POINTERDOWN))
 				);
 
-				expect(store.getState().bottomSheet.active).toBeNull();
+				expect(store.getState().bottomSheet.active).toEqual([]);
 				expect(store.getState().highlight.features).toHaveSize(0);
 			});
 

--- a/test/modules/routing/components/ProposalContextContent.test.js
+++ b/test/modules/routing/components/ProposalContextContent.test.js
@@ -6,7 +6,7 @@ import { MvuElement } from '../../../../src/modules/MvuElement';
 import { EventLike } from '../../../../src/utils/storeUtils';
 import { reset, setProposal } from '../../../../src/store/routing/routing.action';
 import { CoordinateProposalType, RoutingStatusCodes } from '../../../../src/domain/routing';
-import { bottomSheetReducer } from '../../../../src/store/bottomSheet/bottomSheet.reducer';
+import { bottomSheetReducer, INTERACTION_BOTTOM_SHEET_ID } from '../../../../src/store/bottomSheet/bottomSheet.reducer';
 import { mapContextMenuReducer } from '../../../../src/store/mapContextMenu/mapContextMenu.reducer';
 
 window.customElements.define(ProposalContextContent.tag, ProposalContextContent);
@@ -244,7 +244,7 @@ describe('ProposalContextContent', () => {
 
 			element.shadowRoot.querySelector('#start').click();
 
-			expect(store.getState().bottomSheet.active).toBeNull();
+			expect(store.getState().bottomSheet.active).toEqual([]);
 			expect(store.getState().mapContextMenu.active).toBeFalse();
 		});
 
@@ -253,7 +253,7 @@ describe('ProposalContextContent', () => {
 				const element = await setup(
 					{
 						routing: { ...initialRoutingState, ...{ proposal: new EventLike({ coord: [42, 21], type: CoordinateProposalType.START }) } },
-						bottomSheet: { active: true },
+						bottomSheet: { active: [INTERACTION_BOTTOM_SHEET_ID] },
 						mapContextMenu: { active: true }
 					},
 					{ preventClose: true }
@@ -261,7 +261,7 @@ describe('ProposalContextContent', () => {
 
 				element.shadowRoot.querySelector('#start').click();
 
-				expect(store.getState().bottomSheet.active).toBeTrue();
+				expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 				expect(store.getState().mapContextMenu.active).toBeTrue();
 			});
 		});

--- a/test/modules/stackables/components/BottomSheet.test.js
+++ b/test/modules/stackables/components/BottomSheet.test.js
@@ -198,7 +198,7 @@ describe('BottomSheet', () => {
 
 			expect(element.shadowRoot.querySelectorAll('.fade-out')).toHaveSize(1);
 			contentElement.dispatchEvent(new Event('animationend'));
-			expect(store.getState().bottomSheet.data).toEqual(jasmine.arrayWithExactContents([{ id: 'someId', content: null }]));
+			expect(store.getState().bottomSheet.data).toEqual([]);
 		});
 	});
 });

--- a/test/plugins/ContextClickPlugin.test.js
+++ b/test/plugins/ContextClickPlugin.test.js
@@ -10,7 +10,7 @@ import { $injector } from '../../src/injection/index.js';
 import { toolsReducer } from '../../src/store/tools/tools.reducer';
 import { highlightReducer } from '../../src/store/highlight/highlight.reducer.js';
 import { HighlightFeatureType } from '../../src/store/highlight/highlight.action.js';
-import { bottomSheetReducer } from '../../src/store/bottomSheet/bottomSheet.reducer.js';
+import { bottomSheetReducer, INTERACTION_BOTTOM_SHEET_ID } from '../../src/store/bottomSheet/bottomSheet.reducer.js';
 import { setCurrentTool } from '../../src/store/tools/tools.action.js';
 import { Tools } from '../../src/domain/tools.js';
 
@@ -66,12 +66,12 @@ describe('ContextClickPlugin', () => {
 					setContextClick({ coordinate: [2121, 4242], screenCoordinate: [21, 42] });
 
 					expect(store.getState().highlight.features).toHaveSize(1);
-					expect(store.getState().bottomSheet.active).toBe('interaction');
+					expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 
 					setMoveStart();
 
 					expect(store.getState().highlight.features).toHaveSize(0);
-					expect(store.getState().bottomSheet.active).toBeNull();
+					expect(store.getState().bottomSheet.active).toEqual([]);
 				});
 			});
 
@@ -83,39 +83,39 @@ describe('ContextClickPlugin', () => {
 					setContextClick({ coordinate: [2121, 4242], screenCoordinate: [21, 42] });
 
 					expect(store.getState().highlight.features).toHaveSize(1);
-					expect(store.getState().bottomSheet.active).toBe('interaction');
+					expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 
 					setClick({ coordinate: [2121, 4242], screenCoordinate: [21, 42] });
 
 					expect(store.getState().highlight.features).toHaveSize(0);
-					expect(store.getState().bottomSheet.active).toBeNull();
+					expect(store.getState().bottomSheet.active).toEqual([]);
 				});
 			});
 		});
 		describe('when context-click state does NOT change', () => {
 			describe('when move-start state changed', () => {
 				it('does nothing', () => {
-					const store = setup({ bottomSheet: { active: 'interaction' } });
+					const store = setup({ bottomSheet: { active: [INTERACTION_BOTTOM_SHEET_ID] } });
 					new ContextClickPlugin().register(store);
 
-					expect(store.getState().bottomSheet.active).toBe('interaction');
+					expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 
 					setMoveStart();
 
-					expect(store.getState().bottomSheet.active).toBe('interaction');
+					expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 				});
 			});
 
 			describe('when pointer-click state changed', () => {
 				it('does nothing', () => {
-					const store = setup({ bottomSheet: { active: 'interaction' } });
+					const store = setup({ bottomSheet: { active: [INTERACTION_BOTTOM_SHEET_ID] } });
 					new ContextClickPlugin().register(store);
 
-					expect(store.getState().bottomSheet.active).toBe('interaction');
+					expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 
 					setClick({ coordinate: [2121, 4242], screenCoordinate: [21, 42] });
 
-					expect(store.getState().bottomSheet.active).toBe('interaction');
+					expect(store.getState().bottomSheet.active).toEqual([INTERACTION_BOTTOM_SHEET_ID]);
 				});
 			});
 		});

--- a/test/plugins/ElevationProfilePlugin.test.js
+++ b/test/plugins/ElevationProfilePlugin.test.js
@@ -1,4 +1,4 @@
-import { ElevationProfilePlugin } from '../../src/plugins/ElevationProfilePlugin';
+import { ELEVATION_PROFILE_BOTTOM_SHEET_ID, ElevationProfilePlugin } from '../../src/plugins/ElevationProfilePlugin';
 import { openProfile } from '../../src/store/elevationProfile/elevationProfile.action';
 import { elevationProfileReducer, initialState as elevationProfileInitialState } from '../../src/store/elevationProfile/elevationProfile.reducer';
 import { bottomSheetReducer, initialState as bottomSheetInitialState } from '../../src/store/bottomSheet/bottomSheet.reducer';
@@ -60,7 +60,7 @@ describe('ElevationProfilePlugin', () => {
 					active: true,
 					coordinates: []
 				},
-				bottomSheet: { data: [], active: true }
+				bottomSheet: { data: [], active: [ELEVATION_PROFILE_BOTTOM_SHEET_ID] }
 			});
 			const instanceUnderTest = new ElevationProfilePlugin();
 			const bottomSheetUnsubscribeFnSpy = spyOn(instanceUnderTest, '_bottomSheetUnsubscribeFn');

--- a/test/plugins/TimeTravelPlugin.test.js
+++ b/test/plugins/TimeTravelPlugin.test.js
@@ -43,11 +43,11 @@ describe('TimeTravelPlugin', () => {
 				expect(wrapperElement.querySelectorAll(expectedTag)).toHaveSize(1);
 				expect(wrapperElement.querySelector(expectedTag).geoResourceId).toBe(geoResourceId);
 				expect(wrapperElement.querySelector(expectedTag).timestamp).toBe(timestamp0);
-				expect(store.getState().bottomSheet.active).toBe(TIME_TRAVEL_BOTTOM_SHEET_ID);
+				expect(store.getState().bottomSheet.active).toEqual([TIME_TRAVEL_BOTTOM_SHEET_ID]);
 
 				closeSlider();
 
-				expect(store.getState().bottomSheet.active).toBeNull();
+				expect(store.getState().bottomSheet.active).toEqual([]);
 
 				openSlider(timestamp1);
 
@@ -55,7 +55,7 @@ describe('TimeTravelPlugin', () => {
 				expect(wrapperElement.querySelectorAll(expectedTag)).toHaveSize(1);
 				expect(wrapperElement.querySelector(expectedTag).geoResourceId).toBe(geoResourceId);
 				expect(wrapperElement.querySelector(expectedTag).timestamp).toBe(timestamp1);
-				expect(store.getState().bottomSheet.active).toBe(TIME_TRAVEL_BOTTOM_SHEET_ID);
+				expect(store.getState().bottomSheet.active).toEqual([TIME_TRAVEL_BOTTOM_SHEET_ID]);
 			});
 		});
 	});

--- a/test/store/bottomSheet/bottomSheet.reducer.test.js
+++ b/test/store/bottomSheet/bottomSheet.reducer.test.js
@@ -12,63 +12,65 @@ describe('bottomSheetReducer', () => {
 	it('initialize the store with default values', () => {
 		const store = setup();
 		expect(store.getState().bottomSheet.data).toEqual([]);
-		expect(store.getState().bottomSheet.active).toBeNull();
+		expect(store.getState().bottomSheet.active).toEqual([]);
 	});
 
-	it('updates the main bottom sheet properties', () => {
+	it('updates the default bottom sheet properties', () => {
 		const store = setup();
 
 		openBottomSheet('content');
 
-		expect(store.getState().bottomSheet.data).toEqual(jasmine.arrayWithExactContents([{ id: 'default', content: 'content' }]));
-		expect(store.getState().bottomSheet.active).toBe('default');
+		expect(store.getState().bottomSheet.data).toEqual([{ id: 'default', content: 'content' }]);
+		expect(store.getState().bottomSheet.active).toEqual(['default']);
+
+		openBottomSheet('contentUpdate');
+
+		expect(store.getState().bottomSheet.data).toEqual([{ id: 'default', content: 'contentUpdate' }]);
+		expect(store.getState().bottomSheet.active).toEqual(['default']);
 
 		closeBottomSheet();
 
-		expect(store.getState().bottomSheet.data).toEqual(jasmine.arrayWithExactContents([{ id: 'default', content: null }]));
-		expect(store.getState().bottomSheet.active).toBeNull();
+		expect(store.getState().bottomSheet.data).toEqual([]);
+		expect(store.getState().bottomSheet.active).toEqual([]);
 	});
 
-	it('updates the other bottom sheet properties', () => {
+	it('updates also custom bottom sheet properties', () => {
 		const store = setup();
 
 		openBottomSheet('content');
 
-		expect(store.getState().bottomSheet.data).toEqual(jasmine.arrayWithExactContents([{ id: 'default', content: 'content' }]));
-		expect(store.getState().bottomSheet.active).toBe('default');
+		expect(store.getState().bottomSheet.data).toEqual([{ id: 'default', content: 'content' }]);
+		expect(store.getState().bottomSheet.active).toEqual(['default']);
 
 		openBottomSheet('content', 'id');
 
-		expect(store.getState().bottomSheet.active).toBe('id');
-		expect(store.getState().bottomSheet.data).toEqual(
-			jasmine.arrayWithExactContents([
-				{ id: 'id', content: 'content' },
-				{ id: 'default', content: 'content' }
-			])
-		);
+		expect(store.getState().bottomSheet.active).toEqual(['id', 'default']);
+		expect(store.getState().bottomSheet.data).toEqual([
+			{ id: 'id', content: 'content' },
+			{ id: 'default', content: 'content' }
+		]);
 
 		openBottomSheet('contentUpdate');
 		openBottomSheet('contentUpdate', 'id');
 
-		closeBottomSheet();
-		closeBottomSheet('id');
-
-		expect(store.getState().bottomSheet.data).toEqual(
-			jasmine.arrayWithExactContents([
-				{ id: 'id', content: null },
-				{ id: 'default', content: null }
-			])
-		);
-		expect(store.getState().bottomSheet.active).toBeNull();
+		expect(store.getState().bottomSheet.active).toEqual(['id', 'default']);
+		expect(store.getState().bottomSheet.data).toEqual([
+			{ id: 'id', content: 'contentUpdate' },
+			{ id: 'default', content: 'contentUpdate' }
+		]);
 
 		closeBottomSheet('unknown');
 
-		expect(store.getState().bottomSheet.data).toEqual(
-			jasmine.arrayWithExactContents([
-				{ id: 'id', content: null },
-				{ id: 'default', content: null }
-			])
-		);
-		expect(store.getState().bottomSheet.active).toBeNull();
+		expect(store.getState().bottomSheet.active).toEqual(['id', 'default']);
+		expect(store.getState().bottomSheet.data).toEqual([
+			{ id: 'id', content: 'contentUpdate' },
+			{ id: 'default', content: 'contentUpdate' }
+		]);
+
+		closeBottomSheet();
+		closeBottomSheet('id');
+
+		expect(store.getState().bottomSheet.data).toEqual([]);
+		expect(store.getState().bottomSheet.active).toEqual([]);
 	});
 });


### PR DESCRIPTION
It's not easy in tests to detect when a certain bottom sheet is displayed and when not.
Therefore the following changes are made:

1. The `active` property is an array now and reflects all active bottom sheets. An empty array means no bottom sheet is active. This is the most important change
2.  A `BottomSheetContent` item will be removed from the `data` property when `closeBottomSheet` is called

