### PR TITLE
OlSketchHandler: clean activate behavior  

### DIFF
--- a/src/modules/olMap/handler/OlSketchHandler.js
+++ b/src/modules/olMap/handler/OlSketchHandler.js
@@ -55,7 +55,6 @@ export class OlSketchHandler {
 				const onFeatureChange = (event) => {
 					this._monitorProperties(event.target);
 				};
-				sketchFeature.set(GEODESIC_FEATURE_PROPERTY, new GeodesicGeometry(sketchFeature, map, () => !this._isFinishOnFirstPoint));
 				this._listener = sketchFeature.on('change', onFeatureChange);
 			}
 			this._pointCount = 1;
@@ -65,7 +64,6 @@ export class OlSketchHandler {
 
 	deactivate() {
 		unByKey(this._listener);
-		this._sketch.set(GEODESIC_FEATURE_PROPERTY, new GeodesicGeometry(this._sketch.clone(), this._map));
 		this._sketch = null;
 		this._isFinishOnFirstPoint = false;
 		this._isSnapOnLastPoint = false;

--- a/src/modules/olMap/handler/OlSketchHandler.js
+++ b/src/modules/olMap/handler/OlSketchHandler.js
@@ -4,7 +4,6 @@
 import { Polygon } from 'ol/geom';
 import { unByKey } from 'ol/Observable';
 import { Tools } from '../../../domain/tools';
-import { GEODESIC_FEATURE_PROPERTY, GeodesicGeometry } from '../ol/geodesic/geodesicGeometry';
 
 export const DefaultIdPrefix = Tools.DRAW + '_';
 

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -501,6 +501,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			};
 
 			this._sketchHandler.activate(event.feature, this._map, Tools.MEASURE + '_');
+			event.feature.set(GEODESIC_FEATURE_PROPERTY, new GeodesicGeometry(event.feature, this._map, () => !this._sketchHandler.isFinishOnFirstPoint));
 			this._overlayService.add(this._sketchHandler.active, this._map, StyleTypes.MEASURE);
 			this._drawingListeners.push(event.feature.on('change', onFeatureChange));
 			this._drawingListeners.push(this._map.getView().on('change:resolution', onResolutionChange));

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -31,7 +31,7 @@ import { getAttributionForLocallyImportedOrCreatedGeoResource } from '../../../.
 import { Layer } from 'ol/layer';
 import { Tools } from '../../../../../src/domain/tools';
 import { BaOverlay } from '../../../../../src/modules/olMap/components/BaOverlay.js';
-import { GEODESIC_FEATURE_PROPERTY } from '../../../../../src/modules/olMap/ol/geodesic/geodesicGeometry.js';
+import { GEODESIC_FEATURE_PROPERTY, GeodesicGeometry } from '../../../../../src/modules/olMap/ol/geodesic/geodesicGeometry.js';
 import { fileStorageReducer } from '../../../../../src/store/fileStorage/fileStorage.reducer.js';
 import { KML_EMPTY_CONTENT } from '../../../../../src/modules/olMap/formats/kml.js';
 
@@ -656,6 +656,27 @@ describe('OlMeasurementHandler', () => {
 
 			expect(statsSpy).toHaveBeenCalledTimes(1);
 			expect(updateOverlaysSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('sets a geodesic geometry on drawstart', () => {
+			setup();
+			const map = setupMap();
+			const geometry = new LineString([
+				[0, 0],
+				[500, 0],
+				[550, 550],
+				[0, 500],
+				[0, 500]
+			]);
+			const feature = new Feature({ geometry: geometry });
+			feature.setId('measure');
+
+			const classUnderTest = new OlMeasurementHandler();
+
+			classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+
+			expect(feature.get(GEODESIC_FEATURE_PROPERTY)).toEqual(jasmine.any(GeodesicGeometry));
 		});
 
 		it("removes overlays of features on 'drawabort'", () => {


### PR DESCRIPTION
remove the creating of geodesic geometry on OlSketchHandler.activate()
fixes #2647