### PR TITLE
set preload param to 0 for ol.TileLayer

### DIFF
--- a/src/modules/olMap/services/LayerService.js
+++ b/src/modules/olMap/services/LayerService.js
@@ -116,8 +116,7 @@ export class LayerService {
 					geoResourceId: geoResource.id,
 					opacity: opacity,
 					minZoom: minZoom ?? undefined,
-					maxZoom: maxZoom ?? undefined,
-					preload: 3
+					maxZoom: maxZoom ?? undefined
 				});
 				const xyzSource = () => {
 					const config = {

--- a/test/modules/olMap/services/LayerService.test.js
+++ b/test/modules/olMap/services/LayerService.test.js
@@ -233,7 +233,7 @@ describe('LayerService', () => {
 
 				expect(xyzOlLayer.get('id')).toBe(id);
 				expect(xyzOlLayer.get('geoResourceId')).toBe(geoResourceId);
-				expect(xyzOlLayer.getPreload()).toBe(3);
+				expect(xyzOlLayer.getPreload()).toBe(0);
 				expect(xyzOlLayer.getMinZoom()).toBeNegativeInfinity();
 				expect(xyzOlLayer.getMaxZoom()).toBePositiveInfinity();
 				const xyzSource = xyzOlLayer.getSource();
@@ -256,7 +256,7 @@ describe('LayerService', () => {
 
 				expect(xyzOlLayer.get('id')).toBe(id);
 				expect(xyzOlLayer.get('geoResourceId')).toBe(geoResourceId);
-				expect(xyzOlLayer.getPreload()).toBe(3);
+				expect(xyzOlLayer.getPreload()).toBe(0);
 				expect(xyzOlLayer.getMinZoom()).toBeNegativeInfinity();
 				expect(xyzOlLayer.getMaxZoom()).toBePositiveInfinity();
 				const xyzSource = xyzOlLayer.getSource();
@@ -282,7 +282,7 @@ describe('LayerService', () => {
 
 				expect(xyzOlLayer.get('id')).toBe(id);
 				expect(xyzOlLayer.get('geoResourceId')).toBe(geoResourceId);
-				expect(xyzOlLayer.getPreload()).toBe(3);
+				expect(xyzOlLayer.getPreload()).toBe(0);
 				expect(xyzOlLayer.getOpacity()).toBe(0.5);
 				expect(xyzOlLayer.getMinZoom()).toBe(5);
 				expect(xyzOlLayer.getMaxZoom()).toBe(19);


### PR DESCRIPTION
Reduce the amount of HTTP requests by setting the TielLayer `preload` parameter to 0