### PR TITLE
Mfp3Encoder:  fix shortenedUrl for qrCode

### DIFF
--- a/src/modules/olMap/services/Mfp3Encoder.js
+++ b/src/modules/olMap/services/Mfp3Encoder.js
@@ -19,6 +19,8 @@ import { getPolygonFrom } from '../utils/olGeometryUtils';
 import { getUniqueCopyrights } from '../../../utils/attributionUtils';
 import { BaOverlay, OVERLAY_STYLE_CLASS } from '../components/BaOverlay';
 import { findAllBySelector } from '../../../utils/markup';
+import { setQueryParams } from '../../../utils/urlUtils';
+import { QueryParameters } from '../../../domain/queryParameters';
 
 const UnitsRatio = 39.37; //inches per meter
 const PointsPerInch = 72; // PostScript points 1/72"
@@ -929,7 +931,7 @@ export class BvvMfp3Encoder {
 	 *@private
 	 */
 	async _generateShortUrl() {
-		const url = this._shareService.encodeState();
+		const url = setQueryParams(this._shareService.encodeState(), { [QueryParameters.TOOL_ID]: '' });
 		try {
 			return await this._urlService.shorten(url);
 		} catch (e) {

--- a/test/modules/olMap/formats/Mfp3Encoder.test.js
+++ b/test/modules/olMap/formats/Mfp3Encoder.test.js
@@ -56,7 +56,7 @@ describe('BvvMfp3Encoder', () => {
 	};
 
 	const shareServiceMock = {
-		encodeState() {},
+		encodeState: () => 'http://foo',
 		copyToClipboard() {}
 	};
 
@@ -2760,33 +2760,25 @@ describe('BvvMfp3Encoder', () => {
 
 	describe('_generateShortUrl', () => {
 		it('shortenens the url', async () => {
-			const encodedState = 'foo';
-			const shareServiceSpy = spyOn(shareServiceMock, 'encodeState').and.returnValue(encodedState);
-			const urlServiceSpy = spyOn(urlServiceMock, 'shorten').withArgs(encodedState).and.resolveTo('bar');
-
+			const urlServiceSpy = spyOn(urlServiceMock, 'shorten').withArgs('http://foo/?tid=').and.resolveTo('bar');
 			const classUnderTest = setup();
 
 			const shortUrl = await classUnderTest._generateShortUrl();
 
-			expect(shareServiceSpy).toHaveBeenCalled();
 			expect(urlServiceSpy).toHaveBeenCalled();
 			expect(shortUrl).toBe('bar');
 		});
 
 		it('warns in console, if shortening fails', async () => {
-			const encodedState = 'foo';
-			const shareServiceSpy = spyOn(shareServiceMock, 'encodeState').and.returnValue(encodedState);
 			const urlServiceSpy = spyOn(urlServiceMock, 'shorten').and.throwError('bar');
 			const warnSpy = spyOn(console, 'warn');
-
 			const classUnderTest = setup();
 
 			const shortUrl = await classUnderTest._generateShortUrl();
 
-			expect(shareServiceSpy).toHaveBeenCalled();
 			expect(warnSpy).toHaveBeenCalledWith('Could not shorten url: Error: bar');
 			expect(urlServiceSpy).toThrowError('bar');
-			expect(shortUrl).toBe('foo');
+			expect(shortUrl).toBe('http://foo/?tid=');
 		});
 	});
 


### PR DESCRIPTION
reset QueryParameter 'TOOL_ID' to get a url without active ExportTool