### PR TITLE
HelpTooltip: change positioning from center-left to top-left 

### DIFF
--- a/src/modules/olMap/tooltip/HelpTooltip.js
+++ b/src/modules/olMap/tooltip/HelpTooltip.js
@@ -30,7 +30,7 @@ export class HelpTooltip {
 
 	activate(map) {
 		this._map = map;
-		this._overlay = this._createOverlay({ offset: [15, 0], positioning: 'center-left' }, BaOverlayTypes.HELP);
+		this._overlay = this._createOverlay({ offset: [15, 0], positioning: 'top-left' }, BaOverlayTypes.HELP);
 		this._map.addOverlay(this._overlay);
 	}
 

--- a/test/modules/olMap/tooltip/HelpTooltip.test.js
+++ b/test/modules/olMap/tooltip/HelpTooltip.test.js
@@ -48,6 +48,15 @@ describe('HelpTooltip', () => {
 	});
 
 	describe('on activate', () => {
+		const overlayPositioningMatcher = (positioningString) => {
+			return {
+				asymmetricMatch: (compareTo) => {
+					return compareTo instanceof Overlay ? compareTo.getPositioning() === positioningString : false;
+				},
+
+				jasmineToString: () => `<Overlay positioning does not match:'${positioningString}'>`
+			};
+		};
 		it('creates a overlay', () => {
 			const addSpy = jasmine.createSpy();
 			const mapMock = { addOverlay: addSpy };
@@ -55,7 +64,7 @@ describe('HelpTooltip', () => {
 			const classUnderTest = new HelpTooltip();
 			classUnderTest.activate(mapMock);
 
-			expect(addSpy).toHaveBeenCalledWith(jasmine.any(Overlay));
+			expect(addSpy).toHaveBeenCalledWith(jasmine.any(Overlay) && overlayPositioningMatcher('top-left'));
 			expect(classUnderTest.active).toBeTrue();
 		});
 	});


### PR DESCRIPTION
for better readability of distance overlay
**Before**
![center-left](https://github.com/user-attachments/assets/603db25d-d959-47d7-a145-4c8e31199802)
**Optimized**
![top-left](https://github.com/user-attachments/assets/01280bb6-c35d-41c0-a021-359dccb30068)
