### PR TITLE
Revert "pan map on pressing mouse wheel" (v4.3)

### DIFF
--- a/src/modules/olMap/components/OlMap.js
+++ b/src/modules/olMap/components/OlMap.js
@@ -7,7 +7,7 @@ import olCss from 'ol/ol.css';
 import css from './olMap.css';
 import { Map as MapOl, View } from 'ol';
 import { defaults as defaultControls, ScaleLine } from 'ol/control';
-import { defaults as defaultInteractions, PinchRotate, DragPan } from 'ol/interaction';
+import { defaults as defaultInteractions, PinchRotate } from 'ol/interaction';
 import { removeLayer } from '../../../store/layers/layers.action';
 import { changeLiveCenter, changeLiveRotation, changeLiveZoom, changeZoomCenterAndRotation } from '../../../store/position/position.action';
 import { $injector } from '../../../injection';
@@ -171,11 +171,6 @@ export class OlMap extends MvuElement {
 			}).extend([
 				new PinchRotate({
 					threshold: this._mapService.getMinimalRotation()
-				}),
-				new DragPan({
-					condition: (mapBrowserEvent) => {
-						return mapBrowserEvent.originalEvent.isPrimary && mapBrowserEvent.originalEvent.button < 2;
-					}
 				})
 			])
 		});

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -267,7 +267,7 @@ describe('OlMap', () => {
 			//all default controls are removed, ScaleLine control added
 			expect(element._map.getControls().getLength()).toBe(1);
 			//all interactions are present
-			expect(element._map.getInteractions().getLength()).toBe(10);
+			expect(element._map.getInteractions().getLength()).toBe(9);
 			expect(element._map.moveTolerance_).toBe(1);
 			expect(mapServiceSpy).toHaveBeenCalled();
 		});


### PR DESCRIPTION
This reverts commit 90e0d348be814b49786acba2dd9554446e49b6bc which causes problems with the default  `DragZoom` interaction