### PR TITLE
encode URL of imported vector data again

### DIFF
--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -14,7 +14,7 @@ import { UnavailableGeoResourceError } from '../domain/errors';
 /**
  *
  * @typedef {Object} ImportVectorDataOptions
- * @property {string} [id] the ID of the created VectorGeoResource. If not set, id will be created
+ * @property {string} [id] the ID of the created VectorGeoResource. If not set, it will be created, or if the VectorGeoResource is imported from a URL, the URL will be taken as the ID.
  * @property {string} [label] the label of the created VectorGeoResource
  * @property {SourceType|VectorSourceType} [sourceType] the source type. Can be either a SourceType or a VectorSourceType instance. If not set it will be tried to detect it
  */
@@ -58,7 +58,8 @@ export class ImportVectorDataService {
 	 * @returns GeoResourceFuture or `null` when given source type is not supported
 	 */
 	forUrl(url, options = {}) {
-		const { id, label, sourceType } = { ...this._newDefaultImportVectorDataOptions(), ...options };
+		// const { id, label, sourceType } = { ...this._newDefaultImportVectorDataOptions(), ...options };
+		const { id, label, sourceType } = { ...this._newDefaultImportVectorDataOptions(), ...options, ...{ id: options.id ?? url } };
 
 		// check if optional sourceType is supported
 		if (sourceType && !this._mapSourceTypeToVectorSourceType(sourceType)) {

--- a/test/service/ImportVectorDataService.test.js
+++ b/test/service/ImportVectorDataService.test.js
@@ -45,6 +45,41 @@ describe('ImportVectorDataService', () => {
 	});
 
 	describe('forUrl', () => {
+		it('returns a GeoResourceFuture', () => {
+			const instanceUnderTest = setup();
+			const url = 'http://my.url';
+			const options = {
+				label: 'label',
+				sourceType: VectorSourceType.KML
+			};
+			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(addOrReplaceMethodMock);
+
+			const geoResourceFuture = instanceUnderTest.forUrl(url, options);
+
+			expect(geoResourceFuture.id).toBe(url);
+			expect(geoResourceFuture.label).toBeNull();
+			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
+			expect(geoResourceFuture.marker).toBe(handledByGeoResourceServiceMarker);
+		});
+
+		it('returns a GeoResourceFuture for given ID', () => {
+			const instanceUnderTest = setup();
+			const url = 'http://my.url';
+			const options = {
+				id: 'http://my.url||foo||true',
+				label: 'label',
+				sourceType: VectorSourceType.KML
+			};
+			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(addOrReplaceMethodMock);
+
+			const geoResourceFuture = instanceUnderTest.forUrl(url, options);
+
+			expect(geoResourceFuture.id).toBe(options.id);
+			expect(geoResourceFuture.label).toBeNull();
+			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
+			expect(geoResourceFuture.marker).toBe(handledByGeoResourceServiceMarker);
+		});
+
 		it('returns a GeoResourceFuture for given VectorSourceType', () => {
 			const instanceUnderTest = setup();
 			const url = 'http://my.url';


### PR DESCRIPTION
* fix forUrl(): take the URL as ID again if not specified

* improve doc