### PR TITLE
kml: prevent 'null' for description-tag (4.3)

### DIFF
--- a/src/modules/olMap/formats/kml.js
+++ b/src/modules/olMap/formats/kml.js
@@ -111,12 +111,17 @@ export const create = (layer, sourceProjection) => {
 			if (styles) {
 				const kmlStyle = sanitizeStyle(styles(clone));
 
-				if (kmlStyle.getText() && clone.get('name')) {
+				if (clone.get('name')) {
 					clone.unset('name');
 				}
 				clone.setStyle(kmlStyle);
 			}
 
+			// explicit check for NULL; if the feature does not have the 'description' property
+			// the get-function resolves to UNDEFINED and the call of unset() is not needed
+			if (clone.get('description') === null) {
+				clone.unset('description');
+			}
 			kmlFeatures.push(clone);
 		});
 


### PR DESCRIPTION
update cleaning rules for kml format to prevent `null` values in name and description tag