### PR TITLE
FileStoragePlugin: also set  the fileID

### DIFF
--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -230,7 +230,6 @@ export class OlDrawHandler extends OlLayerHandler {
 					// eslint-disable-next-line promise/prefer-await-to-then
 					.finally(() => {
 						this._storedContent = createKML(layer, 'EPSG:3857');
-						this._save(); // save content initially to get a valid fileId
 						registerListeners(layer);
 					});
 			} else {

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -227,7 +227,6 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				// eslint-disable-next-line promise/prefer-await-to-then
 				.finally(() => {
 					this._storedContent = createKML(layer, 'EPSG:3857');
-					this._save(); // save content initially to get a valid fileId
 					registerListeners(layer);
 				});
 			return layer;

--- a/src/plugins/FileStoragePlugin.js
+++ b/src/plugins/FileStoragePlugin.js
@@ -6,7 +6,7 @@ import { SourceTypeName, SourceTypeResultStatus } from '../domain/sourceType';
 import { $injector } from '../injection';
 import { FileStorageServiceDataTypes } from '../services/FileStorageService';
 import {
-	setAdminId,
+	setAdminAndFileId,
 	setLatestStorageResult,
 	setLatestStorageResultAndAdminAndFileId,
 	setLatestStorageResultAndFileId
@@ -50,13 +50,14 @@ export class FileStoragePlugin extends BaPlugin {
 		const queryParams = this.#environmentService.getQueryParams();
 
 		/**
-		 * Set the admin id if available. We just handle the topmost suitable layer
+		 * Set both the admin and the file ID if the admin id is available. We just handle the topmost suitable layer
 		 */
 		if (queryParams.has(QueryParameters.LAYER)) {
 			const geoResourceIds = queryParams.get(QueryParameters.LAYER).split(',');
 			const adminId = geoResourceIds.reverse().find((grId) => this.#fileStorageService.isAdminId(grId));
 			if (adminId) {
-				setAdminId(adminId);
+				const fileId = await this.#fileStorageService.getFileId(adminId);
+				setAdminAndFileId(adminId, fileId);
 			}
 		}
 

--- a/src/store/fileStorage/fileStorage.action.js
+++ b/src/store/fileStorage/fileStorage.action.js
@@ -3,6 +3,7 @@
  */
 
 import { $injector } from '../../injection';
+import { isString } from '../../utils/checks';
 import { EventLike } from '../../utils/storeUtils';
 import {
 	ADMIN_ID_CHANGED,
@@ -27,15 +28,18 @@ const getStore = () => {
 };
 
 /**
- * Sets the admin ID.
- * @param {string|null} adminId
+ * Sets the admin and its corresponding file ID.
+ * @param {string} adminId
+ * @param {string} fileId
  * @function
  */
-export const setAdminId = (adminId) => {
-	getStore().dispatch({
-		type: ADMIN_ID_CHANGED,
-		payload: adminId
-	});
+export const setAdminAndFileId = (adminId, fileId) => {
+	if (isString(adminId) && isString(fileId)) {
+		getStore().dispatch({
+			type: ADMIN_ID_CHANGED,
+			payload: { adminId, fileId }
+		});
+	}
 };
 
 /**

--- a/src/store/fileStorage/fileStorage.reducer.js
+++ b/src/store/fileStorage/fileStorage.reducer.js
@@ -32,9 +32,11 @@ export const fileStorageReducer = (state = initialState, action) => {
 	const { type, payload } = action;
 	switch (type) {
 		case ADMIN_ID_CHANGED: {
+			const { adminId, fileId } = payload;
 			return {
 				...state,
-				adminId: payload
+				adminId,
+				fileId
 			};
 		}
 		case DATA_CHANGED: {

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -1237,7 +1237,7 @@ describe('OlDrawHandler', () => {
 
 			classUnderTest.activate(map);
 			await TestUtils.timeout();
-			expect(saveSpy).toHaveBeenCalledTimes(1);
+			expect(saveSpy).not.toHaveBeenCalledTimes(1);
 			expect(classUnderTest._layerId).toBe('a_oldLayer_id');
 			expect(classUnderTest._vectorLayer).toBeTruthy();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -815,7 +815,7 @@ describe('OlMeasurementHandler', () => {
 
 			classUnderTest.activate(map);
 			await TestUtils.timeout();
-			expect(saveSpy).toHaveBeenCalledTimes(1);
+			expect(saveSpy).not.toHaveBeenCalledTimes(1);
 			expect(classUnderTest._layerId).toBe('a_oldLayer_id');
 			expect(classUnderTest._vectorLayer).toBeTruthy();
 			classUnderTest._vectorLayer.getSource().addFeature(feature);

--- a/test/plugins/FileStoragePlugin.test.js
+++ b/test/plugins/FileStoragePlugin.test.js
@@ -15,7 +15,8 @@ describe('FileStoragePlugin', () => {
 	};
 	const fileStorageService = {
 		isAdminId() {},
-		save() {}
+		save() {},
+		getFileId() {}
 	};
 	const sourceTypeService = {
 		forData() {}
@@ -66,16 +67,18 @@ describe('FileStoragePlugin', () => {
 				expect(store.getState().fileStorage.adminId).toBe(initialState.adminId);
 			});
 
-			it('sets the admin id when an admin id is detected', async () => {
+			it('sets the admin and file id when an admin id is detected', async () => {
 				const store = setup();
-				const queryParam = new URLSearchParams(`${QueryParameters.LAYER}=foo`);
+				const queryParam = new URLSearchParams(`${QueryParameters.LAYER}=adminId`);
 				spyOn(environmentService, 'getQueryParams').and.returnValue(queryParam);
 				spyOn(fileStorageService, 'isAdminId').and.returnValue(true);
+				spyOn(fileStorageService, 'getFileId').withArgs('adminId').and.resolveTo('fileId');
 				const instanceUnderTest = new FileStoragePlugin();
 
 				await instanceUnderTest.register(store);
 
-				expect(store.getState().fileStorage.adminId).toBe('foo');
+				expect(store.getState().fileStorage.adminId).toBe('adminId');
+				expect(store.getState().fileStorage.fileId).toBe('fileId');
 			});
 		});
 

--- a/test/store/fileStorage/fileStorage.reducer.test.js
+++ b/test/store/fileStorage/fileStorage.reducer.test.js
@@ -1,6 +1,6 @@
 import {
 	clear,
-	setAdminId,
+	setAdminAndFileId,
 	setData,
 	setLatestStorageResult,
 	setLatestStorageResultAndAdminAndFileId,
@@ -24,12 +24,23 @@ describe('fileStorageReducer', () => {
 		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 	});
 
-	it('updates the `adminId` property', () => {
+	it('updates the `adminId` and `fileId` property', () => {
 		const store = setup();
 
-		setAdminId('adminId');
+		setAdminAndFileId('adminId');
+
+		expect(store.getState().fileStorage.adminId).toBeNull();
+		expect(store.getState().fileStorage.fileId).toBeNull();
+
+		setAdminAndFileId(null, 'fileId');
+
+		expect(store.getState().fileStorage.adminId).toBeNull();
+		expect(store.getState().fileStorage.fileId).toBeNull();
+
+		setAdminAndFileId('adminId', 'fileId');
 
 		expect(store.getState().fileStorage.adminId).toBe('adminId');
+		expect(store.getState().fileStorage.fileId).toBe('fileId');
 	});
 
 	it('clears the store and resets to initial state', () => {


### PR DESCRIPTION
* remove early save after reading rocksi features again

* change and rename action `setAdminId` to `setAdminAndFileId`

* set both the admin and the file ID if the admin id is available