### PR TITLE
OlMeasurementHandler: optimize behavior after measurement is activated

### DIFF
--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -176,12 +176,15 @@ export class OlMeasurementHandler extends OlLayerHandler {
 						f.on('change', onFeatureChange);
 					});
 					const displayRuler = !oldFeatures.some((f) => f.get('displayruler') === 'false');
+					const hasMeasurementFeature = oldFeatures.some((f) => f.getId().startsWith(Tools.MEASURE + '_'));
 					setDisplayRuler(displayRuler);
 					const oldLayerId = oldLayer.get('id');
 					this._layerId = oldLayerId;
 					this._layerZIndex = oldLayer.getZIndex();
 					removeLayer(oldLayerId);
-					this._finish();
+					if (hasMeasurementFeature) {
+						this._finish();
+					}
 					this._setSelection(this._storeService.getStore().getState().measurement.selection);
 					this._updateMeasureState();
 				}

--- a/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -592,7 +592,7 @@ describe('OlMeasurementHandler', () => {
 			expect(finishSpy).not.toHaveBeenCalled();
 		});
 
-		it('does NOT starts with active drawing, but modify based on old measurement features existing', async () => {
+		it('does NOT start with active drawing, but modify based on old measurement features existing', async () => {
 			setup();
 			const classUnderTest = new OlMeasurementHandler();
 			const lastData =


### PR DESCRIPTION
When measuring starts and old features are read in, which are only drawings, the handler activates the draw-interaction. If at least one measurement feature exists in the old features, the handler activates the modify-interaction.