### PR TITLE
avoid unnecessary warning messages when sharing is canceled (v4.3)

### DIFF
--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -99,7 +99,9 @@ export class ShareChip extends AbstractAssistChip {
 			};
 			await this._environmentService.getWindow().navigator.share(content);
 		} catch (error) {
-			emitNotification(this._translationService.translate('chips_assist_chip_share_position_api_failed'), LevelTypes.WARN);
+			if (!(error instanceof DOMException && error.name === 'AbortError')) {
+				emitNotification(this._translationService.translate('chips_assist_chip_share_position_api_failed'), LevelTypes.WARN);
+			}
 		}
 	}
 

--- a/src/modules/share/components/dialog/ShareDialogContent.js
+++ b/src/modules/share/components/dialog/ShareDialogContent.js
@@ -119,7 +119,9 @@ export class ShareDialogContent extends MvuElement {
 						};
 						await this._environmentService.getWindow().navigator.share(content);
 					} catch (error) {
-						emitNotification(translate('share_dialog_api_failed'), LevelTypes.WARN);
+						if (!(error instanceof DOMException && error.name === 'AbortError')) {
+							emitNotification(translate('share_dialog_api_failed'), LevelTypes.WARN);
+						}
 					}
 				};
 				return html`<ba-icon class="share_api" .icon="${shareIcon}" .title=${translate('share_dialog_api')} .size=${2} @click=${onClickWithApi}>

--- a/test/modules/share/components/shareDialogContent/ShareDialogContent.test.js
+++ b/test/modules/share/components/shareDialogContent/ShareDialogContent.test.js
@@ -196,6 +196,18 @@ describe('ShareDialogContent', () => {
 		expect(store.getState().notifications.latest.payload.level).toEqual(LevelTypes.WARN);
 	});
 
+	it('does NOT emit a warn notification on share api canceled', async () => {
+		const element = await setup({}, { share: () => Promise.reject() });
+		element.urls = shareUrls;
+		const shareButton = element.shadowRoot.querySelector('.share_item .share_api');
+		spyOn(windowMock.navigator, 'share').and.returnValue(Promise.reject(new DOMException('message', 'AbortError')));
+
+		shareButton.click();
+
+		await TestUtils.timeout();
+		expect(store.getState().notifications.latest).toBeNull();
+	});
+
 	it('logs a warning and emits a notification when copyToClipboard fails', async () => {
 		const copySpy = spyOn(shareServiceMock, 'copyToClipboard').and.callFake(() => Promise.reject());
 		const warnSpy = spyOn(console, 'warn');

--- a/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
+++ b/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
@@ -151,7 +151,6 @@ describe('ShareToolContent', () => {
 
 					await TestUtils.timeout();
 					expect(store.getState().notifications.latest).toBeNull();
-					expect(store.getState().notifications.latest).toBeNull();
 				});
 			});
 		});


### PR DESCRIPTION
* cleanup

* handle AbortError of ShareApi