### PR TITLE
VectorLayerService: avoid displaying only one feature if ids are an empty string (v4.3)

### DIFF
--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -10,7 +10,7 @@ import { parse } from '../../../utils/ewkt';
 import { Cluster } from 'ol/source';
 import { getOriginAndPathname, getPathParams } from '../../../utils/urlUtils';
 import { UnavailableGeoResourceError } from '../../../domain/errors';
-import { isHttpUrl } from '../../../utils/checks';
+import { isHttpUrl, isString } from '../../../utils/checks';
 
 const getUrlService = () => {
 	const { UrlService: urlService } = $injector.inject('UrlService');
@@ -206,6 +206,10 @@ export class VectorLayerService {
 				.readFeatures(data)
 				.filter((f) => !!f.getGeometry()) // filter out features without a geometry. Todo: let's inform the user
 				.map((f) => {
+					// avoid ol displaying only one feature if ids are an empty string
+					if (isString(f.getId()) && f.getId().trim() === '') {
+						f.setId(undefined);
+					}
 					f.set('showPointNames', geoResource.showPointNames);
 					f.getGeometry().transform('EPSG:' + geoResource.srid, 'EPSG:' + destinationSrid); //Todo: check for unsupported destinationSrid
 					return f;

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -370,6 +370,23 @@ describe('VectorLayerService', () => {
 					expect(vectorGeoresource.label).toBe(kmlName);
 				});
 			});
+
+			describe('KML VectorGeoresource has empty placemark ids', () => {
+				it('sets the id of the corresponding feature to `undefined`', async () => {
+					setup();
+					const id = 'someId';
+					const srid = 3857;
+					const kmlName = 'kmlName';
+					spyOn(mapService, 'getSrid').and.returnValue(srid);
+					const sourceAsString = `<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><name>${kmlName}</name><Placemark id=" "><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>`;
+					const vectorGeoresource = new VectorGeoResource(id, null, VectorSourceType.KML).setSource(sourceAsString, 4326);
+
+					const olVectorSource = instanceUnderTest._vectorSourceForData(vectorGeoresource);
+
+					expect(olVectorSource.getFeatures().length).toBe(1);
+					expect(olVectorSource.getFeatures()[0].getId()).toBeUndefined();
+				});
+			});
 		});
 
 		describe('_registerEvents', () => {


### PR DESCRIPTION
fixes #2886 