### PR TITLE
Refactor formatting of quantities

### DIFF
--- a/src/modules/elevationProfile/components/panel/ElevationProfile.js
+++ b/src/modules/elevationProfile/components/panel/ElevationProfile.js
@@ -603,42 +603,27 @@ export class ElevationProfile extends MvuElement {
 								return `${translate('elevationProfile_distance')} (${distance.unit}): ${distance.localizedValue}`;
 							},
 							label: (tooltipItem) => {
-								const retArray = [];
-								const selectedAttribute = this.getModel().selectedAttribute;
+								const defaultAttribute = { id: Default_Selected_Attribute, unit: 'm' };
+
+								const selectedAttributeId = this.getModel().selectedAttribute;
 								const elevationEntry = getElevationEntry(tooltipItem);
-								let attributeValue = elevationEntry[selectedAttribute];
-								const selectedAttributeTranslation = translate('elevationProfile_' + selectedAttribute);
 
-								const attribute =
-									selectedAttribute === 'alt'
-										? { id: 'alt', unit: 'm' }
-										: elevationData.attrs.find((attr) => {
-												return attr.id === selectedAttribute;
-											});
+								const createLabel = (attribute) => {
+									const name = translate('elevationProfile_' + attribute.id);
+									const nameWithUnit = `${translate('elevationProfile_' + attribute.id)} (${attribute.unit})`;
+									const prefix = attribute.prefix ? ` ${attribute.prefix} ` : ' ';
+									const value = elevationEntry[attribute.id];
 
-								let selectedLabel = attribute.unit ? `${selectedAttributeTranslation} (${attribute.unit}): ` : `${selectedAttributeTranslation}: `;
+									return `${attribute.unit ? nameWithUnit : name}:${prefix}${typeof value !== 'string' ? toLocaleString(value) : value}`;
+								};
 
-								if (typeof attributeValue !== 'string') {
-									attributeValue = toLocaleString(attributeValue);
-								}
-								if (attribute.prefix) {
-									selectedLabel += attribute.prefix + ' ' + attributeValue;
-								} else {
-									selectedLabel += attributeValue;
-								}
+								const attribute = elevationData.attrs.find((attr) => {
+									return attr.id === selectedAttributeId;
+								});
 
-								if (selectedAttribute === Default_Selected_Attribute) {
-									return selectedLabel;
-								} else {
-									const defaultAttributeTranslation = translate('elevationProfile_' + Default_Selected_Attribute);
-									const defaultAttributeValue = elevationEntry[Default_Selected_Attribute];
-									const defaultLabel = `${defaultAttributeTranslation} (m): ${defaultAttributeValue}`;
-									retArray.push(defaultLabel);
-								}
-
-								retArray.push(selectedLabel);
-
-								return retArray;
+								return selectedAttributeId === Default_Selected_Attribute
+									? createLabel(defaultAttribute)
+									: [createLabel(defaultAttribute), createLabel(attribute)];
 							}
 						}
 					}

--- a/src/modules/elevationProfile/components/panel/ElevationProfile.js
+++ b/src/modules/elevationProfile/components/panel/ElevationProfile.js
@@ -46,7 +46,8 @@ export const SoterSlopeClasses = Object.freeze([
 	{ type: SlopeType.MODERATELY_STEEP, min: 15, max: 30, color: '#d23600' },
 	{ type: SlopeType.STEEP, min: 30, max: Infinity, color: '#691b00' }
 ]);
-export const Default_Selected_Attribute = 'alt';
+export const Default_Attribute_Id = 'alt';
+export const Default_Attribute = { id: Default_Attribute_Id, unit: 'm' };
 
 export const Empty_Profile_Data = Object.freeze({
 	labels: [],
@@ -74,7 +75,7 @@ export class ElevationProfile extends MvuElement {
 			profile: Empty_Profile_Data,
 			labels: null,
 			data: null,
-			selectedAttribute: Default_Selected_Attribute,
+			selectedAttribute: Default_Attribute_Id,
 			darkSchema: null,
 			distUnit: null,
 			portrait: false,
@@ -316,7 +317,7 @@ export class ElevationProfile extends MvuElement {
 			return attr.id === selectedAttribute;
 		});
 		if (!attribute) {
-			this.signal(Update_Selected_Attribute, Default_Selected_Attribute);
+			this.signal(Update_Selected_Attribute, Default_Attribute_Id);
 		}
 
 		return;
@@ -603,11 +604,6 @@ export class ElevationProfile extends MvuElement {
 								return `${translate('elevationProfile_distance')} (${distance.unit}): ${distance.localizedValue}`;
 							},
 							label: (tooltipItem) => {
-								const defaultAttribute = { id: Default_Selected_Attribute, unit: 'm' };
-
-								const selectedAttributeId = this.getModel().selectedAttribute;
-								const elevationEntry = getElevationEntry(tooltipItem);
-
 								const createLabel = (attribute) => {
 									const name = translate('elevationProfile_' + attribute.id);
 									const nameWithUnit = `${translate('elevationProfile_' + attribute.id)} (${attribute.unit})`;
@@ -617,13 +613,15 @@ export class ElevationProfile extends MvuElement {
 									return `${attribute.unit ? nameWithUnit : name}:${prefix}${typeof value !== 'string' ? toLocaleString(value) : value}`;
 								};
 
+								const selectedAttributeId = this.getModel().selectedAttribute;
+								const elevationEntry = getElevationEntry(tooltipItem);
 								const attribute = elevationData.attrs.find((attr) => {
 									return attr.id === selectedAttributeId;
 								});
 
-								return selectedAttributeId === Default_Selected_Attribute
-									? createLabel(defaultAttribute)
-									: [createLabel(defaultAttribute), createLabel(attribute)];
+								return selectedAttributeId === Default_Attribute_Id
+									? createLabel(Default_Attribute)
+									: [createLabel(Default_Attribute), createLabel(attribute)];
 							}
 						}
 					}

--- a/src/modules/elevationProfile/components/panel/ElevationProfile.js
+++ b/src/modules/elevationProfile/components/panel/ElevationProfile.js
@@ -197,8 +197,7 @@ export class ElevationProfile extends MvuElement {
 
 		const getMinWidthClass = () => (minWidth ? 'is-desktop' : 'is-tablet');
 
-		const stringifyWithUnit = (unitsResult) => `${unitsResult.localizedValue} ${unitsResult.unit}`;
-
+		const linearDistanceRepresentation = this._unitsService.formatDistance(linearDistance);
 		return html`
 			<style>
 				${css}
@@ -218,47 +217,45 @@ export class ElevationProfile extends MvuElement {
 				</div>
 				<div class="profile__data" id="route-elevation-chart-footer">
 					<div class="profile__box">
-						<div class="profile__header">${translate('elevationProfile_sumUp')}</div>
+						<div class="profile__header">${translate('elevationProfile_sumUp')} (m)</div>
 						<div class="profile__content">
 							<div class="profile__icon up"></div>
-							<div class="profile__text" id="route-elevation-chart-footer-sumUp">${this._getFooterText(sumUp)}</div>
+							<div class="profile__text" id="route-elevation-chart-footer-sumUp">${this._getLocalizedValue(sumUp)}</div>
 						</div>
 					</div>
 					<div class="profile__box">
-						<div class="profile__header">${translate('elevationProfile_sumDown')}</div>
+						<div class="profile__header">${translate('elevationProfile_sumDown')} (m)</div>
 						<div class="profile__content">
 							<div class="profile__icon down"></div>
-							<div class="profile__text" id="route-elevation-chart-footer-sumDown">${this._getFooterText(sumDown)}</div>
+							<div class="profile__text" id="route-elevation-chart-footer-sumDown">${this._getLocalizedValue(sumDown)}</div>
 						</div>
 					</div>
 					<div class="profile__box">
-						<div class="profile__header">${translate('elevationProfile_highestPoint')}</div>
+						<div class="profile__header">${translate('elevationProfile_highestPoint')} (m)</div>
 						<div class="profile__content">
 							<div class="profile__icon highest"></div>
-							<div class="profile__text" id="route-elevation-chart-footer-highestPoint">${this._getFooterText(highestPoint)}</div>
+							<div class="profile__text" id="route-elevation-chart-footer-highestPoint">${this._getLocalizedValue(highestPoint)}</div>
 						</div>
 					</div>
 					<div class="profile__box">
-						<div class="profile__header">${translate('elevationProfile_lowestPoint')}</div>
+						<div class="profile__header">${translate('elevationProfile_lowestPoint')} (m)</div>
 						<div class="profile__content">
 							<div class="profile__icon lowest"></div>
-							<div class="profile__text" id="route-elevation-chart-footer-lowestPoint">${this._getFooterText(lowestPoint)}</div>
+							<div class="profile__text" id="route-elevation-chart-footer-lowestPoint">${this._getLocalizedValue(lowestPoint)}</div>
 						</div>
 					</div>
 					<div class="profile__box">
-						<div class="profile__header">${translate('elevationProfile_verticalHeight')}</div>
+						<div class="profile__header">${translate('elevationProfile_verticalHeight')} (m)</div>
 						<div class="profile__content">
 							<div class="profile__icon height"></div>
-							<div class="profile__text" id="route-elevation-chart-footer-verticalHeight">${toLocaleString(verticalHeight)} m</div>
+							<div class="profile__text" id="route-elevation-chart-footer-verticalHeight">${toLocaleString(verticalHeight)}</div>
 						</div>
 					</div>
 					<div class="profile__box">
-						<div class="profile__header">${translate('elevationProfile_linearDistance')}</div>
+						<div class="profile__header">${translate('elevationProfile_linearDistance')} (${linearDistanceRepresentation.unit})</div>
 						<div class="profile__content">
 							<div class="profile__icon distance"></div>
-							<div class="profile__text" id="route-elevation-chart-footer-linearDistance">
-								${stringifyWithUnit(this._unitsService.formatDistance(linearDistance))}
-							</div>
+							<div class="profile__text" id="route-elevation-chart-footer-linearDistance">${linearDistanceRepresentation.localizedValue}</div>
 						</div>
 					</div>
 				</div>
@@ -266,8 +263,8 @@ export class ElevationProfile extends MvuElement {
 		`;
 	}
 
-	_getFooterText(measurement) {
-		return measurement === null || measurement === undefined ? `-` : `${toLocaleString(measurement)} m`;
+	_getLocalizedValue(measurement) {
+		return measurement == null ? `-` : `${toLocaleString(measurement)}`;
 	}
 
 	get _noAnimation() {
@@ -560,7 +557,7 @@ export class ElevationProfile extends MvuElement {
 						type: 'linear',
 						title: {
 							display: true,
-							text: `${translate('elevationProfile_distance')} ${distUnit ? `[${distUnit}]` : ''}`,
+							text: `${translate('elevationProfile_distance')} ${distUnit ? `(${distUnit})` : ''}`,
 							color: ElevationProfile.DEFAULT_TEXT_COLOR
 						},
 						ticks: {
@@ -575,7 +572,7 @@ export class ElevationProfile extends MvuElement {
 						beginAtZero: false,
 						title: {
 							display: true,
-							text: translate('elevationProfile_alt') + ' [m]',
+							text: translate('elevationProfile_alt') + ' (m)',
 							color: ElevationProfile.DEFAULT_TEXT_COLOR
 						},
 						ticks: {
@@ -603,7 +600,7 @@ export class ElevationProfile extends MvuElement {
 								const distance = this._unitsService.formatDistance(elevationEntry.dist);
 								this.setCoordinates([elevationEntry.e, elevationEntry.n]);
 
-								return `${translate('elevationProfile_distance')}: ${distance.localizedValue} ${distance.unit}`;
+								return `${translate('elevationProfile_distance')} (${distance.unit}): ${distance.localizedValue}`;
 							},
 							label: (tooltipItem) => {
 								const retArray = [];
@@ -611,10 +608,15 @@ export class ElevationProfile extends MvuElement {
 								const elevationEntry = getElevationEntry(tooltipItem);
 								let attributeValue = elevationEntry[selectedAttribute];
 								const selectedAttributeTranslation = translate('elevationProfile_' + selectedAttribute);
-								let selectedLabel = selectedAttributeTranslation + ': ';
-								const attribute = elevationData.attrs.find((attr) => {
-									return attr.id === selectedAttribute;
-								});
+
+								const attribute =
+									selectedAttribute === 'alt'
+										? { id: 'alt', unit: 'm' }
+										: elevationData.attrs.find((attr) => {
+												return attr.id === selectedAttribute;
+											});
+
+								let selectedLabel = attribute.unit ? `${selectedAttributeTranslation} (${attribute.unit}): ` : `${selectedAttributeTranslation}: `;
 
 								if (typeof attributeValue !== 'string') {
 									attributeValue = toLocaleString(attributeValue);
@@ -626,18 +628,14 @@ export class ElevationProfile extends MvuElement {
 								}
 
 								if (selectedAttribute === Default_Selected_Attribute) {
-									selectedLabel += ' m';
 									return selectedLabel;
 								} else {
 									const defaultAttributeTranslation = translate('elevationProfile_' + Default_Selected_Attribute);
 									const defaultAttributeValue = elevationEntry[Default_Selected_Attribute];
-									const defaultLabel = defaultAttributeTranslation + ': ' + defaultAttributeValue + ' m';
+									const defaultLabel = `${defaultAttributeTranslation} (m): ${defaultAttributeValue}`;
 									retArray.push(defaultLabel);
 								}
 
-								if (attribute.unit) {
-									selectedLabel += ' ' + attribute.unit;
-								}
 								retArray.push(selectedLabel);
 
 								return retArray;

--- a/src/modules/elevationProfile/components/panel/elevationProfile.css
+++ b/src/modules/elevationProfile/components/panel/elevationProfile.css
@@ -45,6 +45,7 @@
 .profile__header {
 	font-size: 0.8rem;
 	min-height: 1.7em;
+	text-wrap: balance;
 }
 .profile__content {
 	display: flex;

--- a/src/modules/info/components/geometryInfo/GeometryInfo.js
+++ b/src/modules/info/components/geometryInfo/GeometryInfo.js
@@ -113,7 +113,7 @@ export class GeometryInfo extends MvuElement {
 		if (lineStatistic.azimuth === null) {
 			const title = translate('info_geometryInfo_title_line_length');
 			return html`<div class="stats-line-length stats-content" title=${title}>
-				<span class="label">${title}:</span><span class="value">${formattedDistance.localizedValue} ${formattedDistance.unit}</span>
+				<span class="label">${title} (${formattedDistance.unit}):</span><span class="value">${formattedDistance.localizedValue}</span>
 				<span class="icon">
 					<ba-icon
 						class="close"
@@ -128,7 +128,7 @@ export class GeometryInfo extends MvuElement {
 		const titleAzimuth = translate('info_geometryInfo_title_azimuth');
 		const titleLength = translate('info_geometryInfo_title_line_length');
 		return html`<div class="stats-line-azimuth stats-content" title=${titleAzimuth}>
-				<span class="label">${titleAzimuth}:</span><span class="value">${formattedAzimuth.localizedValue} ${formattedAzimuth.unit}</span>
+				<span class="label">${titleAzimuth} (${formattedAzimuth.unit}):</span><span class="value">${formattedAzimuth.localizedValue}</span>
 				<span class="icon">
 					<ba-icon
 						class="close"
@@ -140,7 +140,7 @@ export class GeometryInfo extends MvuElement {
 				</span>
 			</div>
 			<div class="stats-line-length stats-content" title=${titleLength}>
-				<span class="label">${titleLength}:</span><span class="value">${formattedDistance.localizedValue} ${formattedDistance.unit}</span>
+				<span class="label">${titleLength} (${formattedDistance.unit}):</span><span class="value">${formattedDistance.localizedValue}</span>
 				<span class="icon">
 					<ba-icon
 						class="close"
@@ -170,7 +170,7 @@ export class GeometryInfo extends MvuElement {
 		};
 
 		return html`<div class="stats-polygon-length stats-content" title=${titleLength}>
-				<span class="label">${titleLength}:</span><span class="value">${formattedDistance.localizedValue} ${formattedDistance.unit}</span>
+				<span class="label">${titleLength} (${formattedDistance.unit}):</span><span class="value">${formattedDistance.localizedValue}</span>
 				<span class="icon">
 					<ba-icon
 						class="close"
@@ -182,7 +182,7 @@ export class GeometryInfo extends MvuElement {
 				</span>
 			</div>
 			<div class="stats-polygon-area stats-content" title=${titleArea}>
-				<span class="label">${titleArea}:</span><span class="value">${formattedArea.localizedValue} ${unsafeHTML(formattedArea.unit)}</span>
+				<span class="label">${titleArea} (${unsafeHTML(formattedArea.unit)}):</span><span class="value">${formattedArea.localizedValue}</span>
 				<span class="icon">
 					<ba-icon
 						class="close"

--- a/src/modules/routing/components/routeDetails/RouteChart.js
+++ b/src/modules/routing/components/routeDetails/RouteChart.js
@@ -128,7 +128,7 @@ export class RouteChart extends MvuElement {
 										@mouseout=${() => resetHighlightedSegments()}
 									>
 										<div class="legend_item" style=${getLegendStyle(legendItem)}></div>
-										<span class="legend_item_label">${legendItem.label}:</span>
+										<span class="legend_item_label">${legendItem.label}</span>
 										<span class="legend_item_value">${getLegendValue(legendItem)}</span>
 									</div>
 								`

--- a/src/modules/routing/components/routeInfo/RouteInfo.js
+++ b/src/modules/routing/components/routeInfo/RouteInfo.js
@@ -65,38 +65,42 @@ export class RouteInfo extends MvuElement {
 		const iconSource = category?.style.icon ?? parent?.style.icon;
 
 		const getDuration = () => {
+			if (!stats) {
+				return { localizedValue: '-:-', unit: 'h:min' };
+			}
 			const estimate = stats.time;
 			const seconds = estimate / 1000;
 			if (seconds < Minute_In_Seconds) {
-				return '< 1 min.';
+				return { localizedValue: '< 1', unit: 'min' };
 			}
 
-			return this._formatDuration(seconds);
+			return { localizedValue: this._formatDuration(seconds), unit: 'h:min' };
 		};
+		const durationRepresentation = getDuration();
 
 		const getDistance = () => {
 			if (stats?.dist) {
-				const distance = this._unitsService.formatDistance(stats.dist);
-				return `${distance.localizedValue} ${distance.unit}`;
+				return this._unitsService.formatDistance(stats.dist);
 			}
-			return '-';
+			return { localizedValue: '-', unit: 'm' };
 		};
+		const distanceRepresentation = getDistance();
 
 		const getUphill = () => {
 			if (stats) {
-				const distance = this._unitsService.formatDistance(stats.twoDiff[0]);
-				return `${distance.localizedValue} ${distance.unit}`;
+				return this._unitsService.formatDistance(stats.twoDiff[0]);
 			}
-			return '-';
+			return { localizedValue: '-', unit: 'm' };
 		};
+		const uphillRepresentation = getUphill();
 
 		const getDownhill = () => {
 			if (stats) {
-				const distance = this._unitsService.formatDistance(stats.twoDiff[1]);
-				return `${distance.localizedValue} ${distance.unit}`;
+				return this._unitsService.formatDistance(stats.twoDiff[1]);
 			}
-			return '-';
+			return { localizedValue: '-', unit: 'm' };
 		};
+		const downhillRepresentation = getDownhill();
 		const getColor = () => {
 			return html`*{--primary-color: ${color}`;
 		};
@@ -122,42 +126,42 @@ export class RouteInfo extends MvuElement {
 								<span class=${`header-icon icon-${categoryId}`}> ${renderCategoryIcon(iconSource)} </span>
 							</div>
 							<div class="header-text">
-								<div class="routing-info-duration-text">${translate('routing_info_duration')}</div>
-								<span class="routing-info-duration" title=${translate('routing_info_duration')}> ${stats ? getDuration() : '-:-'} </span>
+								<div class="routing-info-duration-text">${translate('routing_info_duration')} (${durationRepresentation.unit})</div>
+								<span class="routing-info-duration" title=${translate('routing_info_duration')}> ${durationRepresentation.localizedValue} </span>
 								<div>${category.label}</div>
 							</div>
 						</div>
 						<div class="detail">
 							<div class="row">
 								<div class="item">
-									<div class="item-header">${translate('routing_info_distance')}</div>
+									<div class="item-header">${translate('routing_info_distance')} (${distanceRepresentation.unit})</div>
 									<div class="item-content">
 										<div class="col" title=${translate('routing_info_distance')}>
 											<div class="routing-info-icon distance"></div>
 										</div>
-										<div class="routing-info-text">${getDistance()}</div>
+										<div class="routing-info-text">${distanceRepresentation.localizedValue}</div>
 									</div>
 								</div>
 
 								<div class="item">
-									<div class="item-header">${translate('routing_info_uphill')}</div>
+									<div class="item-header">${translate('routing_info_uphill')} (${uphillRepresentation.unit})</div>
 									<div class="item-content">
 										<div class="col" title=${translate('routing_info_uphill')}>
 											<div class="routing-info-icon uphill"></div>
 										</div>
 										<div class="routing-info-text">
-											<span>${getUphill()}</span>
+											<span>${uphillRepresentation.localizedValue}</span>
 										</div>
 									</div>
 								</div>
 								<div class="item">
-									<div class="item-header">${translate('routing_info_downhill')}</div>
+									<div class="item-header">${translate('routing_info_downhill')} (${downhillRepresentation.unit})</div>
 									<div class="item-content">
 										<div class="col" title=${translate('routing_info_downhill')}>
 											<div class="routing-info-icon downhill"></div>
 										</div>
 										<div class="routing-info-text">
-											<span>${getDownhill()}</span>
+											<span>${downhillRepresentation.localizedValue}</span>
 										</div>
 									</div>
 								</div>

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -90,22 +90,20 @@ export class MeasureToolContent extends AbstractToolContent {
                	</div>  
 				<div class="ba-tool-container__content">	
 					<div class='tool-container__text-item'>
-						<span>
-						${translate('toolbox_measureTool_stats_length')}:						
+						<span class='prime-text-label'>
+						${translate('toolbox_measureTool_stats_length')} (${formattedDistance.unit}):						
 						</span>						
-						<span id='span-distance-value' data-test-id class='prime-text-value selectable'>${formattedDistance.localizedValue}</span>		
-						<span id='span-distance-unit' data-test-id class='prime-text-unit'>${formattedDistance.unit}</span>									
+						<span id='span-distance-value' data-test-id class='prime-text-value selectable'>${formattedDistance.localizedValue}</span>													
 						<span class='copy'>
 							<ba-icon class='close' .icon='${clipboardIcon}' .title=${translate('toolbox_copy_icon')} .size=${1.5} @click=${onCopyDistanceToClipboard}>
 							</ba-icon>
 						</span>											
 					</div>														
 					<div class='tool-container__text-item area ${classMap(areaClasses)}'>
-						<span>
-							${translate('toolbox_measureTool_stats_area')}:		
+						<span class='prime-text-label'>
+							${translate('toolbox_measureTool_stats_area')} (${unsafeHTML(formattedArea.unit)}):		
 						</span>						
 						<span id='span-area-value' data-test-id class='prime-text-value selectable'>${formattedArea.localizedValue}</span>
-						<span id='span-area-unit' data-test-id class='prime-text-unit'>${unsafeHTML(formattedArea.unit)}</span>
 						<span class='copy'>
 							<ba-icon class='close' .icon='${clipboardIcon}' .title=${translate('toolbox_copy_icon')} .size=${1.5} @click=${onCopyAreaToClipboard}>
 							</ba-icon>

--- a/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
+++ b/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
@@ -30,16 +30,16 @@ describe('ElevationProfile', () => {
 	};
 
 	const sumUp = 1480.8;
-	const sumUpAfterToLocaleStringEn = '1480.8 m';
+	const sumUpAfterToLocaleStringEn = '1480.8';
 
 	const sumDown = 1668.6;
-	const sumDownAfterToLocaleStringEn = '1668.6 m';
+	const sumDownAfterToLocaleStringEn = '1668.6';
 
-	const verticalHeight = 50;
-	const highestPoint = 50;
-	const lowestPoint = 0;
+	const verticalHeight = 84;
+	const highestPoint = 42;
+	const lowestPoint = -21;
 	const linearDistance = 5000;
-	const linearDistanceAfterUnitsServiceEn = '5.0 km';
+	const linearDistanceAfterUnitsServiceEn = '5.0';
 
 	const _profile = {
 		elevations: [
@@ -354,13 +354,13 @@ describe('ElevationProfile', () => {
 			// config.options.scales.x
 			expect(config.options.scales.x.type).toBe('linear');
 			expect(config.options.scales.x.title.display).toBe(true);
-			expect(config.options.scales.x.title.text).toBe('elevationProfile_distance [m]');
+			expect(config.options.scales.x.title.text).toBe('elevationProfile_distance (m)');
 			expect(config.options.scales.x.title.color).toBe(ElevationProfile.DEFAULT_TEXT_COLOR);
 			expect(config.options.scales.x.ticks.color).toBe(ElevationProfile.DEFAULT_TEXT_COLOR);
 			// config.options.scales.y
 			expect(config.options.scales.y.type).toBe('linear');
 			expect(config.options.scales.y.title.display).toBe(true);
-			expect(config.options.scales.y.title.text).toBe('elevationProfile_alt [m]');
+			expect(config.options.scales.y.title.text).toBe('elevationProfile_alt (m)');
 			expect(config.options.scales.y.title.color).toBe(ElevationProfile.DEFAULT_TEXT_COLOR);
 			expect(config.options.scales.y.ticks.color).toBe(ElevationProfile.DEFAULT_TEXT_COLOR);
 			// config.options.plugins.title
@@ -385,22 +385,22 @@ describe('ElevationProfile', () => {
 			const profile__box = element.shadowRoot.querySelectorAll('.profile__box');
 			const attrs = element.shadowRoot.getElementById('attrs');
 			expect(attrs.value).toBe('alt');
-			expect(profile__box[0].querySelector('.profile__header').innerText).toBe('elevationProfile_sumUp');
+			expect(profile__box[0].querySelector('.profile__header').innerText).toBe('elevationProfile_sumUp (m)');
 			const sumUpElement = element.shadowRoot.getElementById('route-elevation-chart-footer-sumUp');
 			expect(sumUpElement.innerText).toBe(sumUpAfterToLocaleStringEn);
-			expect(profile__box[1].querySelector('.profile__header').innerText).toBe('elevationProfile_sumDown');
+			expect(profile__box[1].querySelector('.profile__header').innerText).toBe('elevationProfile_sumDown (m)');
 			const sumDownElement = element.shadowRoot.getElementById('route-elevation-chart-footer-sumDown');
 			expect(sumDownElement.innerText).toBe(sumDownAfterToLocaleStringEn);
-			expect(profile__box[2].querySelector('.profile__header').innerText).toBe('elevationProfile_highestPoint');
+			expect(profile__box[2].querySelector('.profile__header').innerText).toBe('elevationProfile_highestPoint (m)');
 			const verticalHeightElement = element.shadowRoot.getElementById('route-elevation-chart-footer-verticalHeight');
-			expect(verticalHeightElement.innerText).toBe(verticalHeight + ' m');
-			expect(profile__box[3].querySelector('.profile__header').innerText).toBe('elevationProfile_lowestPoint');
+			expect(verticalHeightElement.innerText).toBe('84');
+			expect(profile__box[3].querySelector('.profile__header').innerText).toBe('elevationProfile_lowestPoint (m)');
 			const highestPointElement = element.shadowRoot.getElementById('route-elevation-chart-footer-highestPoint');
-			expect(highestPointElement.innerText).toBe(highestPoint + ' m');
-			expect(profile__box[4].querySelector('.profile__header').innerText).toBe('elevationProfile_verticalHeight');
+			expect(highestPointElement.innerText).toBe('42');
+			expect(profile__box[4].querySelector('.profile__header').innerText).toBe('elevationProfile_verticalHeight (m)');
 			const lowestPointElement = element.shadowRoot.getElementById('route-elevation-chart-footer-lowestPoint');
-			expect(lowestPointElement.innerText).toBe(lowestPoint + ' m');
-			expect(profile__box[5].querySelector('.profile__header').innerText).toBe('elevationProfile_linearDistance');
+			expect(lowestPointElement.innerText).toBe('-21');
+			expect(profile__box[5].querySelector('.profile__header').innerText).toBe('elevationProfile_linearDistance (km)');
 			const linearDistanceElement = element.shadowRoot.getElementById('route-elevation-chart-footer-linearDistance');
 			expect(linearDistanceElement.innerText).toBe(linearDistanceAfterUnitsServiceEn);
 		});
@@ -446,7 +446,7 @@ describe('ElevationProfile', () => {
 			const titleRet = config.options.plugins.tooltip.callbacks.title(tooltipItems);
 
 			// assert
-			expect(titleRet).toBe('elevationProfile_distance: 1 m');
+			expect(titleRet).toBe('elevationProfile_distance (m): 1');
 		});
 
 		it('calls setCoordinates() with valid coordinates', async () => {
@@ -495,7 +495,7 @@ describe('ElevationProfile', () => {
 			const labelRet = config.options.plugins.tooltip.callbacks.label(tooltipItem);
 
 			// assert
-			expect(labelRet).toBe('elevationProfile_alt: 30 m');
+			expect(labelRet).toBe('elevationProfile_alt (m): 30');
 		});
 	});
 
@@ -524,7 +524,7 @@ describe('ElevationProfile', () => {
 			element._getBorder(chart, elevationData);
 
 			// assert
-			expect(labelRet).toEqual(['elevationProfile_alt: 30 m', 'elevationProfile_slope: ~ 20 %']);
+			expect(labelRet).toEqual(['elevationProfile_alt (m): 30', 'elevationProfile_slope (%): ~ 20']);
 		});
 	});
 
@@ -553,7 +553,7 @@ describe('ElevationProfile', () => {
 			element._getBorder(chart, elevationData);
 
 			// assert
-			expect(labelRet).toEqual(['elevationProfile_alt: 30 m', 'elevationProfile_surface: gravel']);
+			expect(labelRet).toEqual(['elevationProfile_alt (m): 30', 'elevationProfile_surface: gravel']);
 		});
 	});
 
@@ -862,15 +862,15 @@ describe('ElevationProfile', () => {
 		});
 	});
 
-	describe('when _getFooterText(x) is called', () => {
+	describe('when _getLocalizedValue(x) is called', () => {
 		it('should return "x m" for "x" any number', async () => {
 			// arrange
 			const element = await setup();
 
 			// assert
-			expect(element._getFooterText(0)).toBe('0 m');
-			expect(element._getFooterText(1)).toBe('1 m');
-			expect(element._getFooterText(-1)).toBe('-1 m');
+			expect(element._getLocalizedValue(0)).toBe('0');
+			expect(element._getLocalizedValue(1)).toBe('1');
+			expect(element._getLocalizedValue(-1)).toBe('-1');
 		});
 
 		it('should return "-" for "x" undefined or null', async () => {
@@ -878,9 +878,9 @@ describe('ElevationProfile', () => {
 			const element = await setup();
 
 			// assert
-			expect(element._getFooterText()).toBe('-');
-			expect(element._getFooterText(undefined)).toBe('-');
-			expect(element._getFooterText(null)).toBe('-');
+			expect(element._getLocalizedValue()).toBe('-');
+			expect(element._getLocalizedValue(undefined)).toBe('-');
+			expect(element._getLocalizedValue(null)).toBe('-');
 		});
 	});
 

--- a/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
+++ b/test/modules/elevationProfile/components/panel/ElevationProfile.test.js
@@ -1,6 +1,6 @@
 import { $injector } from '../../../../../src/injection/index.js';
 import {
-	Default_Selected_Attribute,
+	Default_Attribute_Id,
 	ElevationProfile,
 	Empty_Profile_Data,
 	SlopeType,
@@ -302,7 +302,7 @@ describe('ElevationProfile', () => {
 				profile: Empty_Profile_Data,
 				labels: null,
 				data: null,
-				selectedAttribute: Default_Selected_Attribute,
+				selectedAttribute: Default_Attribute_Id,
 				darkSchema: null,
 				distUnit: null,
 				portrait: false,
@@ -1351,7 +1351,7 @@ describe('ElevationProfile', () => {
 			expect(enrichProfileDataSpy).toHaveBeenCalledTimes(1);
 
 			const attrsCheck = element.shadowRoot.getElementById('attrs');
-			expect(attrsCheck.value).toBe(Default_Selected_Attribute);
+			expect(attrsCheck.value).toBe(Default_Attribute_Id);
 		});
 	});
 });

--- a/test/modules/info/components/GeometryInfo.test.js
+++ b/test/modules/info/components/GeometryInfo.test.js
@@ -37,7 +37,7 @@ describe('GeometryInfo', () => {
 				},
 
 				formatArea: (area) => {
-					return { value: area, localizedValue: area, unit: ' m²' };
+					return { value: area, localizedValue: area, unit: 'm²' };
 				},
 				formatAngle: (angle) => {
 					return { value: angle, localizedValue: angle, unit: '°' };
@@ -98,13 +98,13 @@ describe('GeometryInfo', () => {
 
 			expect(element.shadowRoot.querySelector('.stats-container')).toBeTruthy();
 			expect(element.shadowRoot.querySelector('.stats-line-azimuth')).toBeFalsy();
-			expect(element.shadowRoot.querySelector('.stats-line-length')).toBeTruthy();
+			expect(element.shadowRoot.querySelector('.stats-line-length').textContent.trim()).toBe('info_geometryInfo_title_line_length (m):42');
 
-			element.statistic = { geometryType: GeometryType.LINE, coordinate: null, azimuth: 42, length: 42, area: null };
+			element.statistic = { geometryType: GeometryType.LINE, coordinate: null, azimuth: 42, length: 84, area: null };
 
 			expect(element.shadowRoot.querySelector('.stats-container')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('.stats-line-azimuth')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('.stats-line-length')).toBeTruthy();
+			expect(element.shadowRoot.querySelector('.stats-line-azimuth').textContent.trim()).toBe('info_geometryInfo_title_azimuth (°):42');
+			expect(element.shadowRoot.querySelector('.stats-line-length').textContent.trim()).toBe('info_geometryInfo_title_line_length (m):84');
 		});
 
 		it('renders the items with polygon stats', async () => {
@@ -112,8 +112,8 @@ describe('GeometryInfo', () => {
 			element.statistic = { geometryType: GeometryType.POLYGON, coordinate: null, azimuth: null, length: 42, area: 42 };
 
 			expect(element.shadowRoot.querySelector('.stats-container')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('.stats-polygon-length')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('.stats-polygon-area')).toBeTruthy();
+			expect(element.shadowRoot.querySelector('.stats-polygon-length').textContent.trim()).toBe('info_geometryInfo_title_line_length (m):42');
+			expect(element.shadowRoot.querySelector('.stats-polygon-area').textContent.trim()).toBe('info_geometryInfo_title_polygon_area (m²):42');
 		});
 
 		it('renders the items with smallest polygon stats', async () => {

--- a/test/modules/routing/components/RouteChart.test.js
+++ b/test/modules/routing/components/RouteChart.test.js
@@ -121,8 +121,8 @@ describe('RoutingChart', () => {
 			expect(containerElement).toBeTruthy();
 			expect(containerElement.querySelectorAll('.chart_section')).toHaveSize(1);
 			expect(containerElement.querySelectorAll('.highlight')).toHaveSize(2);
-			expect(containerElement.querySelectorAll('.highlight')[0].innerText.replace(/\s/g, '')).toBe('baz:18unit');
-			expect(containerElement.querySelectorAll('.highlight')[1].innerText.replace(/\s/g, '')).toBe('bar:57unit');
+			expect(containerElement.querySelectorAll('.highlight')[0].innerText.replace(/\s/g, '')).toBe('baz18unit');
+			expect(containerElement.querySelectorAll('.highlight')[1].innerText.replace(/\s/g, '')).toBe('bar57unit');
 			expect(containerElement.querySelector('.title').innerText).toBe('foo');
 		});
 
@@ -212,9 +212,9 @@ describe('RoutingChart', () => {
 			const containerElement = element.shadowRoot.querySelector('.container');
 
 			expect(containerElement).toBeTruthy();
-			expect(containerElement.querySelectorAll('.highlight')[0].innerText.replace(/\s/g, '')).toBe('bar:18unit');
-			expect(containerElement.querySelectorAll('.highlight')[1].innerText.replace(/\s/g, '')).toBe('foo:1234unit');
-			expect(containerElement.querySelectorAll('.highlight')[2].innerText.replace(/\s/g, '')).toBe('baz:5678unit');
+			expect(containerElement.querySelectorAll('.highlight')[0].innerText.replace(/\s/g, '')).toBe('bar18unit');
+			expect(containerElement.querySelectorAll('.highlight')[1].innerText.replace(/\s/g, '')).toBe('foo1234unit');
+			expect(containerElement.querySelectorAll('.highlight')[2].innerText.replace(/\s/g, '')).toBe('baz5678unit');
 			expect(unitsServiceSpy).toHaveBeenCalledTimes(3);
 		});
 	});

--- a/test/modules/routing/components/RouteInfo.test.js
+++ b/test/modules/routing/components/RouteInfo.test.js
@@ -318,15 +318,21 @@ describe('RouteInfo', () => {
 				const element = await setup(state);
 
 				setRoute(defaultRoute);
-
+				const routingLabelDuration = element.shadowRoot.querySelectorAll('.routing-info-duration-text');
 				const routingDuration = element.shadowRoot.querySelectorAll('.routing-info-duration');
-				expect(routingDuration[0].innerText).toBe('< 1 min.');
+				expect(routingLabelDuration[0].innerText).toBe('routing_info_duration (min)');
+				expect(routingDuration[0].innerText).toBe('< 1');
 
-				const routingElements = element.shadowRoot.querySelectorAll('.routing-info-text');
-				expect(routingElements).toHaveSize(3);
-				expect(routingElements[0].innerText).toBe('0.33 km');
-				expect(routingElements[1].innerText).toBe('0.11 km');
-				expect(routingElements[2].innerText).toBe('0.22 km');
+				const labelElements = element.shadowRoot.querySelectorAll('.item-header');
+				expect(labelElements[0].innerText).toBe('routing_info_distance (km)');
+				expect(labelElements[1].innerText).toBe('routing_info_uphill (km)');
+				expect(labelElements[2].innerText).toBe('routing_info_downhill (km)');
+				const routingValueElements = element.shadowRoot.querySelectorAll('.routing-info-text');
+
+				expect(routingValueElements).toHaveSize(3);
+				expect(routingValueElements[0].innerText).toBe('0.33');
+				expect(routingValueElements[1].innerText).toBe('0.11');
+				expect(routingValueElements[2].innerText).toBe('0.22');
 			});
 
 			it('renders unknown category', async () => {
@@ -346,9 +352,9 @@ describe('RouteInfo', () => {
 
 				const routingElements = element.shadowRoot.querySelectorAll('.routing-info-text');
 				expect(routingElements).toHaveSize(3);
-				expect(routingElements[0].innerText).toBe('0.33 km');
-				expect(routingElements[1].innerText).toBe('0.11 km');
-				expect(routingElements[2].innerText).toBe('0.22 km');
+				expect(routingElements[0].innerText).toBe('0.33');
+				expect(routingElements[1].innerText).toBe('0.11');
+				expect(routingElements[2].innerText).toBe('0.22');
 			});
 
 			it('renders missing stats', async () => {

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -211,14 +211,13 @@ describe('MeasureToolContent', () => {
 			};
 			const element = await setup(state);
 			const valueSpans = element.shadowRoot.querySelectorAll('.prime-text-value');
-			const unitSpans = element.shadowRoot.querySelectorAll('.prime-text-unit');
+			const labelWithUnitSpans = element.shadowRoot.querySelectorAll('.prime-text-label');
 
 			expect(valueSpans.length).toBe(2);
-			expect(unitSpans.length).toBe(2);
 			expect(valueSpans[0].textContent).toBe('42');
-			expect(unitSpans[0].textContent).toBe('m');
+			expect(labelWithUnitSpans[0].textContent.trim()).toBe('toolbox_measureTool_stats_length (m):');
 			expect(valueSpans[1].textContent).toBe('0');
-			expect(unitSpans[1].textContent).toBe('m²');
+			expect(labelWithUnitSpans[1].textContent.trim()).toBe('toolbox_measureTool_stats_area (m²):');
 		});
 
 		it('shows the empty measurement statistics', async () => {
@@ -231,15 +230,15 @@ describe('MeasureToolContent', () => {
 			};
 			const element = await setup(state);
 			const valueSpans = element.shadowRoot.querySelectorAll('.prime-text-value');
-			const unitSpans = element.shadowRoot.querySelectorAll('.prime-text-unit');
+			const labelWithUnitSpans = element.shadowRoot.querySelectorAll('.prime-text-label');
 			const areaElement = element.shadowRoot.querySelector('.is-area');
 
 			expect(valueSpans.length).toBe(2);
-			expect(unitSpans.length).toBe(2);
+			expect(labelWithUnitSpans.length).toBe(2);
 			expect(valueSpans[0].textContent).toBe('0');
-			expect(unitSpans[0].textContent).toBe('m');
+			expect(labelWithUnitSpans[0].textContent.trim()).toBe('toolbox_measureTool_stats_length (m):');
 			expect(valueSpans[1].textContent).toBe('0');
-			expect(unitSpans[1].textContent).toBe('m²');
+			expect(labelWithUnitSpans[1].textContent.trim()).toBe('toolbox_measureTool_stats_area (m²):');
 			expect(areaElement).toBeFalsy();
 		});
 
@@ -271,10 +270,7 @@ describe('MeasureToolContent', () => {
 			const element = await setup(state);
 
 			expect(element.shadowRoot.querySelector('#span-distance-value').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
-			expect(element.shadowRoot.querySelector('#span-distance-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 			expect(element.shadowRoot.querySelector('#span-area-value').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
-			expect(element.shadowRoot.querySelector('#span-area-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
-			expect(element.shadowRoot.querySelector('#span-area-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 			expect(element.shadowRoot.querySelector('#remove').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 		});
 
@@ -343,13 +339,13 @@ describe('MeasureToolContent', () => {
 			};
 			const element = await setup(state);
 			const valueSpans = element.shadowRoot.querySelectorAll('.prime-text-value');
-			const unitSpans = element.shadowRoot.querySelectorAll('.prime-text-unit');
+			const labelWithUnitSpans = element.shadowRoot.querySelectorAll('.prime-text-label');
 			const areaElement = element.shadowRoot.querySelector('.is-area');
 
 			expect(valueSpans.length).toBe(2);
-			expect(unitSpans.length).toBe(2);
+			expect(labelWithUnitSpans.length).toBe(2);
 			expect(valueSpans[0].textContent).toBe('42');
-			expect(unitSpans[0].textContent).toBe('m');
+			expect(labelWithUnitSpans[0].textContent.trim()).toBe('toolbox_measureTool_stats_length (m):');
 			expect(areaElement).toBeFalsy();
 		});
 


### PR DESCRIPTION
Quantities are displayed in two ways:

1. `Quantity` (`unitOfMeasurement`): `numericValue` --> _'Distance (km): 42.1'_
2. `numericValue` `unitOfMeasurement` --> _'42.1 km'_

components to refactor:
- [x] ElevationProfile
- [x] GeometryInfo
- [x] RouteChart
- [x] RouteInfo
- [x] MeasureToolContent