### PR TITLE
use clean-jsdoc-theme as jsdoc theme

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -20,10 +20,10 @@
 		"destination": "docs",
 		"recurse": true,
 		"readme": "README.md",
-		"template": "./node_modules/docdash"
-	},
-	"docdash": {
-		"search": true,
-		"sectionOrder": ["Modules", "Global", "Interfaces"]
+		"template": "node_modules/clean-jsdoc-theme",
+		"theme_opts": {
+			"homepageTitle": "BayernAtlas v4 Docs",
+			"search": true
+		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
 				"@jsdevtools/coverage-istanbul-loader": "3.0.5",
 				"@playwright/test": "1.50.1",
 				"bundlesize2": "^0.0.34",
+				"clean-jsdoc-theme": "^4.3.0",
 				"copy-webpack-plugin": "12.0.2",
 				"css-loader": "7.1.2",
-				"docdash": "2.0.2",
 				"dotenv-webpack": "8.1.0",
 				"es-check": "8.0.1",
 				"eslint": "8.57.0",
@@ -853,10 +853,11 @@
 			}
 		},
 		"node_modules/@jsdoc/salty": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.3.tgz",
-			"integrity": "sha512-bbtCxCkxcnWhi50I+4Lj6mdz9w3pOXOgEQrID8TCZ/DF51fW7M9GCQW2y45SpBDdHd1Eirm1X/Cf6CkAAe8HPg==",
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
+			"integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"lodash": "^4.17.21"
 			},
@@ -2597,15 +2598,79 @@
 			}
 		},
 		"node_modules/clean-css": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
-			"integrity": "sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"source-map": "~0.6.0"
 			},
 			"engines": {
 				"node": ">= 10.0"
+			}
+		},
+		"node_modules/clean-jsdoc-theme": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/clean-jsdoc-theme/-/clean-jsdoc-theme-4.3.0.tgz",
+			"integrity": "sha512-QMrBdZ2KdPt6V2Ytg7dIt0/q32U4COpxvR0UDhPjRRKRL0o0MvRCR5YpY37/4rPF1SI1AYEKAWyof7ndCb/dzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jsdoc/salty": "^0.2.4",
+				"fs-extra": "^10.1.0",
+				"html-minifier-terser": "^7.2.0",
+				"klaw-sync": "^6.0.0",
+				"lodash": "^4.17.21",
+				"showdown": "^2.1.0"
+			},
+			"peerDependencies": {
+				"jsdoc": ">=3.x <=4.x"
+			}
+		},
+		"node_modules/clean-jsdoc-theme/node_modules/commander": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/clean-jsdoc-theme/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/clean-jsdoc-theme/node_modules/html-minifier-terser": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+			"integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camel-case": "^4.1.2",
+				"clean-css": "~5.3.2",
+				"commander": "^10.0.0",
+				"entities": "^4.4.0",
+				"param-case": "^3.0.4",
+				"relateurl": "^0.2.7",
+				"terser": "^5.15.1"
+			},
+			"bin": {
+				"html-minifier-terser": "cli.js"
+			},
+			"engines": {
+				"node": "^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/cliui": {
@@ -3381,15 +3446,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/docdash": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/docdash/-/docdash-2.0.2.tgz",
-			"integrity": "sha512-3SDDheh9ddrwjzf6dPFe1a16M6ftstqTNjik2+1fx46l24H9dD2osT2q9y+nBEC1wWz4GIqA48JmicOLQ0R8xA==",
-			"dev": true,
-			"dependencies": {
-				"@jsdoc/salty": "^0.2.1"
 			}
 		},
 		"node_modules/doctrine": {
@@ -4872,10 +4928,11 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -6969,6 +7026,16 @@
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.9"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/known-css-properties": {
@@ -9285,6 +9352,33 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/showdown": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+			"integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^9.0.0"
+			},
+			"bin": {
+				"showdown": "bin/showdown.js"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://www.paypal.me/tiviesantos"
+			}
+		},
+		"node_modules/showdown/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || >=14"
 			}
 		},
 		"node_modules/side-channel": {
@@ -11743,9 +11837,9 @@
 			}
 		},
 		"@jsdoc/salty": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.3.tgz",
-			"integrity": "sha512-bbtCxCkxcnWhi50I+4Lj6mdz9w3pOXOgEQrID8TCZ/DF51fW7M9GCQW2y45SpBDdHd1Eirm1X/Cf6CkAAe8HPg==",
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
+			"integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.21"
@@ -13114,12 +13208,55 @@
 			"dev": true
 		},
 		"clean-css": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
-			"integrity": "sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
 			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
+			}
+		},
+		"clean-jsdoc-theme": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/clean-jsdoc-theme/-/clean-jsdoc-theme-4.3.0.tgz",
+			"integrity": "sha512-QMrBdZ2KdPt6V2Ytg7dIt0/q32U4COpxvR0UDhPjRRKRL0o0MvRCR5YpY37/4rPF1SI1AYEKAWyof7ndCb/dzA==",
+			"dev": true,
+			"requires": {
+				"@jsdoc/salty": "^0.2.4",
+				"fs-extra": "^10.1.0",
+				"html-minifier-terser": "^7.2.0",
+				"klaw-sync": "^6.0.0",
+				"lodash": "^4.17.21",
+				"showdown": "^2.1.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+					"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+					"dev": true
+				},
+				"entities": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+					"dev": true
+				},
+				"html-minifier-terser": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+					"integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+					"dev": true,
+					"requires": {
+						"camel-case": "^4.1.2",
+						"clean-css": "~5.3.2",
+						"commander": "^10.0.0",
+						"entities": "^4.4.0",
+						"param-case": "^3.0.4",
+						"relateurl": "^0.2.7",
+						"terser": "^5.15.1"
+					}
+				}
 			}
 		},
 		"cliui": {
@@ -13685,15 +13822,6 @@
 			"dev": true,
 			"requires": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
-			}
-		},
-		"docdash": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/docdash/-/docdash-2.0.2.tgz",
-			"integrity": "sha512-3SDDheh9ddrwjzf6dPFe1a16M6ftstqTNjik2+1fx46l24H9dD2osT2q9y+nBEC1wWz4GIqA48JmicOLQ0R8xA==",
-			"dev": true,
-			"requires": {
-				"@jsdoc/salty": "^0.2.1"
 			}
 		},
 		"doctrine": {
@@ -14822,9 +14950,9 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.0",
@@ -16312,6 +16440,15 @@
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.9"
+			}
+		},
+		"klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"known-css-properties": {
@@ -18030,6 +18167,23 @@
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
 			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
 			"dev": true
+		},
+		"showdown": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+			"integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+			"dev": true,
+			"requires": {
+				"commander": "^9.0.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "9.5.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+					"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+					"dev": true
+				}
+			}
 		},
 		"side-channel": {
 			"version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
 		"@jsdevtools/coverage-istanbul-loader": "3.0.5",
 		"@playwright/test": "1.50.1",
 		"bundlesize2": "^0.0.34",
+		"clean-jsdoc-theme": "^4.3.0",
 		"copy-webpack-plugin": "12.0.2",
 		"css-loader": "7.1.2",
-		"docdash": "2.0.2",
 		"dotenv-webpack": "8.1.0",
 		"es-check": "8.0.1",
 		"eslint": "8.57.0",
@@ -41,6 +41,7 @@
 		"karma-webkit-launcher": "2.6.0",
 		"karma-webpack": "5.0.1",
 		"mapbox-gl-supported": "1.2.0",
+		"mock-socket": "9.3.1",
 		"playwright": "1.50.1",
 		"portfinder-sync": "0.0.2",
 		"prettier": "3.5.1",
@@ -51,8 +52,7 @@
 		"webpack": "5.98.0",
 		"webpack-bundle-analyzer": "4.10.2",
 		"webpack-cli": "6.0.1",
-		"webpack-dev-server": "5.2.0",
-		"mock-socket": "9.3.1"
+		"webpack-dev-server": "5.2.0"
 	},
 	"scripts": {
 		"start": "webpack serve --open --mode=development --devtool=inline-source-map",


### PR DESCRIPTION
see https://ankdev.me/clean-jsdoc-theme/v4/

But `clean-jsdoc-theme` is significantly slower than `docdash` 🙁:

docdash:
```sh
> doc
> jsdoc -c jsdoc.conf.json


real	0m5,942s
user	0m7,306s
sys	0m0,286s
```
clean-jsdoc-theme:
```sh

> doc
> jsdoc -c jsdoc.conf.json


real	1m24,335s
user	1m41,663s
sys	0m1,808s
```
