### PR TITLE
OlDrawHandler: fix behavior on pointer click

### DIFF
--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -263,6 +263,11 @@ export class OlDrawHandler extends OlLayerHandler {
 			const dragging = event.dragging;
 			const pixel = event.pixel;
 
+			if (this._sketchHandler.isActive || this._drawState.type === InteractionStateType.DRAW) {
+				this._updateDrawState(coordinate, pixel, dragging);
+				return;
+			}
+
 			const addToSelection = (features) => {
 				if ([InteractionStateType.MODIFY, InteractionStateType.SELECT].includes(this._drawState.type)) {
 					const ids = features.map((f) => f.getId());

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -2036,6 +2036,44 @@ describe('OlDrawHandler', () => {
 			expect(store.getState().draw.selectedStyle.style.text).toBe('');
 		});
 
+		it('updates the drawState while pointer click a measurement geometry', () => {
+			setup();
+			const feature = new Feature({
+				geometry: new Polygon([
+					[
+						[0, 0],
+						[1, 0],
+						[1, 1],
+						[0, 1],
+						[0, 1]
+					]
+				])
+			});
+			const map = setupMap();
+			const classUnderTest = new OlDrawHandler();
+			const layer = classUnderTest.activate(map);
+			layer.getSource().addFeature(feature);
+
+			const updateDrawStateSpy = spyOn(classUnderTest, '_updateDrawState');
+
+			// initial Phase: the drawing will be activated after this click-event
+			classUnderTest._sketchHandler.activate(feature, map);
+			classUnderTest._drawState.type = InteractionStateType.ACTIVE;
+
+			simulateMapBrowserEvent(map, MapBrowserEventType.CLICK, 0.5, 0.5);
+
+			expect(updateDrawStateSpy).toHaveBeenCalled();
+			updateDrawStateSpy.calls.reset();
+
+			// Phase 2: the drawing will be end after this click-event
+			classUnderTest._sketchHandler.deactivate();
+			classUnderTest._drawState.type = InteractionStateType.DRAW;
+
+			simulateMapBrowserEvent(map, MapBrowserEventType.CLICK, 0.5, 0.5);
+
+			expect(updateDrawStateSpy).toHaveBeenCalled();
+		});
+
 		it('switch to measure-tool, if clickposition is in anyinteract to selected measure-feature', () => {
 			const store = setup();
 


### PR DESCRIPTION
If the user starts a drawing and clicks on a measurement geometry, the draw process should not interrupt, but proceed with changed draw state.