### PR TITLE
 VectorGeoResource: add support for BaFeature

### DIFF
--- a/src/domain/feature.js
+++ b/src/domain/feature.js
@@ -3,7 +3,7 @@
  */
 
 import { isString } from '../utils/checks';
-import { Geometry } from './geometry';
+import { BaGeometry } from './geometry';
 
 /**
  * A feature.
@@ -15,11 +15,11 @@ export class BaFeature {
 	#properties = {};
 	/**
 	 *
-	 * @param {Geometry} geometry The geometry of this feature
+	 * @param {BaGeometry} geometry The geometry of this feature
 	 * @param {String} id The id of this feature
 	 */
 	constructor(geometry, id) {
-		if (!(geometry instanceof Geometry)) {
+		if (!(geometry instanceof BaGeometry)) {
 			throw new Error('<geometry> must be a Geometry');
 		}
 		if (!isString(id)) {

--- a/src/domain/feature.js
+++ b/src/domain/feature.js
@@ -11,6 +11,7 @@ import { Geometry } from './geometry';
 export class Feature {
 	#id;
 	#geometry;
+	#styleHint;
 	#properties = {};
 	/**
 	 *
@@ -62,6 +63,28 @@ export class Feature {
 
 	getProperties() {
 		return { ...this.#properties };
+	}
+
+	/**
+	 * Set the style hint for this `VectorGeoResource`
+	 * @param {StyleHint} styleHint
+	 * @returns {Feature}
+	 */
+	setStyleHint(styleHint) {
+		if (styleHint) {
+			this.#styleHint = styleHint;
+		}
+		return this;
+	}
+	/**
+	 * @returns `true` if this Feature has specific style hint
+	 */
+	hasStyleHint() {
+		return !!this.#styleHint;
+	}
+
+	get styleHint() {
+		return this.#styleHint ?? null;
 	}
 
 	get id() {

--- a/src/domain/feature.js
+++ b/src/domain/feature.js
@@ -6,7 +6,7 @@ import { isString } from '../utils/checks';
 import { BaGeometry } from './geometry';
 
 /**
- * A feature.
+ * A "framework-neutral" feature in the BA context.
  */
 export class BaFeature {
 	#id;

--- a/src/domain/feature.js
+++ b/src/domain/feature.js
@@ -8,7 +8,7 @@ import { Geometry } from './geometry';
 /**
  * A feature.
  */
-export class Feature {
+export class BaFeature {
 	#id;
 	#geometry;
 	#styleHint;
@@ -68,7 +68,7 @@ export class Feature {
 	/**
 	 * Set the style hint for this `VectorGeoResource`
 	 * @param {StyleHint} styleHint
-	 * @returns {Feature}
+	 * @returns {BaFeature}
 	 */
 	setStyleHint(styleHint) {
 		if (styleHint) {

--- a/src/domain/featureInfo.js
+++ b/src/domain/featureInfo.js
@@ -5,5 +5,5 @@
  * @typedef {Object} FeatureInfo
  * @property {string} title The title of this FeatureInfo
  * @property {string|TemplateResult} content The content of this FeatureInfo
- * @property {Geometry} [geometry] Corresponding geometry of this FeatureInfo
+ * @property {BaGeometry} [geometry] Corresponding geometry of this FeatureInfo
  */

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -200,26 +200,51 @@ export class GeoResource {
 		return this._attributionProvider;
 	}
 
+	/**
+	 *
+	 * @param {string} label
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setLabel(label) {
 		this._label = label;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {number} opacity
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setOpacity(opacity) {
 		this._opacity = opacity;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {number} minZoom
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setMinZoom(minZoom) {
 		this._minZoom = minZoom;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {number} maxZoom
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setMaxZoom(maxZoom) {
 		this._maxZoom = maxZoom;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {boolean} hidden
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setHidden(hidden) {
 		this._hidden = hidden;
 		return this;
@@ -228,7 +253,7 @@ export class GeoResource {
 	/**
 	 * Sets the attribution for this GeoResource.
 	 * @param {Attribution|Array<Attribution>|string|null} attribution
-	 * @returns `this` for chaining
+	 * @returns {GeoResource} `this` for chaining
 	 */
 	setAttribution(attribution) {
 		this._attribution = attribution;
@@ -238,23 +263,38 @@ export class GeoResource {
 	/**
 	 * Sets the attribution provider for this GeoResource.
 	 * @param {attributionProvider} provider
-	 * @returns `this` for chaining
+	 * @returns {GeoResource} `this` for chaining
 	 */
 	setAttributionProvider(provider) {
 		this._attributionProvider = provider;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {string} type
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setAuthenticationType(type) {
 		this._authenticationType = type;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {boolean} queryable
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setQueryable(queryable) {
 		this._queryable = queryable;
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {boolean} exportable
+	 * @returns {GeoResource} `this` for chaining
+	 */
 	setExportable(exportable) {
 		this._exportable = exportable;
 		return this;
@@ -263,7 +303,7 @@ export class GeoResource {
 	/**
 	 * Set the timestamps of this GeoResource
 	 * @param {Array<string>} timestamps Timestamps of this GeoResource
-	 * @returns `this` for chaining
+	 * @returns {GeoResource} `this` for chaining
 	 */
 	setTimestamps(timestamps) {
 		if (timestamps) {
@@ -276,7 +316,7 @@ export class GeoResource {
 	 * Set the roles for authentication/authorization of this GeoResource
 	 * and updates its authentication type.
 	 * @param {Array<string>} roles Roles of this GeoResource
-	 * @returns `this` for chaining
+	 * @returns {GeoResource} `this` for chaining
 	 */
 	setAuthRoles(roles) {
 		if (roles) {
@@ -290,7 +330,7 @@ export class GeoResource {
 
 	/**
 	 * Checks if this GeoResource contains a non-default value as label
-	 * @returns `true` if the label is a non-default value
+	 * @returns {boolean} `true` if the label is a non-default value
 	 */
 	hasLabel() {
 		return !!this._label;
@@ -298,7 +338,7 @@ export class GeoResource {
 
 	/**
 	 * Checks if this GeoResource contains one or more timestamps
-	 * @returns `true` if it contains one or more timestamps
+	 * @returns {boolean}`true` if it contains one or more timestamps
 	 */
 	hasTimestamps() {
 		return this._timestamps.length > 0;
@@ -307,6 +347,7 @@ export class GeoResource {
 	/**
 	 * Checks if this GeoResource has an HTTP based id
 	 * which means it denotes an (imported) external resource.
+	 * @returns {boolean}`true` if it an external GeoResource
 	 */
 	isExternal() {
 		return isExternalGeoResourceId(this.id);
@@ -467,6 +508,11 @@ export class WmsGeoResource extends GeoResource {
 		return this._maxSize ? [...this._maxSize] : null;
 	}
 
+	/**
+	 *
+	 * @param {object} extraParams
+	 * @returns {WmsGeoResource} `this` for chaining
+	 */
 	setExtraParams(extraParams) {
 		if (extraParams) {
 			this._extraParams = { ...extraParams };
@@ -474,6 +520,11 @@ export class WmsGeoResource extends GeoResource {
 		return this;
 	}
 
+	/**
+	 *
+	 * @param {number[]} maxSize
+	 * @returns  {WmsGeoResource} `this` for chaining
+	 */
 	setMaxSize(maxSize) {
 		if (maxSize) {
 			this._maxSize = [...maxSize];
@@ -515,6 +566,11 @@ export class XyzGeoResource extends GeoResource {
 		return this._tileGridId;
 	}
 
+	/**
+	 *
+	 * @param {string} tileGridId
+	 * @returns {XyzGeoResource} `this` for chaining
+	 */
 	setTileGridId(tileGridId) {
 		this._tileGridId = tileGridId;
 		return this;
@@ -541,6 +597,7 @@ export const VectorSourceType = Object.freeze({
 
 /**
  * GeoResource for vector data.
+ * The data are hold either as string (together with a SRID) or by one or more `BaFeatures`.
  * @class
  */
 export class VectorGeoResource extends GeoResource {
@@ -553,6 +610,7 @@ export class VectorGeoResource extends GeoResource {
 		this._localData = false;
 		this._clusterParams = {};
 		this._styleHint = null;
+		this._features = [];
 	}
 
 	/**
@@ -590,11 +648,15 @@ export class VectorGeoResource extends GeoResource {
 		return this._srid;
 	}
 
+	get features() {
+		return [...this._features];
+	}
+
 	/**
-	 * Sets the source of this  GeoResource.
+	 * Sets the source of this `VectorGeoResource`.
 	 * @param {string} data
 	 * @param {number} srid of the data
-	 * @returns `this` for chaining
+	 * @returns {VectorGeoResource} `this` for chaining
 	 */
 	setSource(data, srid) {
 		this._data = data;
@@ -603,15 +665,44 @@ export class VectorGeoResource extends GeoResource {
 	}
 
 	/**
+	 * Sets the features of this `VectorGeoResource`.
+	 * Existing features will be replaced.
+	 * @param {Feature[]} features
+	 * @returns {VectorGeoResource} `this` for chaining
+	 */
+	setFeatures(features) {
+		this._features = [...features];
+		return this;
+	}
+
+	/**
+	 * Adds a features to the existing features.
+	 * @param {Feature} feature
+	 * @returns {VectorGeoResource} `this` for chaining
+	 */
+	addFeature(feature) {
+		this._features.push(feature);
+		return this;
+	}
+
+	/**
+	 *
+	 * @returns {boolean} `true` if this `VectorGeoResource` contains features
+	 */
+	hasFeatures() {
+		return this._features.length > 0;
+	}
+
+	/**
 	 * @override
-	 * @returns `true` if this GeoResource contains an non empty string and no fallback as label
+	 * @returns {boolean} `true` if this `VectorGeoResource` contains an non empty string and no fallback as label
 	 */
 	hasLabel() {
 		return !!this._label || this.label !== this._getFallbackLabel();
 	}
 
 	/**
-	 * @returns `true` if this VectorGeoResource should be displayed clustered
+	 * @returns {boolean} `true` if this `VectorGeoResource` should be displayed clustered
 	 */
 	isClustered() {
 		return !!Object.keys(this._clusterParams).length;
@@ -659,7 +750,7 @@ export class VectorGeoResource extends GeoResource {
 	 * Currently effective only for KML:
 	 * Show names as labels for placemarks which contain points.
 	 * @param {boolean} showPointNames
-	 * @returns `this` for chaining
+	 * @returns {VectorGeoResource} `this` for chaining
 	 */
 	setShowPointNames(showPointNames) {
 		this._showPointNames = showPointNames;
@@ -673,7 +764,7 @@ export class VectorGeoResource extends GeoResource {
 	/**
 	 * Mark this `VectorGeoResource` as containing local data
 	 * @param {boolean} localData
-	 * @returns `this` for chaining
+	 * @returns {VectorGeoResource} `this` for chaining
 	 */
 	markAsLocalData(localData) {
 		this._localData = localData;
@@ -738,6 +829,11 @@ export class RtVectorGeoResource extends GeoResource {
 		return { ...this._clusterParams };
 	}
 
+	/**
+	 *
+	 * @param {object} clusterParams
+	 * @returns {RtVectorGeoResource} `this` for chaining
+	 */
 	setClusterParams(clusterParams) {
 		if (clusterParams) {
 			this._clusterParams = { ...clusterParams };
@@ -746,7 +842,7 @@ export class RtVectorGeoResource extends GeoResource {
 	}
 
 	/**
-	 * @returns `true` if this VectorGeoResource has specific style hint
+	 * @returns {boolean}`true` if this VectorGeoResource has specific style hint
 	 */
 	hasStyleHint() {
 		return !!this._styleHint;
@@ -776,7 +872,7 @@ export class RtVectorGeoResource extends GeoResource {
 	 * Currently effective only for KML:
 	 * Show names as labels for placemarks which contain points.
 	 * @param {boolean} showPointNames
-	 * @returns `this` for chaining
+	 * @returns {RtVectorGeoResource} `this` for chaining
 	 */
 	setShowPointNames(showPointNames) {
 		this._showPointNames = showPointNames;
@@ -784,7 +880,7 @@ export class RtVectorGeoResource extends GeoResource {
 	}
 
 	/**
-	 * @returns `true` if this RtVectorGeoResource should be displayed clustered
+	 * @returns {boolean} `true` if this RtVectorGeoResource should be displayed clustered
 	 */
 	isClustered() {
 		return !!Object.keys(this._clusterParams).length;

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -479,6 +479,14 @@ export class GeoResourceFuture extends GeoResource {
  * @class
  */
 export class WmsGeoResource extends GeoResource {
+	/**
+	 *
+	 * @param {string} id
+	 * @param {string} label
+	 * @param {string} url
+	 * @param {string} layers
+	 * @param {string} format
+	 */
 	constructor(id, label, url, layers, format) {
 		super(id, label);
 		this._url = url;
@@ -544,6 +552,12 @@ export class WmsGeoResource extends GeoResource {
  * @class
  */
 export class XyzGeoResource extends GeoResource {
+	/**
+	 *
+	 * @param {string} id
+	 * @param {string} label
+	 * @param {string} url
+	 */
 	constructor(id, label, url) {
 		super(id, label);
 		this._urls = url;
@@ -601,9 +615,15 @@ export const VectorSourceType = Object.freeze({
  * @class
  */
 export class VectorGeoResource extends GeoResource {
-	constructor(id, label, sourceType) {
+	/**
+	 *
+	 * @param {string} id
+	 * @param {String} label
+	 * @param {VectorSourceType} [vectorSourceType] The type of the internal vector data. Only required if the data are hold as `string`.
+	 */
+	constructor(id, label, vectorSourceType = null) {
 		super(id, label);
-		this._sourceType = sourceType;
+		this._sourceType = vectorSourceType;
 		this._data = null;
 		this._srid = null;
 		this._showPointNames = true;
@@ -898,6 +918,12 @@ export class RtVectorGeoResource extends GeoResource {
  * @class
  */
 export class AggregateGeoResource extends GeoResource {
+	/**
+	 *
+	 * @param {string} id
+	 * @param {string} label
+	 * @param {string[]} geoResourceIds
+	 */
 	constructor(id, label, geoResourceIds) {
 		super(id, label);
 		this._geoResourceIds = [...geoResourceIds];
@@ -916,6 +942,12 @@ export class AggregateGeoResource extends GeoResource {
 }
 
 export class VTGeoResource extends GeoResource {
+	/**
+	 *
+	 * @param {string} id
+	 * @param {string} label
+	 * @param {string} styleUrl
+	 */
 	constructor(id, label, styleUrl) {
 		super(id, label);
 		this._styleUrl = styleUrl;

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -640,7 +640,7 @@ export class VectorGeoResource extends GeoResource {
 	}
 
 	/**
-	 * Set the styleHint for this `VectorGeoResource`
+	 * Set the style hint for this `VectorGeoResource`
 	 * @param {StyleHint} styleHint
 	 * @returns {VectorGeoResource}
 	 */
@@ -757,9 +757,9 @@ export class RtVectorGeoResource extends GeoResource {
 	}
 
 	/**
-	 * Set the styleHint for this `VectorGeoResource`
+	 * Set the style hint for this `RtVectorGeoResource`
 	 * @param {StyleHint} styleHint
-	 * @returns {VectorGeoResource}
+	 * @returns {RtVectorGeoResource}
 	 */
 	setStyleHint(styleHint) {
 		if (styleHint) {

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -552,6 +552,7 @@ export class VectorGeoResource extends GeoResource {
 		this._showPointNames = true;
 		this._localData = false;
 		this._clusterParams = {};
+		this._styleHint = null;
 	}
 
 	/**
@@ -623,6 +624,29 @@ export class VectorGeoResource extends GeoResource {
 	setClusterParams(clusterParams) {
 		if (clusterParams) {
 			this._clusterParams = { ...clusterParams };
+		}
+		return this;
+	}
+
+	/**
+	 * @returns `true` if this VectorGeoResource has specific style hint
+	 */
+	hasStyleHint() {
+		return !!this._styleHint;
+	}
+
+	get styleHint() {
+		return this._styleHint;
+	}
+
+	/**
+	 * Set the styleHint for this `VectorGeoResource`
+	 * @param {StyleHint} styleHint
+	 * @returns {VectorGeoResource}
+	 */
+	setStyleHint(styleHint) {
+		if (styleHint) {
+			this._styleHint = styleHint;
 		}
 		return this;
 	}
@@ -699,6 +723,7 @@ export class RtVectorGeoResource extends GeoResource {
 		this._sourceType = sourceType;
 		this._clusterParams = {};
 		this._showPointNames = true;
+		this._styleHint = null;
 	}
 
 	get url() {
@@ -716,6 +741,29 @@ export class RtVectorGeoResource extends GeoResource {
 	setClusterParams(clusterParams) {
 		if (clusterParams) {
 			this._clusterParams = { ...clusterParams };
+		}
+		return this;
+	}
+
+	/**
+	 * @returns `true` if this VectorGeoResource has specific style hint
+	 */
+	hasStyleHint() {
+		return !!this._styleHint;
+	}
+
+	get styleHint() {
+		return this._styleHint;
+	}
+
+	/**
+	 * Set the styleHint for this `VectorGeoResource`
+	 * @param {StyleHint} styleHint
+	 * @returns {VectorGeoResource}
+	 */
+	setStyleHint(styleHint) {
+		if (styleHint) {
+			this._styleHint = styleHint;
 		}
 		return this;
 	}

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -687,7 +687,7 @@ export class VectorGeoResource extends GeoResource {
 	/**
 	 * Sets the features of this `VectorGeoResource`.
 	 * Existing features will be replaced.
-	 * @param {Feature[]} features
+	 * @param {BaFeature[]} features
 	 * @returns {VectorGeoResource} `this` for chaining
 	 */
 	setFeatures(features) {
@@ -697,7 +697,7 @@ export class VectorGeoResource extends GeoResource {
 
 	/**
 	 * Adds a features to the existing features.
-	 * @param {Feature} feature
+	 * @param {BaFeature} feature
 	 * @returns {VectorGeoResource} `this` for chaining
 	 */
 	addFeature(feature) {

--- a/src/domain/geometry.js
+++ b/src/domain/geometry.js
@@ -6,7 +6,7 @@ import { isString } from '../utils/checks';
 import { SourceType, SourceTypeName, SupportedVectorSourceTypes } from './sourceType';
 
 /**
- * A "framework-neutral" feature in the BA context.
+ * A "framework-neutral" geometry in the BA context.
  * The actual geometry is encoded as the specified SourceType or `null` if it is unknown (in that case a consumer can use the `SourceTypeService`  for determination).
  */
 export class BaGeometry {

--- a/src/domain/geometry.js
+++ b/src/domain/geometry.js
@@ -13,8 +13,8 @@ export class Geometry {
 	#sourceType;
 	/**
 	 *
-	 * @param {String|object} data The data of this geometry (Note type `object' is only allowed in case of sourceType GeoJSON)
-	 * @param {SourceType} sourceType The source type of this geometry. If unknown use {@link Geometry.forData}
+	 * @param {String|object} data The data of this geometry (Note type `object` is only allowed in case of sourceType == `SourceType.GeoJSON`)
+	 * @param {SourceType} sourceType The source type of this geometry.
 	 */
 	constructor(data, sourceType) {
 		if (!(sourceType instanceof SourceType)) {

--- a/src/domain/geometry.js
+++ b/src/domain/geometry.js
@@ -13,7 +13,7 @@ export class Geometry {
 	#sourceType;
 	/**
 	 *
-	 * @param {String|object} data The data of this geometry (Note type `object` is only allowed in case of sourceType == `SourceType.GeoJSON`)
+	 * @param {String|object} data The data of this geometry (Note: type `object` is only allowed in case of sourceType == `SourceType.GeoJSON`)
 	 * @param {SourceType} sourceType The source type of this geometry.
 	 */
 	constructor(data, sourceType) {

--- a/src/domain/geometry.js
+++ b/src/domain/geometry.js
@@ -6,7 +6,8 @@ import { isString } from '../utils/checks';
 import { SourceType, SourceTypeName, SupportedVectorSourceTypes } from './sourceType';
 
 /**
- * A geometry. The actual geometry is encoded as the specified SourceType or `null` if it is unknown (in that case a consumer can use the `SourceTypeService`  for determination).
+ * A "framework-neutral" feature in the BA context.
+ * The actual geometry is encoded as the specified SourceType or `null` if it is unknown (in that case a consumer can use the `SourceTypeService`  for determination).
  */
 export class BaGeometry {
 	#data;

--- a/src/domain/geometry.js
+++ b/src/domain/geometry.js
@@ -8,7 +8,7 @@ import { SourceType, SourceTypeName, SupportedVectorSourceTypes } from './source
 /**
  * A geometry. The actual geometry is encoded as the specified SourceType or `null` if it is unknown (in that case a consumer can use the `SourceTypeService`  for determination).
  */
-export class Geometry {
+export class BaGeometry {
 	#data;
 	#sourceType;
 	/**

--- a/src/domain/sourceType.js
+++ b/src/domain/sourceType.js
@@ -56,6 +56,15 @@ export class SourceType {
 	static forGeoJSON() {
 		return new SourceType(SourceTypeName.GEOJSON, null, 4326);
 	}
+
+	/**
+	 *
+	 * @param {number} srid The SRID of the EWKT
+	 * @returns {SourceType} SourceType for WKT
+	 */
+	static forEwkt(srid) {
+		return new SourceType(SourceTypeName.EWKT, null, srid);
+	}
 }
 
 /**

--- a/src/domain/sourceType.js
+++ b/src/domain/sourceType.js
@@ -32,6 +32,30 @@ export class SourceType {
 	get srid() {
 		return this._srid;
 	}
+
+	/**
+	 *
+	 * @returns {SourceType} SourceType for KML
+	 */
+	static forKml() {
+		return new SourceType(SourceTypeName.KML, null, 4326);
+	}
+
+	/**
+	 *
+	 * @returns {SourceType} SourceType for GPX
+	 */
+	static forGpx() {
+		return new SourceType(SourceTypeName.GPX, null, 4326);
+	}
+
+	/**
+	 *
+	 * @returns {SourceType} SourceType for GeoJson
+	 */
+	static forGeoJSON() {
+		return new SourceType(SourceTypeName.GEOJSON, null, 4326);
+	}
 }
 
 /**

--- a/src/domain/styles.js
+++ b/src/domain/styles.js
@@ -17,5 +17,6 @@ export const StyleSize = Object.freeze({
  * @enum {string}
  */
 export const StyleHint = Object.freeze({
-	HIGHLIGHT: 'highlight'
+	HIGHLIGHT: 'highlight',
+	CLUSTER: 'cluster'
 });

--- a/src/domain/styles.js
+++ b/src/domain/styles.js
@@ -12,7 +12,7 @@ export const StyleSize = Object.freeze({
 });
 
 /**
- * StyleHint e.g. of a `VectorGeoResource` a `RtVectorGeoResource` or a `Feature`
+ * StyleHint e.g. of a `VectorGeoResource` a `RtVectorGeoResource` or a `BaFeature`
  * @readonly
  * @enum {string}
  */

--- a/src/domain/styles.js
+++ b/src/domain/styles.js
@@ -10,3 +10,12 @@ export const StyleSize = Object.freeze({
 	MEDIUM: 'medium',
 	LARGE: 'large'
 });
+
+/**
+ * StyleHint e.g. of a `VectorGeoResource` a `RtVectorGeoResource` or a `Feature`
+ * @readonly
+ * @enum {string}
+ */
+export const StyleHint = Object.freeze({
+	HIGHLIGHT: 'highlight'
+});

--- a/src/modules/featureInfo/components/collection/FeatureCollectionPanel.js
+++ b/src/modules/featureInfo/components/collection/FeatureCollectionPanel.js
@@ -13,7 +13,7 @@ import { FEATURE_COLLECTION_GEORESOURCE_ID } from '../../../../plugins/FeatureCo
 
 /**
  * @typedef {Object} FeatureCollectionPanelConfig
- * @property {Feature} feature The feature
+ * @property {BaFeature} feature The feature
  * @property {string|null} geoResourceId The id of the corresponding GeoResource of the feature of `null`
  */
 

--- a/src/modules/featureInfo/components/featureInfoIframePanel/FeatureInfoIframePanel.js
+++ b/src/modules/featureInfo/components/featureInfoIframePanel/FeatureInfoIframePanel.js
@@ -11,7 +11,6 @@ import { addHighlightFeatures, removeHighlightFeaturesById } from '../../../../s
 import { createUniqueId } from '../../../../utils/numberUtils';
 import { isTemplateResult } from '../../../../utils/checks';
 import { MvuElement } from '../../../MvuElement';
-import { Geometry } from '../../../../domain/geometry';
 import { HighlightFeatureType } from '../../../../domain/highlightFeature';
 
 const Update_FeatureInfo_Data = 'update_featureInfo_data';

--- a/src/modules/featureInfo/components/featureInfoIframePanel/FeatureInfoIframePanel.js
+++ b/src/modules/featureInfo/components/featureInfoIframePanel/FeatureInfoIframePanel.js
@@ -67,7 +67,7 @@ export class FeatureInfoIframePanel extends MvuElement {
 				addHighlightFeatures({
 					id: TEMPORARY_FEATURE_HIGHLIGHT_ID,
 					type: HighlightFeatureType.MARKER_TMP,
-					data: new Geometry(featureInfoGeometry.data, featureInfoGeometry.sourceType)
+					data: featureInfoGeometry
 				});
 			}
 		};

--- a/src/modules/featureInfo/components/featureInfoPanel/FeatureInfoPanel.js
+++ b/src/modules/featureInfo/components/featureInfoPanel/FeatureInfoPanel.js
@@ -13,7 +13,7 @@ import printerIcon from '../assets/printer.svg';
 import { addHighlightFeatures, removeHighlightFeaturesById } from '../../../../store/highlight/highlight.action';
 import { createUniqueId } from '../../../../utils/numberUtils';
 import { isTemplateResult } from '../../../../utils/checks';
-import { Geometry } from '../../../../domain/geometry';
+import { BaGeometry } from '../../../../domain/geometry';
 import { HighlightFeatureType } from '../../../../domain/highlightFeature';
 
 const Update_FeatureInfo_Data = 'update_featureInfo_data';
@@ -85,7 +85,7 @@ export class FeatureInfoPanel extends AbstractMvuContentPanel {
 				addHighlightFeatures({
 					id: TEMPORARY_FEATURE_HIGHLIGHT_ID,
 					type: HighlightFeatureType.DEFAULT_TMP,
-					data: new Geometry(featureInfoGeometry.data, featureInfoGeometry.sourceType)
+					data: new BaGeometry(featureInfoGeometry.data, featureInfoGeometry.sourceType)
 				});
 			}
 		};

--- a/src/modules/olMap/components/BaOverlay.js
+++ b/src/modules/olMap/components/BaOverlay.js
@@ -34,7 +34,7 @@ const Default_Placement = { sector: 'init', positioning: 'top-center', offset: [
  *
  * @class
  * @property {string| null} [value] The numeric value.
- * @property {Geometry} geometry The ol geometry which relates to this overlay.
+ * @property {ol.Geometry} geometry The ol geometry which relates to this overlay.
  * @property {boolean} static Defines, whether the overlay is static or not.
  * @property {boolean} isDraggable Defines, whether the overlay is draggable or not.
  * @property {BaOverlayTypes} type='text' Defines the display properties of the overlay.

--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -7,7 +7,7 @@ import { $injector } from '../../../../injection';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { KML } from 'ol/format';
-import { Geometry } from '../../../../domain/geometry';
+import { BaGeometry } from '../../../../domain/geometry';
 import { BaFeature } from '../../../../domain/feature';
 import { SourceType, SourceTypeName } from '../../../../domain/sourceType';
 
@@ -38,7 +38,7 @@ export const bvvFeatureInfoProvider = (olFeature, layerProperties) => {
 			<div class='chips__container'>
 				<ba-profile-chip .coordinates=${elevationProfileCoordinates}></ba-profile-chip>
 				<ba-export-vector-data-chip .exportData=${exportDataAsKML}></ba-export-vector-data-chip>
-				<ba-feature-info-collection-panel .configuration=${{ feature: new BaFeature(new Geometry(exportDataAsKML, SourceType.forKml()), olFeature.getId()), geoResourceId: geoRes?.id ?? null }}></ba-feature-info-collection-panel>
+				<ba-feature-info-collection-panel .configuration=${{ feature: new BaFeature(new BaGeometry(exportDataAsKML, SourceType.forKml()), olFeature.getId()), geoResourceId: geoRes?.id ?? null }}></ba-feature-info-collection-panel>
 			</div>`;
 
 		return descContent
@@ -54,6 +54,6 @@ export const bvvFeatureInfoProvider = (olFeature, layerProperties) => {
 			: `${geoRes.label}`
 		: `${securityService.sanitizeHtml(olFeature.get('name') ?? '')}`;
 	const content = getContent();
-	const geometry = new Geometry(new GeoJSON().writeGeometry(olFeature.getGeometry()), new SourceType(SourceTypeName.GEOJSON));
+	const geometry = new BaGeometry(new GeoJSON().writeGeometry(olFeature.getGeometry()), new SourceType(SourceTypeName.GEOJSON));
 	return { title: name, content, geometry };
 };

--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { KML } from 'ol/format';
 import { Geometry } from '../../../../domain/geometry';
-import { Feature } from '../../../../domain/feature';
+import { BaFeature } from '../../../../domain/feature';
 import { SourceType, SourceTypeName } from '../../../../domain/sourceType';
 
 /**
@@ -38,7 +38,7 @@ export const bvvFeatureInfoProvider = (olFeature, layerProperties) => {
 			<div class='chips__container'>
 				<ba-profile-chip .coordinates=${elevationProfileCoordinates}></ba-profile-chip>
 				<ba-export-vector-data-chip .exportData=${exportDataAsKML}></ba-export-vector-data-chip>
-				<ba-feature-info-collection-panel .configuration=${{ feature: new Feature(new Geometry(exportDataAsKML, SourceType.forKml()), olFeature.getId()), geoResourceId: geoRes?.id ?? null }}></ba-feature-info-collection-panel>
+				<ba-feature-info-collection-panel .configuration=${{ feature: new BaFeature(new Geometry(exportDataAsKML, SourceType.forKml()), olFeature.getId()), geoResourceId: geoRes?.id ?? null }}></ba-feature-info-collection-panel>
 			</div>`;
 
 		return descContent

--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -38,7 +38,7 @@ export const bvvFeatureInfoProvider = (olFeature, layerProperties) => {
 			<div class='chips__container'>
 				<ba-profile-chip .coordinates=${elevationProfileCoordinates}></ba-profile-chip>
 				<ba-export-vector-data-chip .exportData=${exportDataAsKML}></ba-export-vector-data-chip>
-				<ba-feature-info-collection-panel .configuration=${{ feature: new Feature(new Geometry(exportDataAsKML, new SourceType(SourceTypeName.KML)), olFeature.getId()), geoResourceId: geoRes?.id ?? null }}></ba-feature-info-collection-panel>
+				<ba-feature-info-collection-panel .configuration=${{ feature: new Feature(new Geometry(exportDataAsKML, SourceType.forKml()), olFeature.getId()), geoResourceId: geoRes?.id ?? null }}></ba-feature-info-collection-panel>
 			</div>`;
 
 		return descContent

--- a/src/modules/olMap/handler/routing/routeStats.provider.js
+++ b/src/modules/olMap/handler/routing/routeStats.provider.js
@@ -343,7 +343,7 @@ const createRouteWarnings = (vehicleType, roadClassDetails, surfaceDetails, lang
 /**
  * Converts a polyline formatted geometry to a {@link ol.Geometry}
  * @param {string} polyline the polyline formatted geometry
- * @returns {Geometry} the ol geometry
+ * @returns {ol.Geometry} the ol geometry
  */
 const polylineToGeometry = (polyline) => {
 	const polylineFormat = new Polyline();

--- a/src/modules/olMap/services/RtVectorLayerService.js
+++ b/src/modules/olMap/services/RtVectorLayerService.js
@@ -133,13 +133,7 @@ export class RtVectorLayerService {
 			if (isUpdateNeeded(messageData)) {
 				this._processMessage(messageData, olVectorLayer, featureReader);
 
-				vectorLayerService.sanitizeStyles(olVectorLayer);
-				if (rtVectorGeoResource.isClustered()) {
-					vectorLayerService.applyClusterStyle(olVectorLayer);
-				} else {
-					vectorLayerService.applyStyles(olVectorLayer, olMap);
-				}
-
+				vectorLayerService.applyStyle(olVectorLayer, olMap, rtVectorGeoResource);
 				/**
 				 * We use the fit only with the first call, to leave the control over the zoom level by the user
 				 * and to help the user in the special case, that the data of the layer is outside the view, at the beginning.

--- a/src/modules/olMap/services/StyleService.js
+++ b/src/modules/olMap/services/StyleService.js
@@ -24,6 +24,8 @@ import { GeometryCollection, MultiPoint, Point } from '../../../../node_modules/
 import { Stroke, Style, Text } from '../../../../node_modules/ol/style';
 import { GEODESIC_FEATURE_PROPERTY, GeodesicGeometry } from '../ol/geodesic/geodesicGeometry';
 import { VectorSourceType } from '../../../domain/geoResources';
+import { StyleHint } from '../../../domain/styles';
+import { highlightGeometryOrCoordinateFeatureStyleFunction } from '../handler/highlight/styleUtils';
 
 /**
  * Enumeration of predefined types of style
@@ -123,11 +125,21 @@ export class StyleService {
 	}
 
 	/**
-	 * Adds a cluster style to the specified {@link ol.layer.vector.VectorLayer}.
-	 * @param {ol.layer.vector.VectorLayer} olVectorLayer the vector layer with the clustered features
+	 * Applies the style according to the given `StyleHint`
+	 * @param {StyleHint} styleHint
+	 * @param {ol.layer.Vector} olVectorLayer
+	 * @returns {ol.layer.Vector}
 	 */
-	addClusterStyle(olVectorLayer) {
-		olVectorLayer.setStyle(defaultClusterStyleFunction());
+	applyStyleHint(styleHint, olVectorLayer) {
+		switch (styleHint) {
+			case StyleHint.CLUSTER:
+				olVectorLayer.setStyle(defaultClusterStyleFunction());
+				break;
+			case StyleHint.HIGHLIGHT:
+				olVectorLayer.setStyle(highlightGeometryOrCoordinateFeatureStyleFunction());
+				break;
+		}
+		return olVectorLayer;
 	}
 
 	/**

--- a/src/modules/olMap/services/StyleService.js
+++ b/src/modules/olMap/services/StyleService.js
@@ -122,6 +122,15 @@ export class StyleService {
 				console.warn('Could not provide a style for unknown style-type');
 				break;
 		}
+
+		const styleHint = olFeature.get('styleHint');
+		if (styleHint) {
+			switch (styleHint) {
+				case StyleHint.HIGHLIGHT:
+					olFeature.setStyle(highlightGeometryOrCoordinateFeatureStyleFunction()); // TODO: move highlightGeometryOrCoordinateFeatureStyleFunction to src/modules/olMap/utils/olStyleUtils.js
+					break;
+			}
+		}
 	}
 
 	/**
@@ -136,7 +145,7 @@ export class StyleService {
 				olVectorLayer.setStyle(defaultClusterStyleFunction());
 				break;
 			case StyleHint.HIGHLIGHT:
-				olVectorLayer.setStyle(highlightGeometryOrCoordinateFeatureStyleFunction());
+				olVectorLayer.setStyle(highlightGeometryOrCoordinateFeatureStyleFunction()); // TODO: move highlightGeometryOrCoordinateFeatureStyleFunction to src/modules/olMap/utils/olStyleUtils.js
 				break;
 		}
 		return olVectorLayer;

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -1,7 +1,7 @@
 /**
  * @module modules/olMap/services/VectorLayerService
  */
-import { VectorSourceType } from '../../../domain/geoResources';
+import { VectorSourceType, VTGeoResource } from '../../../domain/geoResources';
 import VectorSource from 'ol/source/Vector';
 import { $injector } from '../../../injection';
 import { KML, GPX, GeoJSON, WKT } from 'ol/format';
@@ -171,7 +171,7 @@ export class VectorLayerService {
 	/**
 	 * Builds an ol VectorLayer from an VectorGeoResource
 	 * @param {string} id layerId
-	 * @param {VectorGeoResource} vectorGeoResource
+	 * @param {VectorGeoResource|VTGeoResource} vectorGeoResource
 	 * @param {OlMap} olMap
 	 * @throws UnavailableGeoResourceError
 	 * @returns olVectorLayer

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -148,12 +148,12 @@ export class VectorLayerService {
 
 	/**
 	 * If needed adds specific stylings (and overlays) for a vector layer
-	 * @param {VectorGeoResource|RtVectorGeoResource} vectorGeoResource
 	 * @param {ol.layer.Vector} olVectorLayer
 	 * @param {ol.Map} olMap
+	 * @param {VectorGeoResource|RtVectorGeoResource} vectorGeoResource
 	 * @returns {ol.layer.Vector}
 	 */
-	applyStyle(vectorGeoResource, olVectorLayer, olMap) {
+	applyStyle(olVectorLayer, olMap, vectorGeoResource) {
 		const { StyleService: styleService } = $injector.inject('StyleService');
 		this._sanitizeStyles(olVectorLayer);
 		if (vectorGeoResource.isClustered()) {
@@ -184,7 +184,7 @@ export class VectorLayerService {
 		const vectorSource = this._vectorSourceForData(vectorGeoResource);
 		vectorLayer.setSource(vectorSource);
 
-		return this.applyStyle(vectorGeoResource, vectorLayer, olMap);
+		return this.applyStyle(vectorLayer, olMap, vectorGeoResource);
 	}
 
 	/**

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -147,7 +147,11 @@ export class VectorLayerService {
 	}
 
 	/**
-	 * If needed adds specific stylings (and overlays) for a vector layer
+	 * Adds specific stylings (and overlays) for a vector layer.
+	 * The effective styling is determined in the following order;
+	 * 1. If the GeoResource is clustered we set the cluster style
+	 * 2. If the GeoResource has a style hint we set its corresponding style
+	 * 3. Otherwise we take the style information of the features
 	 * @param {ol.layer.Vector} olVectorLayer
 	 * @param {ol.Map} olMap
 	 * @param {VectorGeoResource|RtVectorGeoResource} vectorGeoResource

--- a/src/modules/olMap/utils/olGeometryUtils.js
+++ b/src/modules/olMap/utils/olGeometryUtils.js
@@ -23,8 +23,8 @@ export const AZIMUTH_GEOMETRY_PROPERTY = 'azimuth';
  * Coerce the provided geometry to a LineString or null,
  * if the geometry is not a LineString,LinearRing or Polygon
  * @function
- * @param {Geometry} geometry the geometry to coerce to LineString
- * @returns {Geometry | null} the coerced LineString or null
+ * @param {ol.Geometry geometry the geometry to coerce to LineString
+ * @returns {ol.Geometry | null} the coerced LineString or null
  */
 export const getLineString = (geometry) => {
 	if (geometry instanceof LineString) {
@@ -48,7 +48,7 @@ export const getLineString = (geometry) => {
  *
  * @function
  * @param {MultiLineString} multiLineString
- * @returns {Geometry | null} the coerced LineString or null
+ * @returns {ol.Geometry | null} the coerced LineString or null
  */
 export const multiLineStringToLineString = (multiLineString) => {
 	if (!(multiLineString instanceof MultiLineString)) {
@@ -82,7 +82,7 @@ export const multiLineStringToLineString = (multiLineString) => {
  * Creates a polygon from an extent
  * @function
  * @param {Extent} extent the extent, which should be converted to a Polygon
- * @returns {Geometry|null} the polygon representing the extent or `null`
+ * @returns {ol.Geometry|null} the polygon representing the extent or `null`
  */
 export const getPolygonFrom = (extent) => {
 	if (!Array.isArray(extent) || extent.length !== 4) {
@@ -131,7 +131,7 @@ export const getBoundingBoxFrom = (centerCoordinate, size) => {
  * Return the coordinate at the provided fraction along the linear geometry or along the boundary of a area-like geometry.
  * The fraction is a number between 0 and 1, where 0 is the start (first coordinate) of the geometry and 1 is the end (last coordinate). *
  * @function
- * @param {Geometry} geometry
+ * @param {ol.Geometry geometry
  * @param {number} fraction
  * @returns {Array.<number>} the calculated coordinate or null if the geometry is not linear or area-like
  */
@@ -147,7 +147,7 @@ export const getCoordinateAt = (geometry, fraction) => {
 /**
  * Determines whether or not the geometry has the property of a azimuth-angle
  * @function
- * @param {Geometry} geometry the geometry
+ * @param {ol.Geometry geometry the geometry
  * @returns {boolean}
  */
 export const canShowAzimuthCircle = (geometry) => {
@@ -168,7 +168,7 @@ export const canShowAzimuthCircle = (geometry) => {
 /**
  * Calculates the azimuth-angle between the start(first coordinate) and end(last coordinate) of the geometry
  * @function
- * @param {Geometry} geometry
+ * @param {ol.Geometry geometry
  * @returns {number} the azimuth-angle as degree of arc with a value between 0 and 360
  */
 export const getAzimuth = (geometry) => {
@@ -259,7 +259,7 @@ export const getPartitionDelta = (geometryLength, resolution = 1) => {
 /**
  * Tests whether the vertex candidate is part of the geometry vertices
  * @function
- * @param {Geometry} geometry the geometry
+ * @param {ol.Geometry geometry the geometry
  * @param {Point} vertexCandidate the candidate point to test against the geometry. If candidate is other than
  * `Point`, it returns immediately false
  * @returns {boolean}
@@ -315,7 +315,7 @@ export const polarStakeOut = (fromCoordinate, angle, distance) => {
 /**
  * Calculates the residuals that occurs when the partitions are distributed over the individual segments of the geometry
  * @function
- * @param {Geometry} geometry the source geometry
+ * @param {ol.Geometry geometry the source geometry
  * @param {number} partitionDelta the delta-value of the partition
  * @returns {Array<number>} the residuals for all segments of the geometry
  */
@@ -339,7 +339,7 @@ export const calculatePartitionResidualOfSegments = (geometry, partitionDelta) =
 /**
  * Checks whether or not the geometry is valid for mapping purposes
  * @function
- * @param {Geometry|null} geometry the geometry supported GeometryTypes are Point, LineString, Polygon
+ * @param {ol.Geometry|null} geometry the geometry supported GeometryTypes are Point, LineString, Polygon
  * @returns {boolean}
  */
 export const isValidGeometry = (geometry) => {
@@ -363,7 +363,7 @@ export const isValidGeometry = (geometry) => {
 
 /**
  * @function
- * @param {Geometry} geometry ol geometry
+ * @param {ol.Geometry geometry ol geometry
  * @returns {module:domain/geometryStatisticTypeDef~GeometryStatistic}
  */
 export const getStats = (geometry) => {
@@ -423,10 +423,10 @@ export const PROFILE_GEOMETRY_SIMPLIFY_MAX_COUNT_COORDINATES = 1000;
  * For LineStrings it uses the Douglas-Peucker algorithm.
  * For Polygons, a quantization-based simplification is used to preserve topology.
  * @function
- * @param {Geometry} geometry ol geometry
+ * @param {ol.Geometry} geometry ol geometry
  * @param {number} maxCount max. count of coordinates on which the geometry won't be simplified
  * @param {number} tolerance the tolerance distance for simplification (in map units)
- * @returns {Geometry} A new, simplified version of the original geometry
+ * @returns {ol.Geometry} A new, simplified version of the original geometry
  */
 export const simplify = (geometry, maxCount, tolerance) => {
 	if (geometry instanceof Geometry && maxCount && tolerance && geometry?.getCoordinates().length > maxCount) {
@@ -438,7 +438,7 @@ export const simplify = (geometry, maxCount, tolerance) => {
 /**
  * Returns an array of coordinates suitable for calculating an elevation profile.
  * @function
- * @param {Geometry} geometry ol geometry
+ * @param {ol.Geometry} geometry ol geometry
  * @returns {Array<module:domain/coordinateTypeDef~Coordinate>} the coordinates
  */
 export const getCoordinatesForElevationProfile = (geometry) => {

--- a/src/modules/olMap/utils/olStyleUtils.js
+++ b/src/modules/olMap/utils/olStyleUtils.js
@@ -141,7 +141,7 @@ export const nullStyleFunction = () => [new Style({})];
  * If no or incomplete styling-information found on the feature, default values will be used.
  *
  * 'marker-symbol'-property is currently not supported
- * @param {Feature} feature the olFeature to be styled
+ * @param {ol.Feature} feature the olFeature to be styled
  * @returns {Array<Style>}
  */
 export const geojsonStyleFunction = (feature) => {
@@ -585,7 +585,7 @@ export const renderGeodesicRulerSegments = (pixelCoordinates, state, contextRend
  * StyleFunction for measurement-feature
  *
  * Inspired by example from https://stackoverflow.com/questions/57421223/openlayers-3-offset-stroke-style
- * @param {Feature} feature the feature to be styled
+ * @param {ol.Feature} feature the feature to be styled
  * @param {number} resolution the resolution of the Map-View
  * @returns {Array<Style>} the measurement styles for the specified feature
  */
@@ -837,7 +837,7 @@ export const getIconUrl = (iconId, color = [255, 255, 255]) => {
 
 /**
  * extracts the color-value (as hex representation) or null from a feature
- * @param {Feature} feature the feature with or without a style
+ * @param {ol.Feature} feature the feature with or without a style
  * @returns {string|null} the color-value
  */
 export const getColorFrom = (feature) => {
@@ -876,7 +876,7 @@ export const getColorFrom = (feature) => {
 
 /**
  * extracts the symbolSrc-value or null from a feature
- * @param {Feature} feature the feature with or without a style
+ * @param {ol.Feature} feature the feature with or without a style
  * @returns {string|null} the symbolSrc-Value or null
  */
 export const getSymbolFrom = (feature) => {
@@ -898,7 +898,7 @@ export const getSymbolFrom = (feature) => {
 
 /**
  * extracts the symbolSrc-value or null from a feature
- * @param {Feature} feature the feature with or without a style
+ * @param {ol.Feature} feature the feature with or without a style
  * @returns {string|null} the symbolSrc-Value or null
  */
 export const getTextFrom = (feature) => {
@@ -921,7 +921,7 @@ export const getTextFrom = (feature) => {
 /**
  * Extracts from the specified feature the size-value if the
  * StyleType is Marker/Text or null for all other StyleTypes.
- * @param {Feature} feature the feature with or without a style
+ * @param {ol.Feature} feature the feature with or without a style
  * @returns {module:domain/styles~StyleSize|null} the Size-Value or null
  */
 export const getSizeFrom = (feature) => {
@@ -951,7 +951,7 @@ export const getSizeFrom = (feature) => {
  * Returns the drawingtype of a feature. If the featue is created with the application itself,
  * the drawingType is part of the featureId and follows the convention id(feature)-> [measure|draw]_[drawingType]_[creationTime]
  * if the feature is not created with this application and the id follows not the before mentioned convention, NULL is returning.
- * @param {Feature} feature the feature
+ * @param {ol.Feature} feature the feature
  * @returns {string|null}
  */
 export const getDrawingTypeFrom = (feature) => {

--- a/src/modules/search/services/domain/searchResult.js
+++ b/src/modules/search/services/domain/searchResult.js
@@ -110,7 +110,7 @@ export class CadastralParcelSearchResult extends SearchResult {
 	 * @param {string} labelFormatted  the label (html formatted)
 	 * @param {module:domain/coordinateTypeDef~Coordinate} center
 	 * @param {module:domain/extentTypeDef~Extent} extent
-	 * @param {Geometry} geometry
+	 * @param {BaGeometry} geometry
 	 */
 	constructor(label, labelFormatted, center = null, extent = null, geometry = null) {
 		super(label, labelFormatted);

--- a/src/modules/search/services/provider/searchResult.provider.js
+++ b/src/modules/search/services/provider/searchResult.provider.js
@@ -5,7 +5,7 @@ import { CadastralParcelSearchResult, GeoResourceSearchResult, LocationSearchRes
 import { $injector } from '../../../../injection';
 import { MediaType } from '../../../../domain/mediaTypes';
 import { SourceType, SourceTypeName } from '../../../../domain/sourceType';
-import { Geometry } from '../../../../domain/geometry';
+import { BaGeometry } from '../../../../domain/geometry';
 
 /**
  *A async function that returns a promise with an array of SearchResults with type LOCATION.
@@ -78,7 +78,7 @@ export const loadBvvCadastralParcelSearchResults = async (query) => {
 				o.attrs.label,
 				o.attrs.coordinate,
 				o.attrs.extent ? o.attrs.extent : null,
-				o.attrs.ewkt ? new Geometry(o.attrs.ewkt, new SourceType(SourceTypeName.EWKT, null, 3857)) : null
+				o.attrs.ewkt ? new BaGeometry(o.attrs.ewkt, new SourceType(SourceTypeName.EWKT, null, 3857)) : null
 			);
 		});
 		return data;

--- a/src/modules/search/services/provider/searchResult.provider.js
+++ b/src/modules/search/services/provider/searchResult.provider.js
@@ -78,7 +78,7 @@ export const loadBvvCadastralParcelSearchResults = async (query) => {
 				o.attrs.label,
 				o.attrs.coordinate,
 				o.attrs.extent ? o.attrs.extent : null,
-				o.attrs.ewkt ? new Geometry(o.attrs.ewkt, new SourceType(SourceTypeName.EWKT)) : null
+				o.attrs.ewkt ? new Geometry(o.attrs.ewkt, new SourceType(SourceTypeName.EWKT, null, 3857)) : null
 			);
 		});
 		return data;

--- a/src/plugins/FeatureCollectionPlugin.js
+++ b/src/plugins/FeatureCollectionPlugin.js
@@ -7,6 +7,7 @@ import { BaPlugin } from './BaPlugin';
 import { $injector } from '../injection/index';
 import { AggregateGeoResource } from '../domain/geoResources';
 import { clearFeatures } from '../store/featureCollection/featureCollection.action';
+import { StyleHint } from '../domain/styles';
 /**
  * Id of the layer used for the visualization of a feature collection
  */
@@ -54,6 +55,7 @@ export class FeatureCollectionPlugin extends BaPlugin {
 				const geoResourceIds = entries.map((feature) => {
 					const geoResourceId = feature.id;
 					this.#importVectorDataService.forData(feature.geometry.data, { id: geoResourceId }, true);
+					this.#geoResourceService.byId(geoResourceId).setStyleHint(StyleHint.HIGHLIGHT);
 					return geoResourceId;
 				});
 

--- a/src/plugins/FeatureCollectionPlugin.js
+++ b/src/plugins/FeatureCollectionPlugin.js
@@ -5,9 +5,8 @@ import { observe } from '../utils/storeUtils';
 import { addLayer, removeLayer } from '../store/layers/layers.action';
 import { BaPlugin } from './BaPlugin';
 import { $injector } from '../injection/index';
-import { AggregateGeoResource } from '../domain/geoResources';
+import { VectorGeoResource } from '../domain/geoResources';
 import { clearFeatures } from '../store/featureCollection/featureCollection.action';
-import { StyleHint } from '../domain/styles';
 /**
  * Id of the layer used for the visualization of a feature collection
  */
@@ -23,18 +22,12 @@ export const FEATURE_COLLECTION_GEORESOURCE_ID = 'feature_collection';
  */
 export class FeatureCollectionPlugin extends BaPlugin {
 	#geoResourceService;
-	#importVectorDataService;
 	#translationService;
 	constructor() {
 		super();
-		const {
-			GeoResourceService: geoResourceService,
-			ImportVectorDataService,
-			TranslationService
-		} = $injector.inject('GeoResourceService', 'ImportVectorDataService', 'TranslationService');
+		const { GeoResourceService: geoResourceService, TranslationService } = $injector.inject('GeoResourceService', 'TranslationService');
 
 		this.#geoResourceService = geoResourceService;
-		this.#importVectorDataService = ImportVectorDataService;
 		this.#translationService = TranslationService;
 	}
 	/**
@@ -46,23 +39,16 @@ export class FeatureCollectionPlugin extends BaPlugin {
 		let ignoreLayerRemoval = false;
 		const onEntriesChanged = (entries) => {
 			/**
-			 * Currently an (aggregated) ol Layer (LayerGroup) won't be update when the backing GeoResource changed.
+			 * Currently an ol Layer won't be update when the backing GeoResource changed.
 			 * Therefore we update the map by removing and re-adding the layer,
 			 */
 			ignoreLayerRemoval = true;
 			removeLayer(FEATURE_COLLECTION_LAYER_ID);
 			if (entries.length > 0) {
-				const geoResourceIds = entries.map((feature) => {
-					const geoResourceId = feature.id;
-					this.#importVectorDataService.forData(feature.geometry.data, { id: geoResourceId }, true);
-					this.#geoResourceService.byId(geoResourceId).setStyleHint(StyleHint.HIGHLIGHT);
-					return geoResourceId;
-				});
-
 				this.#geoResourceService.addOrReplace(
-					new AggregateGeoResource(FEATURE_COLLECTION_GEORESOURCE_ID, `${translate('global_featureCollection_layer_label')} (${entries.length})`, [
-						...geoResourceIds
-					]).setHidden(true)
+					new VectorGeoResource(FEATURE_COLLECTION_GEORESOURCE_ID, `${translate('global_featureCollection_layer_label')} (${entries.length})`)
+						.setFeatures(entries)
+						.setHidden(true)
 				);
 				addLayer(FEATURE_COLLECTION_LAYER_ID, { geoResourceId: FEATURE_COLLECTION_GEORESOURCE_ID });
 			}

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -10,8 +10,6 @@ import { createUniqueId } from '../utils/numberUtils';
 import { $injector } from '../injection/index';
 import { QueryParameters } from '../domain/queryParameters';
 import { isCoordinate } from '../utils/checks';
-import { Geometry } from '../domain/geometry';
-import { SourceType, SourceTypeName } from '../domain/sourceType';
 import { HighlightFeatureType } from '../domain/highlightFeature';
 
 /**

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -119,7 +119,7 @@ export class HighlightPlugin extends BaPlugin {
 					.map((featureInfo) => ({
 						id: QUERY_SUCCESS_WITH_GEOMETRY_HIGHLIGHT_FEATURE_ID,
 						type: HighlightFeatureType.DEFAULT,
-						data: new Geometry(featureInfo.geometry.data, new SourceType(SourceTypeName.GEOJSON))
+						data: featureInfo.geometry
 					}));
 				addHighlightFeatures(highlightFeatures);
 			}

--- a/src/services/SourceTypeService.js
+++ b/src/services/SourceTypeService.js
@@ -1,7 +1,7 @@
 /**
  * @module services/SourceTypeService
  */
-import { Geometry } from '../domain/geometry';
+import { BaGeometry } from '../domain/geometry';
 import { SourceTypeResultStatus } from '../domain/sourceType';
 import { isHttpUrl, isString } from '../utils/checks';
 import { PromiseQueue } from '../utils/PromiseQueue';
@@ -83,12 +83,12 @@ export class SourceTypeService {
 	 * Creates a geometry by detecting the `SourceType` of the given data.
 	 * Returns `null` if the source type cannot be detected.
 	 * @param {String|object} data The data of this geometry (Note: type `object` is only allowed in case of sourceType == `SourceType.GeoJSON`)
-	 * @returns  {Geometry|null}
+	 * @returns  {BaGeometry|null}
 	 */
 	toGeometry(data) {
 		const result = this.forData(data);
 		if (result.status === SourceTypeResultStatus.OK) {
-			return new Geometry(data, result.sourceType);
+			return new BaGeometry(data, result.sourceType);
 		}
 		return null;
 	}

--- a/src/services/SourceTypeService.js
+++ b/src/services/SourceTypeService.js
@@ -82,7 +82,7 @@ export class SourceTypeService {
 	/**
 	 * Creates a geometry by detecting the `SourceType` of the given data.
 	 * Returns `null` if the source type cannot be detected.
-	 * @param {String|object} data The data of this geometry (Note type `object' is only allowed in case of sourceType GeoJSON)
+	 * @param {String|object} data The data of this geometry (Note: type `object` is only allowed in case of sourceType == `SourceType.GeoJSON`)
 	 * @returns  {Geometry|null}
 	 */
 	toGeometry(data) {

--- a/src/services/provider/featureInfo.provider.js
+++ b/src/services/provider/featureInfo.provider.js
@@ -5,7 +5,7 @@ import { $injector } from '../../injection';
 import { GeoResourceAuthenticationType, WmsGeoResource } from '../../domain/geoResources';
 import { MediaType } from '../../domain/mediaTypes';
 import { isHttpUrl } from '../../utils/checks';
-import { Geometry } from '../../domain/geometry';
+import { BaGeometry } from '../../domain/geometry';
 import { SourceType } from '../../domain/sourceType';
 
 const throwError = (geoResourceId, reason) => {
@@ -97,7 +97,7 @@ const loadTimeTravelFeatureInfo = async (geoResource, coordinate3857, timestamp)
 	switch (result.status) {
 		case 200: {
 			const { title, content, geometry: geoJson } = await result.json();
-			const geometry = geoJson ? new Geometry(geoJson, SourceType.forGeoJSON()) : null;
+			const geometry = geoJson ? new BaGeometry(geoJson, SourceType.forGeoJSON()) : null;
 			return { content, title, geometry };
 		}
 		case 204: {

--- a/src/services/provider/featureInfo.provider.js
+++ b/src/services/provider/featureInfo.provider.js
@@ -6,7 +6,7 @@ import { GeoResourceAuthenticationType, WmsGeoResource } from '../../domain/geoR
 import { MediaType } from '../../domain/mediaTypes';
 import { isHttpUrl } from '../../utils/checks';
 import { Geometry } from '../../domain/geometry';
-import { SourceType, SourceTypeName } from '../../domain/sourceType';
+import { SourceType } from '../../domain/sourceType';
 
 const throwError = (geoResourceId, reason) => {
 	throw new Error(`FeatureInfoResult for '${geoResourceId}' could not be loaded: ${reason}`);

--- a/src/services/provider/featureInfo.provider.js
+++ b/src/services/provider/featureInfo.provider.js
@@ -97,7 +97,7 @@ const loadTimeTravelFeatureInfo = async (geoResource, coordinate3857, timestamp)
 	switch (result.status) {
 		case 200: {
 			const { title, content, geometry: geoJson } = await result.json();
-			const geometry = geoJson ? new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)) : null;
+			const geometry = geoJson ? new Geometry(geoJson, SourceType.forGeoJSON()) : null;
 			return { content, title, geometry };
 		}
 		case 204: {

--- a/src/store/featureCollection/featureCollection.action.js
+++ b/src/store/featureCollection/featureCollection.action.js
@@ -10,8 +10,8 @@ const getStore = () => {
 };
 
 /**
- * Adds (appends) a single or an array of {@link Feature}.
- * @param {Array.<Feature>|Feature} features
+ * Adds (appends) a single or an array of {@link BaFeature}.
+ * @param {Array.<BaFeature>|BaFeature} features
  * @function
  */
 export const addFeatures = (features) => {
@@ -23,7 +23,7 @@ export const addFeatures = (features) => {
 };
 
 /**
- * Removes all {@link Feature}s.
+ * Removes all {@link BaFeature}s.
  * @function
  */
 export const clearFeatures = () => {

--- a/test/domain/feature.test.js
+++ b/test/domain/feature.test.js
@@ -1,12 +1,12 @@
 import { Geometry } from '../../src/domain/geometry';
-import { Feature } from '../../src/domain/feature';
+import { BaFeature } from '../../src/domain/feature';
 import { StyleHint } from '../../src/domain/styles';
 import { SourceType, SourceTypeName } from '../../src/domain/sourceType';
 
 describe('Feature', () => {
 	it('provides a constructor and getters for properties', () => {
 		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
-		const feature = new Feature(geometry, 'id');
+		const feature = new BaFeature(geometry, 'id');
 
 		expect(feature.geometry).toEqual(geometry);
 		expect(feature.id).toBe('id');
@@ -14,13 +14,13 @@ describe('Feature', () => {
 	});
 
 	it('check the constructors arguments', () => {
-		expect(() => new Feature('data')).toThrowError('<geometry> must be a Geometry');
-		expect(() => new Feature(new Geometry('data', new SourceType(SourceTypeName.GPX)))).toThrowError('<id> must be a String');
+		expect(() => new BaFeature('data')).toThrowError('<geometry> must be a Geometry');
+		expect(() => new BaFeature(new Geometry('data', new SourceType(SourceTypeName.GPX)))).toThrowError('<id> must be a String');
 	});
 
 	it('provides set, get and remove methods for properties', () => {
 		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
-		const feature = new Feature(geometry, 'id');
+		const feature = new BaFeature(geometry, 'id');
 
 		expect(feature.getProperties()).toEqual({});
 
@@ -37,7 +37,7 @@ describe('Feature', () => {
 
 	it('provides set, get and check methods for a StyleHint', () => {
 		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
-		const feature = new Feature(geometry, 'id');
+		const feature = new BaFeature(geometry, 'id');
 
 		expect(feature.hasStyleHint()).toBeFalse();
 

--- a/test/domain/feature.test.js
+++ b/test/domain/feature.test.js
@@ -1,5 +1,6 @@
 import { Geometry } from '../../src/domain/geometry';
 import { Feature } from '../../src/domain/feature';
+import { StyleHint } from '../../src/domain/styles';
 import { SourceType, SourceTypeName } from '../../src/domain/sourceType';
 
 describe('Feature', () => {
@@ -9,6 +10,7 @@ describe('Feature', () => {
 
 		expect(feature.geometry).toEqual(geometry);
 		expect(feature.id).toBe('id');
+		expect(feature.styleHint).toBeNull();
 	});
 
 	it('check the constructors arguments', () => {
@@ -20,6 +22,8 @@ describe('Feature', () => {
 		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
 		const feature = new Feature(geometry, 'id');
 
+		expect(feature.getProperties()).toEqual({});
+
 		feature.set('foo', 'bar').set('foo', 'bar1').set(123, 123);
 
 		expect(feature.get('foo')).toBe('bar1');
@@ -29,5 +33,21 @@ describe('Feature', () => {
 
 		feature.remove('foo').remove(123);
 		expect(feature.getProperties()).toEqual({});
+	});
+
+	it('provides set, get and check methods for a StyleHint', () => {
+		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
+		const feature = new Feature(geometry, 'id');
+
+		expect(feature.hasStyleHint()).toBeFalse();
+
+		feature.setStyleHint(null);
+
+		expect(feature.hasStyleHint()).toBeFalse();
+
+		feature.setStyleHint(StyleHint.HIGHLIGHT);
+
+		expect(feature.hasStyleHint()).toBeTrue();
+		expect(feature.styleHint).toBe(StyleHint.HIGHLIGHT);
 	});
 });

--- a/test/domain/feature.test.js
+++ b/test/domain/feature.test.js
@@ -1,11 +1,11 @@
-import { Geometry } from '../../src/domain/geometry';
+import { BaGeometry } from '../../src/domain/geometry';
 import { BaFeature } from '../../src/domain/feature';
 import { StyleHint } from '../../src/domain/styles';
 import { SourceType, SourceTypeName } from '../../src/domain/sourceType';
 
 describe('Feature', () => {
 	it('provides a constructor and getters for properties', () => {
-		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
+		const geometry = new BaGeometry('data', new SourceType(SourceTypeName.EWKT));
 		const feature = new BaFeature(geometry, 'id');
 
 		expect(feature.geometry).toEqual(geometry);
@@ -15,11 +15,11 @@ describe('Feature', () => {
 
 	it('check the constructors arguments', () => {
 		expect(() => new BaFeature('data')).toThrowError('<geometry> must be a Geometry');
-		expect(() => new BaFeature(new Geometry('data', new SourceType(SourceTypeName.GPX)))).toThrowError('<id> must be a String');
+		expect(() => new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.GPX)))).toThrowError('<id> must be a String');
 	});
 
 	it('provides set, get and remove methods for properties', () => {
-		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
+		const geometry = new BaGeometry('data', new SourceType(SourceTypeName.EWKT));
 		const feature = new BaFeature(geometry, 'id');
 
 		expect(feature.getProperties()).toEqual({});
@@ -36,7 +36,7 @@ describe('Feature', () => {
 	});
 
 	it('provides set, get and check methods for a StyleHint', () => {
-		const geometry = new Geometry('data', new SourceType(SourceTypeName.EWKT));
+		const geometry = new BaGeometry('data', new SourceType(SourceTypeName.EWKT));
 		const feature = new BaFeature(geometry, 'id');
 
 		expect(feature.hasStyleHint()).toBeFalse();

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -17,6 +17,9 @@ import { $injector } from '../../src/injection';
 import { getDefaultAttribution, getMinimalAttribution } from '../../src/services/provider/attribution.provider';
 import { TestUtils } from '../test-utils';
 import { StyleHint } from '../../src/domain/styles';
+import { Feature } from '../../src/domain/feature';
+import { Geometry } from '../../src/domain/geometry';
+import { SourceType } from '../../src/domain/sourceType';
 
 describe('GeoResource', () => {
 	const geoResourceServiceMock = {
@@ -465,6 +468,7 @@ describe('GeoResource', () => {
 			expect(vectorGeoResource.srid).toBeNull();
 			expect(vectorGeoResource.sourceType).toEqual(VectorSourceType.KML);
 			expect(vectorGeoResource.data).toBeNull();
+			expect(vectorGeoResource.features).toEqual([]);
 		});
 
 		it('provides default properties', () => {
@@ -492,6 +496,14 @@ describe('GeoResource', () => {
 			expect(vectorGeoResource.srid).toBe(1234);
 		});
 
+		it('sets the source of an internal VectorGeoResource by an array o features', () => {
+			const feat0 = new Feature(new Geometry('data', SourceType.forGpx()), 'id0');
+			const feat1 = new Feature(new Geometry('data', SourceType.forGpx()), 'id1');
+			const vectorGeoResource = new VectorGeoResource('id', 'label', VectorSourceType.KML).setFeatures([feat0]).addFeature(feat1);
+
+			expect(vectorGeoResource.features).toEqual([feat0, feat1]);
+		});
+
 		describe('methods', () => {
 			it('sets the source of an internal VectorGeoResource by a string', () => {
 				const vectorGeoResource = new VectorGeoResource('id', 'label', VectorSourceType.KML).setSource('someData', 1234);
@@ -514,6 +526,12 @@ describe('GeoResource', () => {
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).isClustered()).toBeFalse();
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams(null).isClustered()).toBeFalse();
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams({ foo: 'bar' }).isClustered()).toBeTrue();
+			});
+
+			it('provides a check for containing features', () => {
+				const feat0 = new Feature(new Geometry('data', SourceType.forGpx()), 'id0');
+				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).hasFeatures()).toBeFalse();
+				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).addFeature(feat0).hasFeatures()).toBeTrue();
 			});
 
 			it('provides a check for containing a non-default value as styleHint', () => {

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -17,7 +17,7 @@ import { $injector } from '../../src/injection';
 import { getDefaultAttribution, getMinimalAttribution } from '../../src/services/provider/attribution.provider';
 import { TestUtils } from '../test-utils';
 import { StyleHint } from '../../src/domain/styles';
-import { Feature } from '../../src/domain/feature';
+import { BaFeature } from '../../src/domain/feature';
 import { Geometry } from '../../src/domain/geometry';
 import { SourceType } from '../../src/domain/sourceType';
 
@@ -498,8 +498,8 @@ describe('GeoResource', () => {
 		});
 
 		it('sets the source of an internal VectorGeoResource by an array o features', () => {
-			const feat0 = new Feature(new Geometry('data', SourceType.forGpx()), 'id0');
-			const feat1 = new Feature(new Geometry('data', SourceType.forGpx()), 'id1');
+			const feat0 = new BaFeature(new Geometry('data', SourceType.forGpx()), 'id0');
+			const feat1 = new BaFeature(new Geometry('data', SourceType.forGpx()), 'id1');
 			const vectorGeoResource = new VectorGeoResource('id', 'label', VectorSourceType.KML).setFeatures([feat0]).addFeature(feat1);
 
 			expect(vectorGeoResource.features).toEqual([feat0, feat1]);
@@ -530,7 +530,7 @@ describe('GeoResource', () => {
 			});
 
 			it('provides a check for containing features', () => {
-				const feat0 = new Feature(new Geometry('data', SourceType.forGpx()), 'id0');
+				const feat0 = new BaFeature(new Geometry('data', SourceType.forGpx()), 'id0');
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).hasFeatures()).toBeFalse();
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).addFeature(feat0).hasFeatures()).toBeTrue();
 			});

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -18,7 +18,7 @@ import { getDefaultAttribution, getMinimalAttribution } from '../../src/services
 import { TestUtils } from '../test-utils';
 import { StyleHint } from '../../src/domain/styles';
 import { BaFeature } from '../../src/domain/feature';
-import { Geometry } from '../../src/domain/geometry';
+import { BaGeometry } from '../../src/domain/geometry';
 import { SourceType } from '../../src/domain/sourceType';
 
 describe('GeoResource', () => {
@@ -498,8 +498,8 @@ describe('GeoResource', () => {
 		});
 
 		it('sets the source of an internal VectorGeoResource by an array o features', () => {
-			const feat0 = new BaFeature(new Geometry('data', SourceType.forGpx()), 'id0');
-			const feat1 = new BaFeature(new Geometry('data', SourceType.forGpx()), 'id1');
+			const feat0 = new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id0');
+			const feat1 = new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id1');
 			const vectorGeoResource = new VectorGeoResource('id', 'label', VectorSourceType.KML).setFeatures([feat0]).addFeature(feat1);
 
 			expect(vectorGeoResource.features).toEqual([feat0, feat1]);
@@ -530,7 +530,7 @@ describe('GeoResource', () => {
 			});
 
 			it('provides a check for containing features', () => {
-				const feat0 = new BaFeature(new Geometry('data', SourceType.forGpx()), 'id0');
+				const feat0 = new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id0');
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).hasFeatures()).toBeFalse();
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).addFeature(feat0).hasFeatures()).toBeTrue();
 			});

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -497,7 +497,7 @@ describe('GeoResource', () => {
 			expect(vectorGeoResource.srid).toBe(1234);
 		});
 
-		it('sets the source of an internal VectorGeoResource by an array o features', () => {
+		it('sets the source of an internal VectorGeoResource by an array of features', () => {
 			const feat0 = new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id0');
 			const feat1 = new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id1');
 			const vectorGeoResource = new VectorGeoResource('id', 'label', VectorSourceType.KML).setFeatures([feat0]).addFeature(feat1);

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -469,6 +469,7 @@ describe('GeoResource', () => {
 			expect(vectorGeoResource.sourceType).toEqual(VectorSourceType.KML);
 			expect(vectorGeoResource.data).toBeNull();
 			expect(vectorGeoResource.features).toEqual([]);
+			expect(new VectorGeoResource('id', 'label').sourceType).toBeNull();
 		});
 
 		it('provides default properties', () => {

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -16,6 +16,7 @@ import {
 import { $injector } from '../../src/injection';
 import { getDefaultAttribution, getMinimalAttribution } from '../../src/services/provider/attribution.provider';
 import { TestUtils } from '../test-utils';
+import { StyleHint } from '../../src/domain/styles';
 
 describe('GeoResource', () => {
 	const geoResourceServiceMock = {
@@ -472,6 +473,7 @@ describe('GeoResource', () => {
 			expect(vectorGeoResource.clusterParams).toEqual({});
 			expect(vectorGeoResource.showPointNames).toBe(true);
 			expect(vectorGeoResource.localData).toBe(false);
+			expect(vectorGeoResource.styleHint).toBeNull();
 		});
 
 		it('provides the source type as fallback label', () => {
@@ -512,6 +514,12 @@ describe('GeoResource', () => {
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).isClustered()).toBeFalse();
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams(null).isClustered()).toBeFalse();
 				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams({ foo: 'bar' }).isClustered()).toBeTrue();
+			});
+
+			it('provides a check for containing a non-default value as styleHint', () => {
+				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).hasStyleHint()).toBeFalse();
+				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).setStyleHint(null).hasStyleHint()).toBeFalse();
+				expect(new VectorGeoResource('id', 'label', VectorSourceType.KML).setStyleHint(StyleHint.HIGHLIGHT).hasStyleHint()).toBeTrue();
 			});
 
 			it('provides a check for containing a non-default value as label', () => {
@@ -579,6 +587,7 @@ describe('GeoResource', () => {
 			const rtVectorGeoResource = new RtVectorGeoResource('id', 'label', VectorSourceType.KML);
 
 			expect(rtVectorGeoResource.clusterParams).toEqual({});
+			expect(rtVectorGeoResource.styleHint).toBeNull();
 		});
 
 		describe('methods', () => {
@@ -586,6 +595,12 @@ describe('GeoResource', () => {
 				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).isClustered()).toBeFalse();
 				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams(null).isClustered()).toBeFalse();
 				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).setClusterParams({ foo: 'bar' }).isClustered()).toBeTrue();
+			});
+
+			it('provides a check for containing a non-default value as styleHint', () => {
+				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).hasStyleHint()).toBeFalse();
+				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).setStyleHint(null).hasStyleHint()).toBeFalse();
+				expect(new RtVectorGeoResource('id', 'label', VectorSourceType.KML).setStyleHint(StyleHint.HIGHLIGHT).hasStyleHint()).toBeTrue();
 			});
 
 			it('sets the showPointNames property', () => {

--- a/test/domain/geometry.test.js
+++ b/test/domain/geometry.test.js
@@ -1,9 +1,9 @@
-import { Geometry } from '../../src/domain/geometry';
+import { BaGeometry } from '../../src/domain/geometry';
 import { SourceType, SourceTypeName } from '../../src/domain/sourceType';
 
 describe('Geometry', () => {
 	it('provides a constructor and getters for properties', () => {
-		const geometry = new Geometry('data', new SourceType(SourceTypeName.GPX));
+		const geometry = new BaGeometry('data', new SourceType(SourceTypeName.GPX));
 
 		expect(geometry.data).toBe('data');
 		expect(geometry.sourceType).toEqual(new SourceType(SourceTypeName.GPX));
@@ -11,15 +11,15 @@ describe('Geometry', () => {
 
 	it('provides a constructor that stringifies a GeoJSON', () => {
 		const json = { foo: 'bar' };
-		const geometry = new Geometry(json, new SourceType(SourceTypeName.GEOJSON));
+		const geometry = new BaGeometry(json, new SourceType(SourceTypeName.GEOJSON));
 
 		expect(geometry.data).toBe(JSON.stringify(json));
 		expect(geometry.sourceType).toEqual(new SourceType(SourceTypeName.GEOJSON));
 	});
 
 	it('check the constructors arguments', () => {
-		expect(() => new Geometry('data', new SourceType(SourceTypeName.WMS))).toThrowError('Unsupported source type: wms');
-		expect(() => new Geometry('data')).toThrowError('<sourceType> must be a SourceType');
-		expect(() => new Geometry(123, new SourceType(SourceTypeName.GPX))).toThrowError('<data> must be a String');
+		expect(() => new BaGeometry('data', new SourceType(SourceTypeName.WMS))).toThrowError('Unsupported source type: wms');
+		expect(() => new BaGeometry('data')).toThrowError('<sourceType> must be a SourceType');
+		expect(() => new BaGeometry(123, new SourceType(SourceTypeName.GPX))).toThrowError('<data> must be a String');
 	});
 });

--- a/test/domain/sourceType.test.js
+++ b/test/domain/sourceType.test.js
@@ -23,6 +23,12 @@ describe('SourceType', () => {
 		expect(sourceType.version).toBeNull();
 		expect(sourceType.srid).toBeNull();
 	});
+
+	it('provides static convenience methods', () => {
+		expect(SourceType.forKml()).toEqual(new SourceType(SourceTypeName.KML, null, 4326));
+		expect(SourceType.forGpx()).toEqual(new SourceType(SourceTypeName.GPX, null, 4326));
+		expect(SourceType.forGeoJSON()).toEqual(new SourceType(SourceTypeName.GEOJSON, null, 4326));
+	});
 });
 
 describe('SourceTypeResult', () => {

--- a/test/domain/sourceType.test.js
+++ b/test/domain/sourceType.test.js
@@ -28,6 +28,7 @@ describe('SourceType', () => {
 		expect(SourceType.forKml()).toEqual(new SourceType(SourceTypeName.KML, null, 4326));
 		expect(SourceType.forGpx()).toEqual(new SourceType(SourceTypeName.GPX, null, 4326));
 		expect(SourceType.forGeoJSON()).toEqual(new SourceType(SourceTypeName.GEOJSON, null, 4326));
+		expect(SourceType.forEwkt(12345)).toEqual(new SourceType(SourceTypeName.EWKT, null, 12345));
 	});
 });
 

--- a/test/domain/styles.test.js
+++ b/test/domain/styles.test.js
@@ -11,8 +11,9 @@ describe('StyleSize', () => {
 });
 describe('StyleHint', () => {
 	it('is an enum with a value ', () => {
-		expect(Object.entries(StyleHint).length).toBe(1);
+		expect(Object.entries(StyleHint).length).toBe(2);
 		expect(Object.isFrozen(StyleHint)).toBeTrue();
 		expect(StyleHint.HIGHLIGHT).toEqual('highlight');
+		expect(StyleHint.CLUSTER).toEqual('cluster');
 	});
 });

--- a/test/domain/styles.test.js
+++ b/test/domain/styles.test.js
@@ -1,4 +1,4 @@
-import { StyleSize } from '../../src/domain/styles';
+import { StyleHint, StyleSize } from '../../src/domain/styles';
 
 describe('StyleSize', () => {
 	it('is an enum with a value ', () => {
@@ -7,5 +7,12 @@ describe('StyleSize', () => {
 		expect(StyleSize.LARGE).toEqual('large');
 		expect(StyleSize.MEDIUM).toEqual('medium');
 		expect(StyleSize.SMALL).toEqual('small');
+	});
+});
+describe('StyleHint', () => {
+	it('is an enum with a value ', () => {
+		expect(Object.entries(StyleHint).length).toBe(1);
+		expect(Object.isFrozen(StyleHint)).toBeTrue();
+		expect(StyleHint.HIGHLIGHT).toEqual('highlight');
 	});
 });

--- a/test/modules/featureInfo/components/FeatureCollectionPanel.test.js
+++ b/test/modules/featureInfo/components/FeatureCollectionPanel.test.js
@@ -4,7 +4,7 @@ import { $injector } from '../../../../src/injection/index.js';
 import { FeatureCollectionPanel } from '../../../../src/modules/featureInfo/components/collection/FeatureCollectionPanel.js';
 import { Geometry } from '../../../../src/domain/geometry.js';
 import { featureCollectionReducer } from '../../../../src/store/featureCollection/featureCollection.reducer.js';
-import { Feature } from '../../../../src/domain/feature.js';
+import { BaFeature } from '../../../../src/domain/feature.js';
 import { featureInfoReducer } from '../../../../src/store/featureInfo/featureInfo.reducer.js';
 import { highlightReducer } from '../../../../src/store/highlight/highlight.reducer.js';
 import { SourceType, SourceTypeName } from '../../../../src/domain/sourceType.js';
@@ -51,7 +51,7 @@ describe('FeatureCollectionPanel', () => {
 			describe('containing feature that is not part of the feature collection', () => {
 				it('renders an ADD button', async () => {
 					const element = await setup({});
-					const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+					const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 					element.configuration = { feature, geoResourceId: null };
 
@@ -65,7 +65,7 @@ describe('FeatureCollectionPanel', () => {
 
 			describe('containing feature that is already a part of the feature collection and its corresponding GeoResource is NOT the FEATURE_COLLECTION_GEORESOURCE', () => {
 				it('renders nothing', async () => {
-					const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+					const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 					const element = await setup({
 						featureCollection: {
 							entries: [feature]
@@ -80,7 +80,7 @@ describe('FeatureCollectionPanel', () => {
 
 			describe('containing feature that is already a part of the feature collection and its corresponding GeoResource is the FEATURE_COLLECTION_GEORESOURCE', () => {
 				it('renders a REMOVE button', async () => {
-					const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+					const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 					const element = await setup({
 						featureCollection: {
 							entries: [feature]
@@ -109,7 +109,7 @@ describe('FeatureCollectionPanel', () => {
 					features: [{ foo: 'bar' }]
 				}
 			});
-			const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+			const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 			element.configuration = { feature };
 			const button = element.shadowRoot.querySelector('.chips__button.add');
@@ -129,7 +129,7 @@ describe('FeatureCollectionPanel', () => {
 	describe('REMOVE button is clicked', () => {
 		it('removes the feature from the featureCollection s-o-s and resets the highlight and featureInfo s-o-s', async () => {
 			const featureId = 'featureId0';
-			const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), featureId);
+			const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), featureId);
 			const element = await setup({
 				featureCollection: {
 					entries: [feature]

--- a/test/modules/featureInfo/components/FeatureCollectionPanel.test.js
+++ b/test/modules/featureInfo/components/FeatureCollectionPanel.test.js
@@ -2,7 +2,7 @@
 import { TestUtils } from '../../../test-utils.js';
 import { $injector } from '../../../../src/injection/index.js';
 import { FeatureCollectionPanel } from '../../../../src/modules/featureInfo/components/collection/FeatureCollectionPanel.js';
-import { Geometry } from '../../../../src/domain/geometry.js';
+import { BaGeometry } from '../../../../src/domain/geometry.js';
 import { featureCollectionReducer } from '../../../../src/store/featureCollection/featureCollection.reducer.js';
 import { BaFeature } from '../../../../src/domain/feature.js';
 import { featureInfoReducer } from '../../../../src/store/featureInfo/featureInfo.reducer.js';
@@ -51,7 +51,7 @@ describe('FeatureCollectionPanel', () => {
 			describe('containing feature that is not part of the feature collection', () => {
 				it('renders an ADD button', async () => {
 					const element = await setup({});
-					const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+					const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 					element.configuration = { feature, geoResourceId: null };
 
@@ -65,7 +65,7 @@ describe('FeatureCollectionPanel', () => {
 
 			describe('containing feature that is already a part of the feature collection and its corresponding GeoResource is NOT the FEATURE_COLLECTION_GEORESOURCE', () => {
 				it('renders nothing', async () => {
-					const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+					const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 					const element = await setup({
 						featureCollection: {
 							entries: [feature]
@@ -80,7 +80,7 @@ describe('FeatureCollectionPanel', () => {
 
 			describe('containing feature that is already a part of the feature collection and its corresponding GeoResource is the FEATURE_COLLECTION_GEORESOURCE', () => {
 				it('renders a REMOVE button', async () => {
-					const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+					const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 					const element = await setup({
 						featureCollection: {
 							entries: [feature]
@@ -109,7 +109,7 @@ describe('FeatureCollectionPanel', () => {
 					features: [{ foo: 'bar' }]
 				}
 			});
-			const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+			const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 			element.configuration = { feature };
 			const button = element.shadowRoot.querySelector('.chips__button.add');
@@ -129,7 +129,7 @@ describe('FeatureCollectionPanel', () => {
 	describe('REMOVE button is clicked', () => {
 		it('removes the feature from the featureCollection s-o-s and resets the highlight and featureInfo s-o-s', async () => {
 			const featureId = 'featureId0';
-			const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), featureId);
+			const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), featureId);
 			const element = await setup({
 				featureCollection: {
 					entries: [feature]

--- a/test/modules/featureInfo/components/FeatureInfoIframePanel.test.js
+++ b/test/modules/featureInfo/components/FeatureInfoIframePanel.test.js
@@ -10,7 +10,7 @@ import {
 } from '../../../../src/modules/featureInfo/components/featureInfoIframePanel/FeatureInfoIframePanel.js';
 import { addFeatureInfoItems } from '../../../../src/store/featureInfo/featureInfo.action.js';
 import { SourceType, SourceTypeName } from '../../../../src/domain/sourceType.js';
-import { Geometry } from '../../../../src/domain/geometry.js';
+import { BaGeometry } from '../../../../src/domain/geometry.js';
 import { HighlightFeatureType } from '../../../../src/domain/highlightFeature.js';
 
 window.customElements.define(FeatureInfoIframePanel.tag, FeatureInfoIframePanel);
@@ -136,7 +136,7 @@ describe('FeatureInfoIframePanel', () => {
 							{
 								title: 'title0',
 								content: 'content0',
-								geometry: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
+								geometry: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
 							}
 						]
 					}
@@ -146,7 +146,7 @@ describe('FeatureInfoIframePanel', () => {
 				target.dispatchEvent(new Event('mouseenter'));
 
 				expect(store.getState().highlight.features).toHaveSize(1);
-				expect(store.getState().highlight.features[0].data).toEqual(new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)));
+				expect(store.getState().highlight.features[0].data).toEqual(new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON)));
 				expect(store.getState().highlight.features[0].type).toBe(HighlightFeatureType.MARKER_TMP);
 				expect(store.getState().highlight.features[0].id).toBe(TEMPORARY_FEATURE_HIGHLIGHT_ID);
 				expect(element.shadowRoot.querySelectorAll('.is-geometry')).toHaveSize(1);
@@ -181,12 +181,12 @@ describe('FeatureInfoIframePanel', () => {
 							{
 								title: 'title0',
 								content: 'content0',
-								geometry: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
+								geometry: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
 							}
 						]
 					},
 					highlight: {
-						features: [{ id: TEMPORARY_FEATURE_HIGHLIGHT_ID, data: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)) }]
+						features: [{ id: TEMPORARY_FEATURE_HIGHLIGHT_ID, data: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON)) }]
 					}
 				});
 

--- a/test/modules/featureInfo/components/FeatureInfoPanel.test.js
+++ b/test/modules/featureInfo/components/FeatureInfoPanel.test.js
@@ -8,7 +8,7 @@ import { html } from 'lit-html';
 import { addFeatureInfoItems } from '../../../../src/store/featureInfo/featureInfo.action.js';
 import { highlightReducer } from '../../../../src/store/highlight/highlight.reducer.js';
 import { createNoInitialStateMediaReducer } from '../../../../src/store/media/media.reducer';
-import { Geometry } from '../../../../src/domain/geometry.js';
+import { BaGeometry } from '../../../../src/domain/geometry.js';
 import { SourceType, SourceTypeName } from '../../../../src/domain/sourceType.js';
 import { HighlightFeatureType } from '../../../../src/domain/highlightFeature.js';
 
@@ -269,7 +269,7 @@ describe('FeatureInfoPanel', () => {
 							{
 								title: 'title0',
 								content: 'content0',
-								geometry: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
+								geometry: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
 							}
 						]
 					}
@@ -280,7 +280,7 @@ describe('FeatureInfoPanel', () => {
 
 				expect(store.getState().highlight.features).toHaveSize(1);
 				expect(store.getState().highlight.features[0].type).toBe(HighlightFeatureType.DEFAULT_TMP);
-				expect(store.getState().highlight.features[0].data).toEqual(new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)));
+				expect(store.getState().highlight.features[0].data).toEqual(new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON)));
 				expect(store.getState().highlight.features[0].id).toBe(TEMPORARY_FEATURE_HIGHLIGHT_ID);
 				expect(element.shadowRoot.querySelectorAll('.is-geometry')).toHaveSize(1);
 			});
@@ -314,13 +314,13 @@ describe('FeatureInfoPanel', () => {
 							{
 								title: 'title0',
 								content: 'content0',
-								geometry: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
+								geometry: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
 							}
 						]
 					},
 					highlight: {
 						// features: [{ id: TEMPORARY_FEATURE_HIGHLIGHT_ID, data: { geometry: geoJson, geometryType: HighlightGeometryType.GEOJSON } }]
-						features: [{ id: TEMPORARY_FEATURE_HIGHLIGHT_ID, data: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)) }]
+						features: [{ id: TEMPORARY_FEATURE_HIGHLIGHT_ID, data: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON)) }]
 					}
 				});
 

--- a/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -21,7 +21,7 @@ import { QUERY_RUNNING_HIGHLIGHT_FEATURE_ID } from '../../../../../src/plugins/H
 import { Cluster } from 'ol/source';
 import LayerGroup from 'ol/layer/Group';
 import { VectorGeoResource, VectorSourceType } from '../../../../../src/domain/geoResources';
-import { Geometry } from '../../../../../src/domain/geometry';
+import { BaGeometry } from '../../../../../src/domain/geometry';
 import { SourceType, SourceTypeName } from '../../../../../src/domain/sourceType';
 import { HighlightFeatureType } from '../../../../../src/domain/highlightFeature';
 
@@ -48,7 +48,7 @@ describe('OlFeatureInfoHandler', () => {
 	};
 
 	const mockFeatureInfoProvider = (olFeature, layer) => {
-		const geometry = new Geometry(new GeoJSON().writeGeometry(olFeature.getGeometry()), new SourceType(SourceTypeName.GEOJSON));
+		const geometry = new BaGeometry(new GeoJSON().writeGeometry(olFeature.getGeometry()), new SourceType(SourceTypeName.GEOJSON));
 		return { title: `${olFeature.get('name')}-${layer.id}`, content: `${olFeature.get('description')}`, geometry };
 	};
 
@@ -224,7 +224,7 @@ describe('OlFeatureInfoHandler', () => {
 			);
 			const map = setupMap();
 			const geometry = new Point(matchingCoordinate);
-			const expectedFeatureInfoGeometry = new Geometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
+			const expectedFeatureInfoGeometry = new BaGeometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
 			// 1. "default" vector layer
 			const olVectorSource0 = new VectorSource();
 			const feature0 = new Feature({ geometry: geometry });
@@ -349,7 +349,7 @@ describe('OlFeatureInfoHandler', () => {
 		it('sets the `id` property on each olFeature when missing', async () => {
 			// this provider also returns the `id` property of the olFeature as `content` property
 			const mockFeatureInfoProvider = (olFeature, layer) => {
-				const geometry = new Geometry(new GeoJSON().writeGeometry(olFeature.getGeometry()), new SourceType(SourceTypeName.GEOJSON));
+				const geometry = new BaGeometry(new GeoJSON().writeGeometry(olFeature.getGeometry()), new SourceType(SourceTypeName.GEOJSON));
 				return {
 					title: `${olFeature.get('name')}-${layer.id}`,
 					content: `${olFeature.getId()}`,
@@ -371,7 +371,7 @@ describe('OlFeatureInfoHandler', () => {
 			);
 			const map = setupMap();
 			const geometry = new Point(matchingCoordinate);
-			const expectedFeatureInfoGeometry = new Geometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
+			const expectedFeatureInfoGeometry = new BaGeometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
 			// 1. "default" vector layer
 			const olVectorSource0 = new VectorSource();
 			const feature0 = new Feature({ geometry: geometry });

--- a/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
+++ b/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
@@ -12,7 +12,7 @@ import GeoJSON from 'ol/format/GeoJSON';
 import { $injector } from '../../../../../src/injection';
 import { TestUtils } from '../../../../test-utils';
 import { SourceType, SourceTypeName } from '../../../../../src/domain/sourceType';
-import { Geometry } from '../../../../../src/domain/geometry';
+import { BaGeometry } from '../../../../../src/domain/geometry';
 
 describe('FeatureInfo provider', () => {
 	const mapServiceMock = {
@@ -80,7 +80,7 @@ describe('FeatureInfo provider', () => {
 					let feature = new Feature({ geometry: geometry });
 					feature.set('name', 'name');
 					feature.setId('id');
-					const expectedFeatureInfoGeometry = new Geometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
+					const expectedFeatureInfoGeometry = new BaGeometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
 
 					let featureInfo = bvvFeatureInfoProvider(feature, layerProperties);
 					render(featureInfo.content, target);
@@ -198,7 +198,7 @@ describe('FeatureInfo provider', () => {
 					let feature = new Feature({ geometry: geometry });
 					feature.set('name', 'name');
 					feature.setId('id');
-					const expectedFeatureInfoGeometry = new Geometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
+					const expectedFeatureInfoGeometry = new BaGeometry(new GeoJSON().writeGeometry(geometry), new SourceType(SourceTypeName.GEOJSON));
 
 					let featureInfo = bvvFeatureInfoProvider(feature, layerProperties);
 					render(featureInfo.content, target);

--- a/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
+++ b/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
@@ -286,7 +286,7 @@ describe('FeatureInfo provider', () => {
 				const panel = target.querySelector(FeatureCollectionPanel.tag);
 
 				expect(panel.configuration.feature.geometry.data.startsWith('<kml')).toBeTrue();
-				expect(panel.configuration.feature.geometry.sourceType).toEqual(new SourceType(SourceTypeName.KML));
+				expect(panel.configuration.feature.geometry.sourceType).toEqual(SourceType.forKml());
 				expect(panel.configuration.geoResourceId).toBe(geoResourceId);
 			});
 		});

--- a/test/modules/olMap/handler/highlight/OlHighlightLayerHandler.test.js
+++ b/test/modules/olMap/handler/highlight/OlHighlightLayerHandler.test.js
@@ -17,7 +17,7 @@ import GeoJSON from 'ol/format/GeoJSON';
 import { Point } from 'ol/geom';
 import { Feature } from 'ol';
 import { $injector } from '../../../../../src/injection';
-import { Geometry } from '../../../../../src/domain/geometry';
+import { BaGeometry } from '../../../../../src/domain/geometry';
 import { SourceType, SourceTypeName } from '../../../../../src/domain/sourceType';
 import { HighlightFeatureType } from '../../../../../src/domain/highlightFeature';
 
@@ -204,11 +204,11 @@ describe('OlHighlightLayerHandler', () => {
 			spyOn(mapService, 'getSrid').and.returnValue(3857);
 			const appendStyleSpy = spyOn(handler, '_appendStyle').withArgs(jasmine.anything(), jasmine.any(Feature)).and.callThrough();
 			const highlightGeometryWktFeature = {
-				data: new Geometry(`SRID=3857;${new WKT().writeGeometry(new Point([21, 42]))}`, new SourceType(SourceTypeName.EWKT)),
+				data: new BaGeometry(`SRID=3857;${new WKT().writeGeometry(new Point([21, 42]))}`, new SourceType(SourceTypeName.EWKT)),
 				label: 'WKT'
 			};
 			const highlightGeometryGeoJsonFeature = {
-				data: new Geometry(JSON.stringify(new GeoJSON().writeGeometry(new Point([5, 10]))), new SourceType(SourceTypeName.GEOJSON)),
+				data: new BaGeometry(JSON.stringify(new GeoJSON().writeGeometry(new Point([5, 10]))), new SourceType(SourceTypeName.GEOJSON)),
 				label: 'GeoJSON'
 			};
 
@@ -228,7 +228,7 @@ describe('OlHighlightLayerHandler', () => {
 				const handler = new OlHighlightLayerHandler();
 				spyOn(mapService, 'getSrid').and.returnValue(3857);
 				const highlightGeometryWktFeature = {
-					data: new Geometry(`SRID=4326;${new WKT().writeGeometry(new Point([21, 42]))}`, new SourceType(SourceTypeName.EWKT)),
+					data: new BaGeometry(`SRID=4326;${new WKT().writeGeometry(new Point([21, 42]))}`, new SourceType(SourceTypeName.EWKT)),
 					label: 'WKT'
 				};
 
@@ -241,7 +241,7 @@ describe('OlHighlightLayerHandler', () => {
 			const handler = new OlHighlightLayerHandler();
 			const appendStyleSpy = spyOn(handler, '_appendStyle').withArgs(jasmine.anything(), jasmine.any(Feature)).and.callThrough();
 			const unknownHighlightFeatureType = {
-				data: new Geometry(JSON.stringify(new GeoJSON().writeGeometry(new Point([5, 10]))), new SourceType(SourceTypeName.KML))
+				data: new BaGeometry(JSON.stringify(new GeoJSON().writeGeometry(new Point([5, 10]))), new SourceType(SourceTypeName.KML))
 			};
 
 			expect(() => handler._toOlFeature(unknownHighlightFeatureType)).toThrow('SourceType "kml" is currently not supported');
@@ -282,11 +282,11 @@ describe('OlHighlightLayerHandler', () => {
 			setup();
 			const handler = new OlHighlightLayerHandler();
 			const highlightGeometryGeoJsonFeature0 = {
-				data: new Geometry(new GeoJSON().writeGeometry(olPoint), new SourceType(SourceTypeName.GEOJSON)),
+				data: new BaGeometry(new GeoJSON().writeGeometry(olPoint), new SourceType(SourceTypeName.GEOJSON)),
 				type: HighlightFeatureType.DEFAULT
 			};
 			const highlightGeometryGeoJsonFeature1 = {
-				data: new Geometry(new GeoJSON().writeGeometry(olPoint), new SourceType(SourceTypeName.GEOJSON)),
+				data: new BaGeometry(new GeoJSON().writeGeometry(olPoint), new SourceType(SourceTypeName.GEOJSON)),
 				type: HighlightFeatureType.DEFAULT_TMP
 			};
 

--- a/test/modules/olMap/services/RtVectorLayerService.test.js
+++ b/test/modules/olMap/services/RtVectorLayerService.test.js
@@ -15,9 +15,7 @@ describe('RtVectorLayerService', () => {
 	};
 
 	const vectorLayerService = {
-		applyStyles: () => {},
-		applyClusterStyle: () => {},
-		sanitizeStyles: () => {}
+		applyStyle: () => {}
 	};
 
 	describe('utils', () => {
@@ -177,10 +175,7 @@ describe('RtVectorLayerService', () => {
 				const olVectorLayer = instanceUnderTest.createLayer(id, rtVectorGeoResource, olMap);
 				spyOn(olMap, 'getView').and.returnValue({ calculateExtent: () => [] });
 				const processSpy = spyOn(instanceUnderTest, '_processMessage').and.callThrough();
-				const sanitizeStyleSpy = spyOn(vectorLayerService, 'sanitizeStyles').and.callFake(() => {});
-				const applyStyleSpy = spyOn(vectorLayerService, 'applyStyles')
-					.withArgs(olVectorLayer, olMap)
-					.and.callFake(() => {});
+				const applyStyleSpy = spyOn(vectorLayerService, 'applyStyle').and.callFake(() => {});
 				const fitViewSpy = spyOn(instanceUnderTest, '_centerViewOptionally').and.callThrough();
 				expect(olVectorLayer.getSource().getFeatures().length).toBe(0);
 
@@ -189,8 +184,7 @@ describe('RtVectorLayerService', () => {
 				expect(olVectorLayer.getSource().getFeatures().length).toBe(1);
 				expect(olVectorLayer.getSource().getFeatures()[0].get('showPointNames')).toBeTrue();
 				expect(processSpy).toHaveBeenCalled();
-				expect(sanitizeStyleSpy).toHaveBeenCalled();
-				expect(applyStyleSpy).toHaveBeenCalled();
+				expect(applyStyleSpy).toHaveBeenCalledWith(olVectorLayer, olMap, rtVectorGeoResource);
 				expect(fitViewSpy).toHaveBeenCalled();
 				expect(store.getState().position.fitRequest.payload.extent).toEqual(olVectorLayer.getSource().getExtent());
 			});
@@ -211,11 +205,8 @@ describe('RtVectorLayerService', () => {
 				const olVectorLayer = instanceUnderTest.createLayer(id, clusteredRtVectorGeoResource, olMap);
 				const processSpy = spyOn(instanceUnderTest, '_processMessage').and.callThrough();
 				spyOn(olMap, 'getView').and.callFake(() => viewMock);
-				const sanitizeStyleSpy = spyOn(vectorLayerService, 'sanitizeStyles').and.callFake(() => {});
 
-				const applyStyleSpy = spyOn(vectorLayerService, 'applyClusterStyle')
-					.withArgs(olVectorLayer)
-					.and.callFake(() => {});
+				const applyStyleSpy = spyOn(vectorLayerService, 'applyStyle').and.callFake(() => {});
 				const fitViewSpy = spyOn(instanceUnderTest, '_centerViewOptionally').and.callThrough();
 				expect(olVectorLayer.getSource().getFeatures().length).toBe(0);
 
@@ -224,13 +215,12 @@ describe('RtVectorLayerService', () => {
 				expect(olVectorLayer.getSource().getFeatures().length).toBe(1);
 				expect(olVectorLayer.getSource().getFeatures()[0].get('showPointNames')).toBeTrue();
 				expect(processSpy).toHaveBeenCalled();
-				expect(sanitizeStyleSpy).toHaveBeenCalled();
-				expect(applyStyleSpy).toHaveBeenCalled();
+				expect(applyStyleSpy).toHaveBeenCalledWith(olVectorLayer, olMap, clusteredRtVectorGeoResource);
 				expect(fitViewSpy).toHaveBeenCalled();
 				expect(store.getState().position.fitRequest.payload.extent).toEqual(olVectorLayer.getSource().getExtent());
 			});
 
-			it('makes a fit request for the first features only', () => {
+			it('fires a fit request for the first features only', () => {
 				const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };
 				const state = {
 					layers: {
@@ -246,10 +236,7 @@ describe('RtVectorLayerService', () => {
 				const olVectorLayer = instanceUnderTest.createLayer(id, rtVectorGeoResource, olMap);
 				spyOn(olMap, 'getView').and.returnValue(viewMock);
 				spyOn(instanceUnderTest, '_processMessage').and.callThrough();
-				spyOn(vectorLayerService, 'sanitizeStyles').and.callFake(() => {});
-				spyOn(vectorLayerService, 'applyStyles')
-					.withArgs(olVectorLayer, olMap)
-					.and.callFake(() => {});
+				spyOn(vectorLayerService, 'applyStyle').and.callFake(() => {});
 				const fitViewSpy = spyOn(instanceUnderTest, '_centerViewOptionally')
 					.withArgs(olVectorLayer, olMap, true)
 					.and.callThrough()
@@ -270,7 +257,7 @@ describe('RtVectorLayerService', () => {
 				expect(store.getState().position.center).not.toEqual(initialCenter);
 			});
 
-			it('does NOT makes a fit request for already containing extent in the view', () => {
+			it('does NOT fire a fit request for already containing extent in the view', () => {
 				const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0' };
 				const state = {
 					layers: {
@@ -285,9 +272,7 @@ describe('RtVectorLayerService', () => {
 
 				spyOn(olMap, 'getView').and.returnValue(viewMock);
 				spyOn(instanceUnderTest, '_processMessage').and.callThrough();
-				spyOn(vectorLayerService, 'sanitizeStyles').and.callFake(() => {});
-				spyOn(vectorLayerService, 'applyStyles')
-					.withArgs(olVectorLayer, olMap)
+				spyOn(vectorLayerService, 'applyStyle')
 					.and.callFake(() => {});
 				const fitViewSpy = spyOn(instanceUnderTest, '_centerViewOptionally').and.callThrough();
 				expect(olVectorLayer.getSource().getFeatures().length).toBe(0);

--- a/test/modules/olMap/services/RtVectorLayerService.test.js
+++ b/test/modules/olMap/services/RtVectorLayerService.test.js
@@ -272,8 +272,7 @@ describe('RtVectorLayerService', () => {
 
 				spyOn(olMap, 'getView').and.returnValue(viewMock);
 				spyOn(instanceUnderTest, '_processMessage').and.callThrough();
-				spyOn(vectorLayerService, 'applyStyle')
-					.and.callFake(() => {});
+				spyOn(vectorLayerService, 'applyStyle').and.callFake(() => {});
 				const fitViewSpy = spyOn(instanceUnderTest, '_centerViewOptionally').and.callThrough();
 				expect(olVectorLayer.getSource().getFeatures().length).toBe(0);
 				expect(store.getState().position.fitRequest.payload).toBeNull();

--- a/test/modules/olMap/services/StyleService.test.js
+++ b/test/modules/olMap/services/StyleService.test.js
@@ -11,6 +11,9 @@ import VectorLayer from 'ol/layer/Vector';
 import CircleStyle from 'ol/style/Circle.js';
 import { GEODESIC_FEATURE_PROPERTY, GeodesicGeometry } from '../../../../src/modules/olMap/ol/geodesic/geodesicGeometry.js';
 import { VectorSourceType } from '../../../../src/domain/geoResources.js';
+import { StyleHint } from '../../../../src/domain/styles.js';
+import { defaultClusterStyleFunction } from '../../../../src/modules/olMap/utils/olStyleUtils.js';
+import { highlightGeometryOrCoordinateFeatureStyleFunction } from '../../../../src/modules/olMap/handler/highlight/styleUtils.js';
 
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 register(proj4);
@@ -896,12 +899,15 @@ describe('StyleService', () => {
 
 	describe('add cluster style', () => {
 		it('adds a style function to the cluster layer', () => {
-			const clusterLayer = new VectorLayer({ id: 'foo' });
-			const styleSpy = spyOn(clusterLayer, 'setStyle').and.callThrough();
+			const layer = new VectorLayer({ id: 'foo' });
+			const feature1 = new Feature({ geometry: new Point([0, 0]) });
+			const feature2 = new Feature({ geometry: new Point([0, 0]) });
+			const clusterFeature = new Feature({ geometry: new Point([0, 0]), features: [feature1, feature2] });
 
-			instanceUnderTest.addClusterStyle(clusterLayer);
-
-			expect(styleSpy).toHaveBeenCalledWith(jasmine.any(Function));
+			expect(instanceUnderTest.applyStyleHint(StyleHint.CLUSTER, layer).getStyle()(clusterFeature)).toEqual(
+				defaultClusterStyleFunction()(clusterFeature)
+			);
+			expect(instanceUnderTest.applyStyleHint(StyleHint.HIGHLIGHT, layer).getStyle()).toEqual(highlightGeometryOrCoordinateFeatureStyleFunction());
 		});
 	});
 

--- a/test/modules/olMap/services/StyleService.test.js
+++ b/test/modules/olMap/services/StyleService.test.js
@@ -895,6 +895,27 @@ describe('StyleService', () => {
 
 			expect(updateSpy).toHaveBeenCalledWith(feature, mapMock, 'measure');
 		});
+
+		describe('checks the `styleHint` property of an ol.Feature', () => {
+			it('does nothing when a StyleHint is not available', () => {
+				const olFeature = new Feature({ geometry: new Point([0, 0]) });
+				spyOn(instanceUnderTest, '_detectStyleType').and.returnValue(null);
+
+				instanceUnderTest.addStyle(olFeature, {}, {});
+
+				expect(olFeature.getStyle()).toBeNull();
+			});
+
+			it('sets the correct style for `StyleHint.HIGHLIGHT`', () => {
+				const olFeature = new Feature({ geometry: new Point([0, 0]) });
+				olFeature.set('styleHint', StyleHint.HIGHLIGHT);
+				spyOn(instanceUnderTest, '_detectStyleType').and.returnValue(null);
+
+				instanceUnderTest.addStyle(olFeature, {}, {});
+
+				expect(olFeature.getStyle()).toEqual(highlightGeometryOrCoordinateFeatureStyleFunction());
+			});
+		});
 	});
 
 	describe('add cluster style', () => {

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -316,9 +316,9 @@ describe('VectorLayerService', () => {
 				});
 			});
 
-			describe('VectorGeoResource holds ist data as `BaFeature`', () => {
+			describe('VectorGeoResource holds its data as `BaFeature`', () => {
 				describe('exactly one feature', () => {
-					it('builds an olVectorSource for an VectorGeoResource', async () => {
+					it('builds an olVectorSource for a VectorGeoResource', async () => {
 						setup();
 						const kmlName = 'kmlName';
 						const featureId = 'featureIO';
@@ -344,7 +344,7 @@ describe('VectorLayerService', () => {
 				});
 
 				describe('more than one feature', () => {
-					it('builds an olVectorSource for an VectorGeoResource', async () => {
+					it('builds an olVectorSource for a VectorGeoResource', async () => {
 						setup();
 						const kmlName = 'kmlName';
 						const data = `<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><name>${kmlName}</name><Placemark id=" "><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>`;

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -16,7 +16,7 @@ import { createDefaultLayer, layersReducer } from '../../../../src/store/layers/
 import { UnavailableGeoResourceError } from '../../../../src/domain/errors';
 import { StyleHint } from '../../../../src/domain/styles';
 import { Geometry as BaGeometry } from '../../../../src/domain/geometry';
-import { Feature as BaFeature } from '../../../../src/domain/feature';
+import { BaFeature } from '../../../../src/domain/feature';
 import { SourceType } from '../../../../src/domain/sourceType';
 
 describe('VectorLayerService', () => {

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -143,8 +143,8 @@ describe('VectorLayerService', () => {
 				const vectorGeoResource = new VectorGeoResource(geoResourceId, geoResourceLabel, VectorSourceType.KML).setSource(sourceAsString, 4326);
 				spyOn(instanceUnderTest, '_vectorSourceForData').withArgs(vectorGeoResource).and.returnValue(olSource);
 				spyOn(instanceUnderTest, 'applyStyle')
-					.withArgs(vectorGeoResource, jasmine.anything(), olMap)
-					.and.callFake((vrg, olLayer) => olLayer);
+					.withArgs(jasmine.anything(), olMap, vectorGeoResource)
+					.and.callFake((olLayer) => olLayer);
 
 				const olVectorLayer = instanceUnderTest.createLayer(id, vectorGeoResource, olMap);
 
@@ -640,6 +640,16 @@ describe('VectorLayerService', () => {
 		});
 
 		describe('applyStyle', () => {
+			it('calls return the ol.Layer', () => {
+				setup();
+				const olLayer = new VectorLayer({ source: new VectorSource() });
+				const vectorGeoResource = new VectorGeoResource('geoResourceId', 'geoResourceLabel', VectorSourceType.KML);
+				const olMap = new Map();
+
+				const result = instanceUnderTest.applyStyle(olLayer, olMap, vectorGeoResource);
+
+				expect(result).toEqual(olLayer);
+			});
 			it('calls _sanitizeStyles', () => {
 				setup();
 				const olLayer = new VectorLayer({ source: new VectorSource() });
@@ -647,7 +657,7 @@ describe('VectorLayerService', () => {
 				const olMap = new Map();
 				const sanitizeStylesSpy = spyOn(instanceUnderTest, '_sanitizeStyles');
 
-				instanceUnderTest.applyStyle(vectorGeoResource, olLayer, olMap);
+				instanceUnderTest.applyStyle(olLayer, olMap, vectorGeoResource);
 
 				expect(sanitizeStylesSpy).toHaveBeenCalledWith(olLayer);
 			});
@@ -659,7 +669,7 @@ describe('VectorLayerService', () => {
 				const olMap = new Map();
 				const styleServiceSpy = spyOn(styleService, 'applyStyleHint');
 
-				instanceUnderTest.applyStyle(vectorGeoResource, olLayer, olMap);
+				instanceUnderTest.applyStyle(olLayer, olMap, vectorGeoResource);
 
 				expect(styleServiceSpy).toHaveBeenCalledWith(StyleHint.CLUSTER, olLayer);
 			});
@@ -671,7 +681,7 @@ describe('VectorLayerService', () => {
 				const olMap = new Map();
 				const styleServiceSpy = spyOn(styleService, 'applyStyleHint');
 
-				instanceUnderTest.applyStyle(vectorGeoResource, olLayer, olMap);
+				instanceUnderTest.applyStyle(olLayer, olMap, vectorGeoResource);
 
 				expect(styleServiceSpy).toHaveBeenCalledWith(StyleHint.HIGHLIGHT, olLayer);
 			});
@@ -683,7 +693,7 @@ describe('VectorLayerService', () => {
 				const applyFeatureSpecificStylesSpy = spyOn(instanceUnderTest, '_applyFeatureSpecificStyles');
 				const olMap = new Map();
 
-				instanceUnderTest.applyStyle(vectorGeoResource, olLayer, olMap);
+				instanceUnderTest.applyStyle(olLayer, olMap, vectorGeoResource);
 
 				expect(applyFeatureSpecificStylesSpy).toHaveBeenCalledWith(olLayer, olMap);
 			});

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -15,7 +15,7 @@ import { TestUtils } from '../../../test-utils';
 import { createDefaultLayer, layersReducer } from '../../../../src/store/layers/layers.reducer';
 import { UnavailableGeoResourceError } from '../../../../src/domain/errors';
 import { StyleHint } from '../../../../src/domain/styles';
-import { Geometry as BaGeometry } from '../../../../src/domain/geometry';
+import { BaGeometry } from '../../../../src/domain/geometry';
 import { BaFeature } from '../../../../src/domain/feature';
 import { SourceType } from '../../../../src/domain/sourceType';
 

--- a/test/modules/search/components/menu/types/cp/CpResultItem.test.js
+++ b/test/modules/search/components/menu/types/cp/CpResultItem.test.js
@@ -6,7 +6,7 @@ import { createNoInitialStateMediaReducer } from '../../../../../../../src/store
 import { positionReducer } from '../../../../../../../src/store/position/position.reducer';
 import { TestUtils } from '../../../../../../test-utils.js';
 import { SEARCH_RESULT_HIGHLIGHT_FEATURE_ID, SEARCH_RESULT_TEMPORARY_HIGHLIGHT_FEATURE_ID } from '../../../../../../../src/plugins/HighlightPlugin';
-import { Geometry } from '../../../../../../../src/domain/geometry.js';
+import { BaGeometry } from '../../../../../../../src/domain/geometry.js';
 import { SourceType, SourceTypeName } from '../../../../../../../src/domain/sourceType.js';
 import { HighlightFeatureType } from '../../../../../../../src/domain/highlightFeature.js';
 window.customElements.define(CpResultItem.tag, CpResultItem);
@@ -59,8 +59,8 @@ describe('CpResultItem', () => {
 		const previousCoordinate = [1, 2];
 		const coordinate = [21, 42];
 		const extent = [0, 1, 2, 3];
-		const wktGeometry = new Geometry('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))', new SourceType(SourceTypeName.EWKT));
-		const geoJsonGeometry = new Geometry("{ type: 'Point', coordinates: [21, 42, 0] }", new SourceType(SourceTypeName.GEOJSON));
+		const wktGeometry = new BaGeometry('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))', new SourceType(SourceTypeName.EWKT));
+		const geoJsonGeometry = new BaGeometry("{ type: 'Point', coordinates: [21, 42, 0] }", new SourceType(SourceTypeName.GEOJSON));
 
 		const setupOnMouseEnterTests = async (portraitOrientation, extent = null, geometry = null) => {
 			const cpSearchResult = new CadastralParcelSearchResult('label', 'labelFormatted', coordinate, extent, geometry);

--- a/test/modules/search/services/domain/searchResult.test.js
+++ b/test/modules/search/services/domain/searchResult.test.js
@@ -6,7 +6,7 @@ import {
 	SearchResultTypes
 } from '../../../../../src/modules/search/services/domain/searchResult';
 import { SourceType, SourceTypeName } from '../../../../../src/domain/sourceType';
-import { Geometry } from '../../../../../src/domain/geometry';
+import { BaGeometry } from '../../../../../src/domain/geometry';
 import { hashCode } from '../../../../../src/utils/hashCode';
 
 describe('searchResult', () => {
@@ -163,7 +163,7 @@ describe('CadastralParcelSearchResult', () => {
 		const labelFormatted = 'labelFormatted';
 		const center = [1, 2];
 		const extent = [3, 4, 5, 6];
-		const geometry = new Geometry('ewkt', new SourceType(SourceTypeName.EWKT));
+		const geometry = new BaGeometry('ewkt', new SourceType(SourceTypeName.EWKT));
 
 		const cadastralParcelSearchResult = new CadastralParcelSearchResult(label, labelFormatted, center, extent, geometry);
 

--- a/test/modules/search/services/provider/searchResult.provider.test.js
+++ b/test/modules/search/services/provider/searchResult.provider.test.js
@@ -262,7 +262,7 @@ describe('SearchResult provider', () => {
 			expect(searchResult0.center).toEqual([10.270116669125855, 48.44638557638974]);
 			expect(searchResult0.extent).toEqual([0, 1, 2, 3]);
 			expect(searchResult0.geometry.data).toBe('SRID=3857;POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))');
-			expect(searchResult0.geometry.sourceType).toEqual(new SourceType(SourceTypeName.EWKT));
+			expect(searchResult0.geometry.sourceType).toEqual(new SourceType(SourceTypeName.EWKT, null, 3857));
 		});
 
 		it('returns an empty array when response is empty', async () => {

--- a/test/plugins/FeatureCollectionPlugin.test.js
+++ b/test/plugins/FeatureCollectionPlugin.test.js
@@ -7,7 +7,7 @@ import {
 	FeatureCollectionPlugin
 } from '../../src/plugins/FeatureCollectionPlugin.js';
 import { createDefaultLayer, layersReducer } from '../../src/store/layers/layers.reducer.js';
-import { Feature } from '../../src/domain/feature.js';
+import { BaFeature } from '../../src/domain/feature.js';
 import { addFeatures, clearFeatures } from '../../src/store/featureCollection/featureCollection.action.js';
 import { Geometry } from '../../src/domain/geometry.js';
 import { VectorGeoResource } from '../../src/domain/geoResources.js';
@@ -35,7 +35,7 @@ describe('FeatureCollectionPlugin', () => {
 					active: [createDefaultLayer(FEATURE_COLLECTION_LAYER_ID)]
 				},
 				featureCollection: {
-					entries: [new Feature(new Geometry('data', SourceType.forGpx()), 'id')]
+					entries: [new BaFeature(new Geometry('data', SourceType.forGpx()), 'id')]
 				}
 			});
 			const instanceUnderTest = new FeatureCollectionPlugin();
@@ -51,13 +51,16 @@ describe('FeatureCollectionPlugin', () => {
 		it('preserves existing features', async () => {
 			const store = setup({
 				featureCollection: {
-					entries: [new Feature(new Geometry('data', SourceType.forGpx()), 'id0')]
+					entries: [new BaFeature(new Geometry('data', SourceType.forGpx()), 'id0')]
 				}
 			});
 			const instanceUnderTest = new FeatureCollectionPlugin();
 			await instanceUnderTest.register(store);
 
-			addFeatures([new Feature(new Geometry('data0', SourceType.forGpx()), 'id1'), new Feature(new Geometry('data1', SourceType.forGpx()), 'id2')]);
+			addFeatures([
+				new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id1'),
+				new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id2')
+			]);
 
 			expect(store.getState().featureCollection.entries).toHaveSize(3);
 		});
@@ -66,8 +69,8 @@ describe('FeatureCollectionPlugin', () => {
 			const store = setup({});
 			const instanceUnderTest = new FeatureCollectionPlugin();
 			await instanceUnderTest.register(store);
-			const feature0 = new Feature(new Geometry('data0', SourceType.forGpx()), 'id0');
-			const feature1 = new Feature(new Geometry('data1', SourceType.forGpx()), 'id1');
+			const feature0 = new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id0');
+			const feature1 = new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id1');
 			const geoResourceServiceAddOrReplaceSpy = spyOn(geoResourceService, 'addOrReplace');
 
 			addFeatures([feature0, feature1]);
@@ -88,7 +91,10 @@ describe('FeatureCollectionPlugin', () => {
 				const store = setup({});
 				const instanceUnderTest = new FeatureCollectionPlugin();
 				await instanceUnderTest.register(store);
-				addFeatures([new Feature(new Geometry('data0', SourceType.forGpx()), 'id0'), new Feature(new Geometry('data1', SourceType.forGpx()), 'id1')]);
+				addFeatures([
+					new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id0'),
+					new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id1')
+				]);
 
 				expect(store.getState().featureCollection.entries).toHaveSize(2);
 
@@ -108,7 +114,10 @@ describe('FeatureCollectionPlugin', () => {
 				});
 				const instanceUnderTest = new FeatureCollectionPlugin();
 				await instanceUnderTest.register(store);
-				addFeatures([new Feature(new Geometry('data0', SourceType.forGpx()), 'id0'), new Feature(new Geometry('data1', SourceType.forGpx()), 'id1')]);
+				addFeatures([
+					new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id0'),
+					new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id1')
+				]);
 
 				expect(store.getState().featureCollection.entries).toHaveSize(2);
 

--- a/test/plugins/FeatureCollectionPlugin.test.js
+++ b/test/plugins/FeatureCollectionPlugin.test.js
@@ -9,7 +9,7 @@ import {
 import { createDefaultLayer, layersReducer } from '../../src/store/layers/layers.reducer.js';
 import { BaFeature } from '../../src/domain/feature.js';
 import { addFeatures, clearFeatures } from '../../src/store/featureCollection/featureCollection.action.js';
-import { Geometry } from '../../src/domain/geometry.js';
+import { BaGeometry } from '../../src/domain/geometry.js';
 import { VectorGeoResource } from '../../src/domain/geoResources.js';
 import { SourceType } from '../../src/domain/sourceType.js';
 import { removeLayer } from '../../src/store/layers/layers.action.js';
@@ -35,7 +35,7 @@ describe('FeatureCollectionPlugin', () => {
 					active: [createDefaultLayer(FEATURE_COLLECTION_LAYER_ID)]
 				},
 				featureCollection: {
-					entries: [new BaFeature(new Geometry('data', SourceType.forGpx()), 'id')]
+					entries: [new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id')]
 				}
 			});
 			const instanceUnderTest = new FeatureCollectionPlugin();
@@ -51,15 +51,15 @@ describe('FeatureCollectionPlugin', () => {
 		it('preserves existing features', async () => {
 			const store = setup({
 				featureCollection: {
-					entries: [new BaFeature(new Geometry('data', SourceType.forGpx()), 'id0')]
+					entries: [new BaFeature(new BaGeometry('data', SourceType.forGpx()), 'id0')]
 				}
 			});
 			const instanceUnderTest = new FeatureCollectionPlugin();
 			await instanceUnderTest.register(store);
 
 			addFeatures([
-				new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id1'),
-				new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id2')
+				new BaFeature(new BaGeometry('data0', SourceType.forGpx()), 'id1'),
+				new BaFeature(new BaGeometry('data1', SourceType.forGpx()), 'id2')
 			]);
 
 			expect(store.getState().featureCollection.entries).toHaveSize(3);
@@ -69,8 +69,8 @@ describe('FeatureCollectionPlugin', () => {
 			const store = setup({});
 			const instanceUnderTest = new FeatureCollectionPlugin();
 			await instanceUnderTest.register(store);
-			const feature0 = new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id0');
-			const feature1 = new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id1');
+			const feature0 = new BaFeature(new BaGeometry('data0', SourceType.forGpx()), 'id0');
+			const feature1 = new BaFeature(new BaGeometry('data1', SourceType.forGpx()), 'id1');
 			const geoResourceServiceAddOrReplaceSpy = spyOn(geoResourceService, 'addOrReplace');
 
 			addFeatures([feature0, feature1]);
@@ -92,8 +92,8 @@ describe('FeatureCollectionPlugin', () => {
 				const instanceUnderTest = new FeatureCollectionPlugin();
 				await instanceUnderTest.register(store);
 				addFeatures([
-					new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id0'),
-					new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id1')
+					new BaFeature(new BaGeometry('data0', SourceType.forGpx()), 'id0'),
+					new BaFeature(new BaGeometry('data1', SourceType.forGpx()), 'id1')
 				]);
 
 				expect(store.getState().featureCollection.entries).toHaveSize(2);
@@ -115,8 +115,8 @@ describe('FeatureCollectionPlugin', () => {
 				const instanceUnderTest = new FeatureCollectionPlugin();
 				await instanceUnderTest.register(store);
 				addFeatures([
-					new BaFeature(new Geometry('data0', SourceType.forGpx()), 'id0'),
-					new BaFeature(new Geometry('data1', SourceType.forGpx()), 'id1')
+					new BaFeature(new BaGeometry('data0', SourceType.forGpx()), 'id0'),
+					new BaFeature(new BaGeometry('data1', SourceType.forGpx()), 'id1')
 				]);
 
 				expect(store.getState().featureCollection.entries).toHaveSize(2);

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -25,7 +25,7 @@ import { setQuery } from '../../src/store/search/search.action';
 import { $injector } from '../../src/injection';
 import { QueryParameters } from '../../src/domain/queryParameters';
 import { positionReducer } from '../../src/store/position/position.reducer';
-import { Geometry } from '../../src/domain/geometry.js';
+import { BaGeometry } from '../../src/domain/geometry.js';
 import { SourceType, SourceTypeName } from '../../src/domain/sourceType.js';
 import { HighlightFeatureType } from '../../src/domain/highlightFeature.js';
 
@@ -118,7 +118,7 @@ describe('HighlightPlugin', () => {
 			const highlightFeature2 = { type: HighlightFeatureType.DEFAULT, data: [21, 42], id: QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID };
 			const highlightFeature3 = {
 				type: HighlightFeatureType.DEFAULT,
-				data: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)),
+				data: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON)),
 				id: QUERY_SUCCESS_WITH_GEOMETRY_HIGHLIGHT_FEATURE_ID
 			};
 			const store = setup({
@@ -231,7 +231,7 @@ describe('HighlightPlugin', () => {
 			};
 			const highlightFeature1 = {
 				type: HighlightFeatureType.DEFAULT,
-				data: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON)),
+				data: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON)),
 				id: QUERY_SUCCESS_WITH_GEOMETRY_HIGHLIGHT_FEATURE_ID
 			};
 			const store = setup({
@@ -260,7 +260,7 @@ describe('HighlightPlugin', () => {
 		it('adds a success highlight feature both for FeatureInfos owning a geometry and not', async () => {
 			const coordinate = [21, 42];
 			const geoJson = '{"type":"Point","coordinates":[1224514.3987260093,6106854.83488507]}';
-			const geometry = new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON));
+			const geometry = new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON));
 			const store = setup();
 			const queryId = 'foo';
 			const instanceUnderTest = new HighlightPlugin();
@@ -274,7 +274,7 @@ describe('HighlightPlugin', () => {
 				{
 					title: 'title1',
 					content: 'content1',
-					geometry: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
+					geometry: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
 				}
 			]);
 			resolveQuery(queryId);
@@ -291,7 +291,7 @@ describe('HighlightPlugin', () => {
 		it('does NOT add a success highlight feature when containing solely FeatureInfo objects owning a geometry', async () => {
 			const coordinate = [21, 42];
 			const geoJson = '{"type":"Point","coordinates":[1224514.3987260093,6106854.83488507]}';
-			const geometry = new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON));
+			const geometry = new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON));
 			const store = setup();
 			const queryId = 'foo';
 			const instanceUnderTest = new HighlightPlugin();
@@ -303,7 +303,7 @@ describe('HighlightPlugin', () => {
 			addFeatureInfoItems({
 				title: 'title1',
 				content: 'content1',
-				geometry: new Geometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
+				geometry: new BaGeometry(geoJson, new SourceType(SourceTypeName.GEOJSON))
 			});
 			resolveQuery(queryId);
 

--- a/test/service/provider/featureInfo.provider.test.js
+++ b/test/service/provider/featureInfo.provider.test.js
@@ -275,7 +275,7 @@ describe('FeatureInfoResult provider', () => {
 				expect(featureInfoResult.content).toBe(content);
 				expect(featureInfoResult.title).toBe(title);
 				expect(featureInfoResult.geometry.data).toBe(geoJson);
-				expect(featureInfoResult.geometry.sourceType).toEqual(new SourceType(SourceTypeName.GEOJSON));
+				expect(featureInfoResult.geometry.sourceType).toEqual(SourceType.forGeoJSON());
 			});
 
 			it('loads a FeatureInfoResult without a geometry', async () => {

--- a/test/service/provider/featureInfo.provider.test.js
+++ b/test/service/provider/featureInfo.provider.test.js
@@ -4,7 +4,7 @@ import { MediaType } from '../../../src/domain/mediaTypes';
 import { loadBvvFeatureInfo } from '../../../src/services/provider/featureInfo.provider';
 import { TestUtils } from '../../test-utils';
 import { positionReducer } from '../../../src/store/position/position.reducer';
-import { SourceType, SourceTypeName } from '../../../src/domain/sourceType';
+import { SourceType } from '../../../src/domain/sourceType';
 
 describe('FeatureInfoResult provider', () => {
 	describe('Bvv FeatureInfoResult provider', () => {

--- a/test/store/featureCollection/featureCollection.reducer.test.js
+++ b/test/store/featureCollection/featureCollection.reducer.test.js
@@ -2,7 +2,7 @@ import { BaFeature } from '../../../src/domain/feature.js';
 import { featureCollectionReducer } from '../../../src/store/featureCollection/featureCollection.reducer.js';
 import { addFeatures, clearFeatures, removeFeaturesById } from '../../../src/store/featureCollection/featureCollection.action.js';
 import { TestUtils } from '../../test-utils.js';
-import { Geometry } from '../../../src/domain/geometry.js';
+import { BaGeometry } from '../../../src/domain/geometry.js';
 import { SourceType, SourceTypeName } from '../../../src/domain/sourceType.js';
 
 describe('featureCollectionReducer', () => {
@@ -19,7 +19,7 @@ describe('featureCollectionReducer', () => {
 
 	it("changes the 'entries' property by adding and removing features", () => {
 		const store = setup();
-		const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+		const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 		addFeatures([]);
 
@@ -51,7 +51,7 @@ describe('featureCollectionReducer', () => {
 
 	it("changes the 'entries` property by clearing all features", () => {
 		const store = setup();
-		const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+		const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 		addFeatures(feature);
 
@@ -64,7 +64,7 @@ describe('featureCollectionReducer', () => {
 
 	it('does NOT modify the feature id if already present', () => {
 		const store = setup();
-		const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+		const feature = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 		addFeatures(feature);
 
@@ -74,9 +74,9 @@ describe('featureCollectionReducer', () => {
 	it("changes the 'entries' property by removing a features by its id", () => {
 		const id = 'foo';
 		const store = setup();
-		const feature0 = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), id);
+		const feature0 = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), id);
 		//a second feature with the same id
-		const feature1 = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), id);
+		const feature1 = new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), id);
 
 		addFeatures(feature0);
 
@@ -85,7 +85,7 @@ describe('featureCollectionReducer', () => {
 		expect(store.getState().featureCollection.entries).toHaveSize(0);
 
 		addFeatures([feature0, feature1]);
-		addFeatures(new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id'));
+		addFeatures(new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'id'));
 
 		removeFeaturesById(id);
 
@@ -94,7 +94,7 @@ describe('featureCollectionReducer', () => {
 
 		clearFeatures();
 		addFeatures([feature0, feature1]);
-		addFeatures(new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'bar'));
+		addFeatures(new BaFeature(new BaGeometry('data', new SourceType(SourceTypeName.EWKT)), 'bar'));
 
 		removeFeaturesById([id, 'bar']);
 

--- a/test/store/featureCollection/featureCollection.reducer.test.js
+++ b/test/store/featureCollection/featureCollection.reducer.test.js
@@ -1,4 +1,4 @@
-import { Feature } from '../../../src/domain/feature.js';
+import { BaFeature } from '../../../src/domain/feature.js';
 import { featureCollectionReducer } from '../../../src/store/featureCollection/featureCollection.reducer.js';
 import { addFeatures, clearFeatures, removeFeaturesById } from '../../../src/store/featureCollection/featureCollection.action.js';
 import { TestUtils } from '../../test-utils.js';
@@ -19,7 +19,7 @@ describe('featureCollectionReducer', () => {
 
 	it("changes the 'entries' property by adding and removing features", () => {
 		const store = setup();
-		const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+		const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 		addFeatures([]);
 
@@ -51,7 +51,7 @@ describe('featureCollectionReducer', () => {
 
 	it("changes the 'entries` property by clearing all features", () => {
 		const store = setup();
-		const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+		const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 		addFeatures(feature);
 
@@ -64,7 +64,7 @@ describe('featureCollectionReducer', () => {
 
 	it('does NOT modify the feature id if already present', () => {
 		const store = setup();
-		const feature = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
+		const feature = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id');
 
 		addFeatures(feature);
 
@@ -74,9 +74,9 @@ describe('featureCollectionReducer', () => {
 	it("changes the 'entries' property by removing a features by its id", () => {
 		const id = 'foo';
 		const store = setup();
-		const feature0 = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), id);
+		const feature0 = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), id);
 		//a second feature with the same id
-		const feature1 = new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), id);
+		const feature1 = new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), id);
 
 		addFeatures(feature0);
 
@@ -85,7 +85,7 @@ describe('featureCollectionReducer', () => {
 		expect(store.getState().featureCollection.entries).toHaveSize(0);
 
 		addFeatures([feature0, feature1]);
-		addFeatures(new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id'));
+		addFeatures(new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'id'));
 
 		removeFeaturesById(id);
 
@@ -94,7 +94,7 @@ describe('featureCollectionReducer', () => {
 
 		clearFeatures();
 		addFeatures([feature0, feature1]);
-		addFeatures(new Feature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'bar'));
+		addFeatures(new BaFeature(new Geometry('data', new SourceType(SourceTypeName.EWKT)), 'bar'));
 
 		removeFeaturesById([id, 'bar']);
 


### PR DESCRIPTION
- [x] `VectorGeoResource` can have `BaFeature`s as data source
- [x] rename `Feature` to `BaFeature`; `Geometry` to `BaGeometry`
- [x] introduce a generic `StyleHint` which can be applied to a `VectorGeoresource`, `RtVectorGeoresource` or `BaFeature`
- [x] extend the `StyleService` for that purpose
- [x] improve jsdoc for all `GeoResources` 