### PR TITLE
refactor StyleService

### DIFF
--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -14,7 +14,12 @@ import {
 	getSizeFrom,
 	getSymbolFrom,
 	getTextFrom,
-	selectStyleFunction
+	lineStyleFunction,
+	markerStyleFunction,
+	nullStyleFunction,
+	polygonStyleFunction,
+	selectStyleFunction,
+	textStyleFunction
 } from '../../utils/olStyleUtils';
 import { StyleTypes } from '../../services/StyleService';
 import { StyleSize } from '../../../../domain/styles';
@@ -499,8 +504,7 @@ export class OlDrawHandler extends OlLayerHandler {
 				if (description) {
 					this._sketchHandler.active.set('description', description);
 				}
-				const styleFunction = this._getStyleFunctionByDrawType(type, this._getStyleOption());
-				const styles = styleFunction(this._sketchHandler.active);
+				const styles = this._getStyleFunctionByDrawType(type, this._getStyleOption());
 				this._sketchHandler.active.setStyle(styles);
 				this._drawingListeners.push(event.feature.on('change', onFeatureChange));
 			});
@@ -717,12 +721,19 @@ export class OlDrawHandler extends OlLayerHandler {
 	}
 
 	_getStyleFunctionByDrawType(drawType, styleOption) {
-		const drawTypes = [StyleTypes.POINT, StyleTypes.MARKER, StyleTypes.TEXT, StyleTypes.LINE, StyleTypes.POLYGON];
-		if (drawTypes.includes(drawType)) {
-			const styleFunction = this._styleService.getStyleFunction(drawType);
-			return () => styleFunction(styleOption);
+		switch (drawType) {
+			case StyleTypes.LINE:
+				return lineStyleFunction(styleOption);
+			case StyleTypes.POLYGON:
+				return polygonStyleFunction(styleOption);
+			case StyleTypes.POINT:
+			case StyleTypes.MARKER:
+				return markerStyleFunction(styleOption);
+			case StyleTypes.TEXT:
+				return textStyleFunction(styleOption);
+			default:
+				return nullStyleFunction();
 		}
-		return this._styleService.getStyleFunction(StyleTypes.DRAW);
 	}
 
 	_updateStatistic() {
@@ -791,8 +802,7 @@ export class OlDrawHandler extends OlLayerHandler {
 		if (this._drawState.type === InteractionStateType.MODIFY && this._select.getFeatures().getLength() > 0) {
 			const feature = this._select.getFeatures().item(0);
 
-			const styleFunction = this._getStyleFunctionFrom(feature);
-			const newStyles = styleFunction(feature);
+			const newStyles = this._getStyleFunctionFrom(feature);
 
 			feature.setStyle([newStyles[0], ...feature.getStyle().slice(1)]);
 			this._setSelected(feature);
@@ -800,8 +810,7 @@ export class OlDrawHandler extends OlLayerHandler {
 
 		if (this._drawState.type === InteractionStateType.DRAW) {
 			if (this._sketchHandler.isActive) {
-				const styleFunction = this._getStyleFunctionFrom(this._sketchHandler.active);
-				const newStyles = styleFunction(this._sketchHandler.active);
+				const newStyles = this._getStyleFunctionFrom(this._sketchHandler.active);
 				this._sketchHandler.active.setStyle(newStyles);
 			}
 		}

--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -8,18 +8,18 @@ import { Vector as VectorLayer } from 'ol/layer';
 import { $injector } from '../../../../injection';
 import { Draw, Modify, Select, Snap } from 'ol/interaction';
 import {
-	createSketchStyleFunction,
+	getSketchStyleFunction,
 	getColorFrom,
 	getDrawingTypeFrom,
 	getSizeFrom,
 	getSymbolFrom,
 	getTextFrom,
-	lineStyleFunction,
-	markerStyleFunction,
-	nullStyleFunction,
-	polygonStyleFunction,
-	selectStyleFunction,
-	textStyleFunction
+	getLineStyleArray,
+	getMarkerStyleArray,
+	getNullStyleArray,
+	getPolygonStyleArray,
+	getSelectStyleFunction,
+	getTextStyleArray
 } from '../../utils/olStyleUtils';
 import { StyleTypes } from '../../services/StyleService';
 import { StyleSize } from '../../../../domain/styles';
@@ -612,7 +612,7 @@ export class OlDrawHandler extends OlLayerHandler {
 					source: source,
 					type: 'LineString',
 					snapTolerance: snapTolerance,
-					style: createSketchStyleFunction(this._getStyleFunctionByDrawType('line', styleOption)),
+					style: getSketchStyleFunction(this._getStyleFunctionByDrawType('line', styleOption)),
 					wrapX: true
 				});
 			case StyleTypes.POLYGON:
@@ -621,7 +621,7 @@ export class OlDrawHandler extends OlLayerHandler {
 					type: 'Polygon',
 					minPoints: 3,
 					snapTolerance: snapTolerance,
-					style: createSketchStyleFunction(this._getStyleFunctionByDrawType('polygon', styleOption)),
+					style: getSketchStyleFunction(this._getStyleFunctionByDrawType('polygon', styleOption)),
 					wrapX: true
 				});
 			default:
@@ -633,7 +633,7 @@ export class OlDrawHandler extends OlLayerHandler {
 		const select = new Select(getSelectOptions(this._vectorLayer));
 		select.getFeatures().on('add', (e) => {
 			const feature = e.element;
-			const styleFunction = selectStyleFunction();
+			const styleFunction = getSelectStyleFunction();
 			const styles = styleFunction(feature);
 			e.element.setStyle(styles);
 		});
@@ -723,16 +723,16 @@ export class OlDrawHandler extends OlLayerHandler {
 	_getStyleFunctionByDrawType(drawType, styleOption) {
 		switch (drawType) {
 			case StyleTypes.LINE:
-				return lineStyleFunction(styleOption);
+				return getLineStyleArray(styleOption);
 			case StyleTypes.POLYGON:
-				return polygonStyleFunction(styleOption);
+				return getPolygonStyleArray(styleOption);
 			case StyleTypes.POINT:
 			case StyleTypes.MARKER:
-				return markerStyleFunction(styleOption);
+				return getMarkerStyleArray(styleOption);
 			case StyleTypes.TEXT:
-				return textStyleFunction(styleOption);
+				return getTextStyleArray(styleOption);
 			default:
-				return nullStyleFunction();
+				return getNullStyleArray();
 		}
 	}
 

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -10,7 +10,7 @@ import { $injector } from '../../../../injection';
 import { OlLayerHandler } from '../OlLayerHandler';
 import { setStatistic, setMode, setSelection, setDisplayRuler } from '../../../../store/measurement/measurement.action';
 import { addLayer, removeLayer } from '../../../../store/layers/layers.action';
-import { createSketchStyleFunction, measureStyleFunction, selectStyleFunction } from '../../utils/olStyleUtils';
+import { getSketchStyleFunction, measureStyleFunction, getSelectStyleFunction } from '../../utils/olStyleUtils';
 import { getLineString, getStats, PROJECTED_LENGTH_GEOMETRY_PROPERTY } from '../../utils/olGeometryUtils';
 import MapBrowserEventType from 'ol/MapBrowserEventType';
 import { observe } from '../../../../utils/storeUtils';
@@ -492,7 +492,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			type: 'Polygon',
 			minPoints: 2,
 			snapTolerance: getSnapTolerancePerDevice(),
-			style: createSketchStyleFunction(measureStyleFunction, this._getSketchStyleOptions()),
+			style: getSketchStyleFunction(measureStyleFunction, this._getSketchStyleOptions()),
 			wrapX: true
 		});
 
@@ -555,7 +555,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		select.getFeatures().on('change:length', this._updateStatistic);
 		select.getFeatures().on('add', (e) => {
 			const feature = e.element;
-			const styleFunction = selectStyleFunction();
+			const styleFunction = getSelectStyleFunction();
 			const styles = styleFunction(feature, getResolution());
 			e.element.setStyle(styles);
 		});

--- a/src/modules/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/olMap/handler/measure/OlMeasurementHandler.js
@@ -142,7 +142,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			const source = new VectorSource({ wrapX: true, useSpatialIndex: false });
 			const layer = new VectorLayer({
 				source: source,
-				style: this._styleService.getStyleFunction(StyleTypes.MEASURE)
+				style: measureStyleFunction
 			});
 			layer.label = translate('olMap_handler_draw_layer_label');
 			return layer;
@@ -487,13 +487,12 @@ export class OlMeasurementHandler extends OlLayerHandler {
 	}
 
 	_createDraw(source) {
-		const measureFeatureStyleFunction = this._styleService.getStyleFunction(StyleTypes.MEASURE);
 		const draw = new Draw({
 			source: source,
 			type: 'Polygon',
 			minPoints: 2,
 			snapTolerance: getSnapTolerancePerDevice(),
-			style: createSketchStyleFunction(measureFeatureStyleFunction, this._getSketchStyleOptions()),
+			style: createSketchStyleFunction(measureStyleFunction, this._getSketchStyleOptions()),
 			wrapX: true
 		});
 

--- a/src/modules/olMap/services/StyleService.js
+++ b/src/modules/olMap/services/StyleService.js
@@ -6,9 +6,6 @@ import { $injector } from '../../../injection';
 import { getContrastColorFrom, rgbToHex } from '../../../utils/colors';
 import {
 	measureStyleFunction,
-	nullStyleFunction,
-	lineStyleFunction,
-	polygonStyleFunction,
 	textStyleFunction,
 	markerScaleToKeyword,
 	getStyleArray,
@@ -18,7 +15,6 @@ import {
 	markerStyleFunction,
 	getTransparentImageStyle
 } from '../utils/olStyleUtils';
-import { isFunction } from '../../../utils/checks';
 import { getRoutingStyleFunction } from '../handler/routing/styleUtils';
 import { GeometryCollection, MultiPoint, Point } from '../../../../node_modules/ol/geom';
 import { Stroke, Style, Text } from '../../../../node_modules/ol/style';
@@ -188,49 +184,6 @@ export class StyleService {
 		const usingStyleType = this._detectStyleType(olFeature);
 		const { OverlayService: overlayService } = $injector.inject('OverlayService');
 		overlayService.remove(olFeature, olMap, usingStyleType);
-	}
-
-	/**
-	 * Returns a {@link ol.style.StyleFunction} for the specified {@link StyleTypes}
-	 * @param {StyleTypes} styleType
-	 * @returns {Function} the {@link ol.style.StyleFunction}, used by ol to render a feature
-	 */
-	getStyleFunction(styleType) {
-		switch (styleType) {
-			case StyleTypes.NULL:
-				return nullStyleFunction;
-			case StyleTypes.MEASURE:
-				return measureStyleFunction;
-			case StyleTypes.LINE:
-				return lineStyleFunction;
-			case StyleTypes.POLYGON:
-				return polygonStyleFunction;
-			case StyleTypes.POINT:
-			case StyleTypes.MARKER:
-				return markerStyleFunction;
-			case StyleTypes.TEXT:
-				return textStyleFunction;
-			case StyleTypes.DRAW:
-				return nullStyleFunction;
-			case StyleTypes.GEOJSON:
-				return geojsonStyleFunction;
-			case StyleTypes.DEFAULT:
-				return defaultStyleFunction;
-			default:
-				console.warn('Could not provide a style for unknown style-type:', styleType);
-		}
-	}
-
-	/**
-	 * Returns a {@link ol.style.StyleFunction} for a specified {@link StyleTypes}
-	 * @param {StyleTypes} styleType
-	 * @returns {Function|null} the {@link ol.style.StyleFunction} or `null`
-	 */
-	getFeatureStyleFunction(styleType) {
-		return (feature, resolution) => {
-			const result = this.getStyleFunction(styleType);
-			return isFunction(result) ? result(feature, resolution) : result;
-		};
 	}
 
 	/**

--- a/src/modules/olMap/services/StyleService.js
+++ b/src/modules/olMap/services/StyleService.js
@@ -6,13 +6,13 @@ import { $injector } from '../../../injection';
 import { getContrastColorFrom, rgbToHex } from '../../../utils/colors';
 import {
 	measureStyleFunction,
-	textStyleFunction,
+	getTextStyleArray,
 	markerScaleToKeyword,
 	getStyleArray,
-	geojsonStyleFunction,
-	defaultStyleFunction,
+	getGeojsonStyleArray,
+	getDefaultStyleFunction,
 	defaultClusterStyleFunction,
-	markerStyleFunction,
+	getMarkerStyleArray,
 	getTransparentImageStyle
 } from '../utils/olStyleUtils';
 import { getRoutingStyleFunction } from '../handler/routing/styleUtils';
@@ -301,7 +301,7 @@ export class StyleService {
 	}
 
 	_addGeoJSONStyle(olFeature) {
-		olFeature.setStyle(geojsonStyleFunction);
+		olFeature.setStyle(getGeojsonStyleArray);
 	}
 
 	_addTextStyle(olFeature) {
@@ -321,7 +321,7 @@ export class StyleService {
 			return styles ? fromStyle(styles[0]) : fromAttribute(olFeature);
 		};
 
-		const newStyle = textStyleFunction(getStyleOption());
+		const newStyle = getTextStyleArray(getStyleOption());
 
 		olFeature.setStyle(() => newStyle);
 	}
@@ -355,7 +355,7 @@ export class StyleService {
 			return styles ? fromStyle(styles[0]) : fromAttribute(olFeature);
 		};
 
-		const newStyle = markerStyleFunction(getStyleOption(olFeature));
+		const newStyle = getMarkerStyleArray(getStyleOption(olFeature));
 
 		olFeature.setStyle(() => newStyle);
 	}
@@ -380,7 +380,7 @@ export class StyleService {
 		};
 
 		const color = olLayer && !isGPX(olLayer) ? getColorByLayerId(olLayer) : this._nextColor();
-		olFeature.setStyle(defaultStyleFunction(color));
+		olFeature.setStyle(getDefaultStyleFunction(color));
 	}
 
 	_detectStyleType(olFeature) {

--- a/src/modules/olMap/utils/olStyleUtils.js
+++ b/src/modules/olMap/utils/olStyleUtils.js
@@ -134,8 +134,10 @@ export const getMarkerSrc = (symbolSrc = null, symbolColor = '#ffffff') => {
 	return getIconUrl(Default_Symbol);
 };
 
+// TODO: --> no StyleFunction!
 export const nullStyleFunction = () => [new Style({})];
 
+// TODO: --> no StyleFunction!
 /**
  * A StyleFunction which returns styles based on styling properties of the feature
  * according to {@see https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0| simpleStyle spec 1.1.0}.
@@ -293,6 +295,7 @@ export const defaultClusterStyleFunction = () => {
 	};
 };
 
+// TODO: --> no StyleFunction!
 /**
  * Function to style a marker symbol
  * @param {null|StyleOption} styleOption the styleOption
@@ -335,6 +338,7 @@ export const markerStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
 	];
 };
 
+// TODO: --> no StyleFunction!
 /**
  * Function to style a text symbol
  * @param {StyleOption} styleOption the styleOption
@@ -353,6 +357,7 @@ export const textStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
 	];
 };
 
+// TODO: --> no StyleFunction!
 /**
  * Function to style a line geometry
  * @param {StyleOption} styleOption the styleOption
@@ -668,6 +673,7 @@ export const modifyStyleFunction = (feature) => {
 	];
 };
 
+// TODO: --> no StyleFunction!
 export const selectStyleFunction = () => {
 	const constructionStroke = new Stroke({
 		color: Black_Color.concat([1]),
@@ -727,6 +733,7 @@ export const selectStyleFunction = () => {
 	};
 };
 
+// TODO: --> no StyleFunction!
 /**
  * returns the default styleFunction, based on the specified color
  * @param {Array<number>} color the rgba-color An Array of numbers, defining a RGBA-Color with [Red{0,255},Green{0,255},Blue{0,255},Alpha{0,1}]

--- a/src/modules/olMap/utils/olStyleUtils.js
+++ b/src/modules/olMap/utils/olStyleUtils.js
@@ -134,10 +134,8 @@ export const getMarkerSrc = (symbolSrc = null, symbolColor = '#ffffff') => {
 	return getIconUrl(Default_Symbol);
 };
 
-// TODO: --> no StyleFunction!
-export const nullStyleFunction = () => [new Style({})];
+export const getNullStyleArray = () => [new Style({})];
 
-// TODO: --> no StyleFunction!
 /**
  * A StyleFunction which returns styles based on styling properties of the feature
  * according to {@see https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0| simpleStyle spec 1.1.0}.
@@ -147,7 +145,7 @@ export const nullStyleFunction = () => [new Style({})];
  * @param {ol.Feature} feature the olFeature to be styled
  * @returns {Array<Style>}
  */
-export const geojsonStyleFunction = (feature) => {
+export const getGeojsonStyleArray = (feature) => {
 	// default style properties based on simpleStyle spec
 	// hint: 'marker-symbol' is currently not supported
 	const defaultStyleProperties = {
@@ -295,13 +293,12 @@ export const defaultClusterStyleFunction = () => {
 	};
 };
 
-// TODO: --> no StyleFunction!
 /**
  * Function to style a marker symbol
  * @param {null|StyleOption} styleOption the styleOption
  * @returns {Array<Style>} the resulting array of marker styles
  */
-export const markerStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
+export const getMarkerStyleArray = (styleOption = DEFAULT_STYLE_OPTION) => {
 	const markerColor = styleOption.color ? styleOption.color : '#ff0000';
 	const markerAnchor = styleOption.anchor ? styleOption.anchor : [0.5, 0.5];
 	const rasterIconOptions = {
@@ -338,13 +335,12 @@ export const markerStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
 	];
 };
 
-// TODO: --> no StyleFunction!
 /**
  * Function to style a text symbol
  * @param {StyleOption} styleOption the styleOption
  * @returns {Array<Style>}  the resulting array of text styles
  */
-export const textStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
+export const getTextStyleArray = (styleOption = DEFAULT_STYLE_OPTION) => {
 	const strokeColor = styleOption.color ? styleOption.color : '#ff0000';
 	const textContent = isString(styleOption.text) ? styleOption.text : DEFAULT_TEXT;
 
@@ -357,13 +353,12 @@ export const textStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
 	];
 };
 
-// TODO: --> no StyleFunction!
 /**
  * Function to style a line geometry
  * @param {StyleOption} styleOption the styleOption
  * @returns the resulting array of line styles
  */
-export const lineStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
+export const getLineStyleArray = (styleOption = DEFAULT_STYLE_OPTION) => {
 	const strokeColor = styleOption.color ? hexToRgb(styleOption.color) : hexToRgb('#ff0000');
 	const strokeWidth = 3;
 	// TODO: activate TextStyle with:
@@ -385,7 +380,7 @@ export const lineStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
  * @param {StyleOption} styleOption the styleOption
  * @returns the resulting array of polygon styles
  */
-export const polygonStyleFunction = (styleOption = DEFAULT_STYLE_OPTION) => {
+export const getPolygonStyleArray = (styleOption = DEFAULT_STYLE_OPTION) => {
 	const strokeColor = styleOption.color ? hexToRgb(styleOption.color) : hexToRgb('#ff0000');
 	const strokeWidth = 3;
 	// TODO: activate TextStyle with:
@@ -673,8 +668,7 @@ export const modifyStyleFunction = (feature) => {
 	];
 };
 
-// TODO: --> no StyleFunction!
-export const selectStyleFunction = () => {
+export const getSelectStyleFunction = () => {
 	const constructionStroke = new Stroke({
 		color: Black_Color.concat([1]),
 		width: 1,
@@ -733,13 +727,12 @@ export const selectStyleFunction = () => {
 	};
 };
 
-// TODO: --> no StyleFunction!
 /**
  * returns the default styleFunction, based on the specified color
  * @param {Array<number>} color the rgba-color An Array of numbers, defining a RGBA-Color with [Red{0,255},Green{0,255},Blue{0,255},Alpha{0,1}]
  * @returns {Function} the default styleFunction
  */
-export const defaultStyleFunction = (color) => {
+export const getDefaultStyleFunction = (color) => {
 	const colorRGBA = color;
 	const colorRGB = color.slice(0, -1);
 
@@ -812,7 +805,7 @@ export const getTransparentImageStyle = () => {
 	});
 };
 
-export const createSketchStyleFunction = (featureStyleFunction, sketchStyleFunctionsByGeometry = {}) => {
+export const getSketchStyleFunction = (featureStyleFunction, sketchStyleFunctionsByGeometry = {}) => {
 	const defaultSketchStyles = {
 		Point: () => [
 			new Style({

--- a/test/modules/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/olMap/handler/draw/OlDrawHandler.test.js
@@ -72,7 +72,7 @@ describe('OlDrawHandler', () => {
 
 	const translationServiceMock = { translate: (key, params = []) => `${key}${params.length ? ` [${params.join(',')}]` : ''}` };
 	const environmentServiceMock = { isTouch: () => false, isStandalone: () => false, isEmbedded: () => false };
-	const iconServiceMock = { getDefault: () => new IconResult('foo', 'bar') };
+	const iconServiceMock = { getDefault: () => new IconResult('foo', 'bar'), decodeColor: () => {} };
 
 	const initialDrawState = {
 		active: false,
@@ -1038,7 +1038,7 @@ describe('OlDrawHandler', () => {
 				);
 				spyOn(classUnderTest, '_getStyleFunctionFrom')
 					.withArgs(feature)
-					.and.callFake(() => () => [newStyle]);
+					.and.callFake(() => [newStyle]);
 				feature.setId('draw_Symbol_1234');
 				feature.setStyle([oldStyle1, oldStyle2]);
 				const drawStateFake = {
@@ -1267,12 +1267,12 @@ describe('OlDrawHandler', () => {
 				setup();
 				const classUnderTest = new OlDrawHandler();
 
-				expect(classUnderTest._getStyleFunctionByDrawType('point', defaultStyleOption)()).toContain(jasmine.any(Style));
-				expect(classUnderTest._getStyleFunctionByDrawType('marker', defaultStyleOption)()).toContain(jasmine.any(Style));
-				expect(classUnderTest._getStyleFunctionByDrawType('text', defaultStyleOption)()).toContain(jasmine.any(Style));
-				expect(classUnderTest._getStyleFunctionByDrawType('line', defaultStyleOption)()).toContain(jasmine.any(Style));
-				expect(classUnderTest._getStyleFunctionByDrawType('polygon', defaultStyleOption)()).toContain(jasmine.any(Style));
-				expect(classUnderTest._getStyleFunctionByDrawType('foo', defaultStyleOption)()).toContain(jasmine.any(Style));
+				expect(classUnderTest._getStyleFunctionByDrawType('point', defaultStyleOption)).toContain(jasmine.any(Style));
+				expect(classUnderTest._getStyleFunctionByDrawType('marker', defaultStyleOption)).toContain(jasmine.any(Style));
+				expect(classUnderTest._getStyleFunctionByDrawType('text', defaultStyleOption)).toContain(jasmine.any(Style));
+				expect(classUnderTest._getStyleFunctionByDrawType('line', defaultStyleOption)).toContain(jasmine.any(Style));
+				expect(classUnderTest._getStyleFunctionByDrawType('polygon', defaultStyleOption)).toContain(jasmine.any(Style));
+				expect(classUnderTest._getStyleFunctionByDrawType('foo', defaultStyleOption)).toContain(jasmine.any(Style));
 			});
 		});
 	});

--- a/test/modules/olMap/services/StyleService.test.js
+++ b/test/modules/olMap/services/StyleService.test.js
@@ -1194,60 +1194,6 @@ describe('StyleService', () => {
 		});
 	});
 
-	describe('getStyleFunction', () => {
-		it('returns a StyleFunction for a valid StyleType', () => {
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.NULL)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.MEASURE)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.POINT)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.MARKER)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.TEXT)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.LINE)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.POLYGON)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.DRAW)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.DEFAULT)).toEqual(jasmine.any(Function));
-			expect(instanceUnderTest.getStyleFunction(StyleTypes.GEOJSON)).toEqual(jasmine.any(Function));
-		});
-
-		it('fails for a invalid StyleType', () => {
-			const warnSpy = spyOn(console, 'warn');
-
-			const styleFunction = instanceUnderTest.getStyleFunction('unknown');
-
-			expect(styleFunction).toBeUndefined();
-			expect(warnSpy).toHaveBeenCalledWith('Could not provide a style for unknown style-type:', 'unknown');
-		});
-	});
-
-	describe('getFeatureStyleFunction', () => {
-		describe('#getStyle returns a style function', () => {
-			it('returns a style function', () => {
-				const style = new Style();
-				const feature = new Feature();
-				const resolution = 42;
-				const spy = jasmine.createSpy().and.returnValue(style);
-				spyOn(instanceUnderTest, 'getStyleFunction').withArgs(StyleTypes.ROUTING).and.returnValue(spy);
-
-				const result = instanceUnderTest.getFeatureStyleFunction(StyleTypes.ROUTING)(feature, resolution);
-
-				expect(spy).toHaveBeenCalledOnceWith(feature, resolution);
-				expect(result).toEqual(style);
-			});
-		});
-
-		describe('#getStyle returns a style', () => {
-			it('returns a style function', () => {
-				const style = new Style();
-				const feature = new Feature();
-				const resolution = 42;
-				spyOn(instanceUnderTest, 'getStyleFunction').withArgs(StyleTypes.ROUTING).and.returnValue(style);
-
-				const result = instanceUnderTest.getFeatureStyleFunction(StyleTypes.ROUTING)(feature, resolution);
-
-				expect(result).toEqual(style);
-			});
-		});
-	});
-
 	describe('removes styles', () => {
 		it('removes a style from measure feature', () => {
 			const feature = new Feature({

--- a/test/modules/olMap/util/olStyleUtils.test.js
+++ b/test/modules/olMap/util/olStyleUtils.test.js
@@ -1,14 +1,7 @@
 import {
 	measureStyleFunction,
-	createSketchStyleFunction,
 	modifyStyleFunction,
-	nullStyleFunction,
-	markerStyleFunction,
-	selectStyleFunction,
 	getColorFrom,
-	lineStyleFunction,
-	polygonStyleFunction,
-	textStyleFunction,
 	getIconUrl,
 	getMarkerSrc,
 	getDrawingTypeFrom,
@@ -17,14 +10,21 @@ import {
 	getTextFrom,
 	getStyleArray,
 	renderLinearRulerSegments,
-	defaultStyleFunction,
 	defaultClusterStyleFunction,
-	geojsonStyleFunction,
 	DEFAULT_TEXT,
 	getSizeFrom,
 	textScaleToKeyword,
 	getTransparentImageStyle,
-	renderGeodesicRulerSegments
+	renderGeodesicRulerSegments,
+	getNullStyleArray,
+	getGeojsonStyleArray,
+	getDefaultStyleFunction,
+	getMarkerStyleArray,
+	getTextStyleArray,
+	getLineStyleArray,
+	getPolygonStyleArray,
+	getSelectStyleFunction,
+	getSketchStyleFunction
 } from '../../../../src/modules/olMap/utils/olStyleUtils';
 import { Point, LineString, Polygon, Geometry, MultiLineString, MultiPolygon } from 'ol/geom';
 import { Feature } from 'ol';
@@ -668,18 +668,18 @@ describe('renderGeodesicRulerSegments', () => {
 	});
 });
 
-describe('nullStyleFunction', () => {
+describe('getNullStyleArray', () => {
 	it('should return a style', () => {
-		const styles = nullStyleFunction();
+		const styles = getNullStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles.length).toBe(1);
 	});
 });
 
-describe('geojsonStyleFunction', () => {
+describe('getGeojsonStyleArray', () => {
 	it('should return a default style', () => {
-		const styles = geojsonStyleFunction();
+		const styles = getGeojsonStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles.length).toBe(1);
@@ -696,10 +696,10 @@ describe('geojsonStyleFunction', () => {
 		const largePointFeature = getFeatureWithProperties({ 'marker-size': 'large', 'marker-color': '#0000ff' });
 		const numberMarkerSizePointFeature = getFeatureWithProperties({ 'marker-size': 42, 'marker-color': '#0000ff' });
 
-		const smallPointStyles = geojsonStyleFunction(smallPointFeature);
-		const mediumPointStyles = geojsonStyleFunction(mediumPointFeature);
-		const largePointStyles = geojsonStyleFunction(largePointFeature);
-		const numberMarkerSizePointStyle = geojsonStyleFunction(numberMarkerSizePointFeature);
+		const smallPointStyles = getGeojsonStyleArray(smallPointFeature);
+		const mediumPointStyles = getGeojsonStyleArray(mediumPointFeature);
+		const largePointStyles = getGeojsonStyleArray(largePointFeature);
+		const numberMarkerSizePointStyle = getGeojsonStyleArray(numberMarkerSizePointFeature);
 
 		expect(smallPointStyles).toBeDefined();
 		expect(smallPointStyles.length).toBe(1);
@@ -725,7 +725,7 @@ describe('geojsonStyleFunction', () => {
 	it('should return a stroke style', () => {
 		const lineFeature = getFeatureWithProperties({ 'stroke-opacity': 0.42, stroke: '#ffff00', 'stroke-width': 4 });
 
-		const lineStyles = geojsonStyleFunction(lineFeature);
+		const lineStyles = getGeojsonStyleArray(lineFeature);
 
 		expect(lineStyles).toBeDefined();
 		expect(lineStyles.length).toBe(1);
@@ -736,7 +736,7 @@ describe('geojsonStyleFunction', () => {
 	it('should return a fill style', () => {
 		const lineFeature = getFeatureWithProperties({ 'fill-opacity': 0.21, fill: '#00ff00' });
 
-		const lineStyles = geojsonStyleFunction(lineFeature);
+		const lineStyles = getGeojsonStyleArray(lineFeature);
 
 		expect(lineStyles).toBeDefined();
 		expect(lineStyles.length).toBe(1);
@@ -744,9 +744,9 @@ describe('geojsonStyleFunction', () => {
 	});
 });
 
-describe('defaultStyleFunction', () => {
+describe('getDefaultStyleFunction', () => {
 	it('should return a style with color', () => {
-		const styleFunction = defaultStyleFunction([0, 0, 0, 0]);
+		const styleFunction = getDefaultStyleFunction([0, 0, 0, 0]);
 		const getFeatureMock = (geometryType) => {
 			const geometryMock = { getType: () => geometryType };
 			return { getGeometry: () => geometryMock };
@@ -778,9 +778,9 @@ describe('defaultStyleFunction', () => {
 	});
 });
 
-describe('markerStyleFunction', () => {
+describe('getMarkerStyleArray', () => {
 	it('should return a style', () => {
-		const styles = markerStyleFunction();
+		const styles = getMarkerStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles.length).toBe(1);
@@ -788,7 +788,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style with a default Image for offline-modus', () => {
 		spyOn(environmentService, 'isStandalone').and.returnValue(true);
-		const styles = markerStyleFunction();
+		const styles = getMarkerStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getImage().getSrc()).toBe(markerIcon);
@@ -797,7 +797,7 @@ describe('markerStyleFunction', () => {
 	it('should return a style with a default Image', () => {
 		const styleOption = { color: '#BEDA55', scale: 'small' };
 		spyOn(environmentService, 'isStandalone').and.returnValue(() => true);
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -811,7 +811,7 @@ describe('markerStyleFunction', () => {
 	it('should return a style with a Text', () => {
 		const styleOption = { color: '#BEDA55', scale: 'small', text: 'foo' };
 		spyOn(environmentService, 'isStandalone').and.returnValue(() => true);
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getText().getText()).toBe('foo');
@@ -822,7 +822,7 @@ describe('markerStyleFunction', () => {
 	it('should return a style WITHOUT a Text', () => {
 		const styleOption = { color: '#BEDA55', scale: 'small' };
 		spyOn(environmentService, 'isStandalone').and.returnValue(() => true);
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getText()).toBeNull();
@@ -830,7 +830,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption; small image', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 'small' };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -842,7 +842,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption with a Text; small image', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 'small', text: 'foo' };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -856,7 +856,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption; medium image', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 'medium' };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -868,7 +868,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption with a Text; medium image', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 'medium', text: 'foo' };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -882,7 +882,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption; large image', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 'large' };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -894,7 +894,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption with a Text; large image', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 'large', text: 'foo' };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -908,7 +908,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified by styleOption; scale value as number', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 0.75 };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -920,7 +920,7 @@ describe('markerStyleFunction', () => {
 
 	it('should return a style specified as remote raster icon', () => {
 		const styleOption = { symbolSrc: 'http://url.to/raster.resource', color: '#BEDA55', scale: 0.75 };
-		const styles = markerStyleFunction(styleOption);
+		const styles = getMarkerStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const image = styles[0].getImage();
@@ -930,16 +930,16 @@ describe('markerStyleFunction', () => {
 	});
 });
 
-describe('textStyleFunction', () => {
+describe('getTextStyleArray', () => {
 	it('should return a style', () => {
-		const styles = textStyleFunction();
+		const styles = getTextStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles.length).toBe(1);
 	});
 
 	it('should return a style with a default Text', () => {
-		const styles = textStyleFunction();
+		const styles = getTextStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getText().getText()).toBe(DEFAULT_TEXT);
@@ -948,7 +948,7 @@ describe('textStyleFunction', () => {
 
 	it('should return a style specified by styleOption; large text', () => {
 		const styleOption = { color: '#BEDA55', scale: 'large', text: 'Foo' };
-		const styles = textStyleFunction(styleOption);
+		const styles = getTextStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const textStyle = styles[0].getText();
@@ -960,7 +960,7 @@ describe('textStyleFunction', () => {
 
 	it('should return a style specified by styleOption; medium text', () => {
 		const styleOption = { color: '#BEDA55', scale: 'medium', text: 'Bar' };
-		const styles = textStyleFunction(styleOption);
+		const styles = getTextStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const textStyle = styles[0].getText();
@@ -972,7 +972,7 @@ describe('textStyleFunction', () => {
 
 	it('should return a style specified by styleOption; small text', () => {
 		const styleOption = { color: '#BEDA55', scale: 'small', text: 'Bar' };
-		const styles = textStyleFunction(styleOption);
+		const styles = getTextStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const textStyle = styles[0].getText();
@@ -984,7 +984,7 @@ describe('textStyleFunction', () => {
 
 	it('should return a style specified by styleOption; text scale as number ', () => {
 		const styleOption = { color: '#BEDA55', scale: 2, text: 'Foo' };
-		const styles = textStyleFunction(styleOption);
+		const styles = getTextStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const textStyle = styles[0].getText();
@@ -995,16 +995,16 @@ describe('textStyleFunction', () => {
 	});
 });
 
-describe('lineStyleFunction', () => {
+describe('getLineStyleArray', () => {
 	it('should return a style', () => {
-		const styles = lineStyleFunction();
+		const styles = getLineStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles.length).toBe(1);
 	});
 
 	it('should return a style with a default Stroke', () => {
-		const styles = lineStyleFunction();
+		const styles = getLineStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getStroke().getWidth()).toBe(3);
@@ -1012,7 +1012,7 @@ describe('lineStyleFunction', () => {
 
 	it('should return a style specified by styleOption', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55', scale: 0.5 };
-		const styles = lineStyleFunction(styleOption);
+		const styles = getLineStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const stroke = styles[0].getStroke();
@@ -1023,16 +1023,16 @@ describe('lineStyleFunction', () => {
 	});
 });
 
-describe('polygonStyleFunction', () => {
+describe('getPolygonStyleArray', () => {
 	it('should return a style', () => {
-		const styles = polygonStyleFunction();
+		const styles = getPolygonStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles.length).toBe(1);
 	});
 
 	it('should return a style with a default Stroke', () => {
-		const styles = polygonStyleFunction();
+		const styles = getPolygonStyleArray();
 
 		expect(styles).toBeDefined();
 		expect(styles[0].getStroke().getWidth()).toBe(3);
@@ -1040,7 +1040,7 @@ describe('polygonStyleFunction', () => {
 
 	it('should return a style specified by styleOption', () => {
 		const styleOption = { symbolSrc: markerIcon, color: '#BEDA55' };
-		const styles = polygonStyleFunction(styleOption);
+		const styles = getPolygonStyleArray(styleOption);
 
 		expect(styles).toBeDefined();
 		const stroke = styles[0].getStroke();
@@ -1147,9 +1147,9 @@ describe('modifyStyleFunction', () => {
 	});
 });
 
-describe('selectStyleFunction', () => {
+describe('getSelectStyleFunction', () => {
 	it('should create a styleFunction', () => {
-		const styleFunction = selectStyleFunction();
+		const styleFunction = getSelectStyleFunction();
 
 		expect(styleFunction).toBeDefined();
 	});
@@ -1160,11 +1160,11 @@ describe('selectStyleFunction', () => {
 			[1, 0]
 		]);
 		const featureWithStyle = new Feature({ geometry: geometry });
-		featureWithStyle.setStyle(defaultStyleFunction([0, 0, 0, 0]));
+		featureWithStyle.setStyle(getDefaultStyleFunction([0, 0, 0, 0]));
 		const featureWithEmptyFirstStyle = new Feature({ geometry: geometry });
 		const featureWithoutStyles = new Feature({ geometry: geometry });
 		featureWithEmptyFirstStyle.setStyle(() => []);
-		const styleFunction = selectStyleFunction();
+		const styleFunction = getSelectStyleFunction();
 
 		expect(styleFunction(featureWithStyle).length).toBe(2);
 		expect(styleFunction(featureWithEmptyFirstStyle).length).toBe(2);
@@ -1177,8 +1177,8 @@ describe('selectStyleFunction', () => {
 			[1, 0]
 		]);
 		const feature = new Feature({ geometry: geometry });
-		feature.setStyle(nullStyleFunction);
-		const styleFunction = selectStyleFunction();
+		feature.setStyle(getNullStyleArray);
+		const styleFunction = getSelectStyleFunction();
 		const styles = styleFunction(feature);
 
 		const vertexStyle = styles[1];
@@ -1209,11 +1209,11 @@ describe('selectStyleFunction', () => {
 			[1, 0]
 		]);
 		const featureWithStyle = new Feature({ geometry: geometry });
-		featureWithStyle.setStyle(defaultStyleFunction([0, 0, 0, 0]));
+		featureWithStyle.setStyle(getDefaultStyleFunction([0, 0, 0, 0]));
 		const featureWithEmptyFirstStyle = new Feature({ geometry: geometry });
 		const featureWithoutStyles = new Feature({ geometry: geometry });
 		featureWithEmptyFirstStyle.setStyle(() => []);
-		const styleFunction = selectStyleFunction();
+		const styleFunction = getSelectStyleFunction();
 		featureWithStyle.set(GEODESIC_FEATURE_PROPERTY, new GeodesicGeometry(featureWithStyle));
 		featureWithEmptyFirstStyle.set(GEODESIC_FEATURE_PROPERTY, new GeodesicGeometry(featureWithEmptyFirstStyle));
 		featureWithoutStyles.set(GEODESIC_FEATURE_PROPERTY, new GeodesicGeometry(featureWithoutStyles));
@@ -1351,9 +1351,9 @@ describe('defaultClusterStyleFunction', () => {
 	});
 });
 
-describe('createSketchStyleFunction', () => {
+describe('getSketchStyleFunction', () => {
 	it('should create a style function', () => {
-		const styleFunction = createSketchStyleFunction(measureStyleFunction);
+		const styleFunction = getSketchStyleFunction(measureStyleFunction);
 
 		expect(styleFunction).toBeDefined();
 	});
@@ -1366,7 +1366,7 @@ describe('createSketchStyleFunction', () => {
 		const feature = new Feature({ geometry: geometry });
 		const geometrySpy = spyOn(feature, 'getGeometry').and.returnValue(geometry);
 
-		const styleFunction = createSketchStyleFunction(measureStyleFunction);
+		const styleFunction = getSketchStyleFunction(measureStyleFunction);
 		const styles = styleFunction(feature, null);
 
 		expect(styles).toBeTruthy();
@@ -1383,7 +1383,7 @@ describe('createSketchStyleFunction', () => {
 		const idSpy = spyOn(feature, 'getId').and.returnValue('foo');
 		const featureStyleFunction = jasmine.createSpy();
 
-		const styleFunction = createSketchStyleFunction(featureStyleFunction);
+		const styleFunction = getSketchStyleFunction(featureStyleFunction);
 		styleFunction(feature, resolution);
 
 		expect(idSpy).toHaveBeenCalled();
@@ -1402,7 +1402,7 @@ describe('createSketchStyleFunction', () => {
 		]);
 		const feature = new Feature({ geometry: geometry });
 
-		const styleFunction = createSketchStyleFunction(measureStyleFunction);
+		const styleFunction = getSketchStyleFunction(measureStyleFunction);
 		const styles = styleFunction(feature, null);
 
 		expect(styles).toBeTruthy();
@@ -1421,7 +1421,7 @@ describe('createSketchStyleFunction', () => {
 		]);
 		const feature = new Feature({ geometry: geometry });
 
-		const styleFunction = createSketchStyleFunction(measureStyleFunction);
+		const styleFunction = getSketchStyleFunction(measureStyleFunction);
 		const styles = styleFunction(feature, null);
 
 		expect(styles).toBeTruthy();
@@ -1435,7 +1435,7 @@ describe('createSketchStyleFunction', () => {
 		const geometry = new Point([0, 0]);
 		const feature = new Feature({ geometry: geometry });
 
-		const styleFunction = createSketchStyleFunction(measureStyleFunction);
+		const styleFunction = getSketchStyleFunction(measureStyleFunction);
 		const styles = styleFunction(feature, null);
 
 		expect(styles).toBeTruthy();
@@ -1779,9 +1779,9 @@ describe('util functions creating a text style', () => {
 		const textStyleOption = { color: '#BEDA55', scale: 'large', text: 'Foo' };
 		const clusterFeature = getClusterFeature();
 
-		const markerStyles = markerStyleFunction(markerStyleOption);
-		const defaultTextStyles = textStyleFunction();
-		const customTextStyles = textStyleFunction(textStyleOption);
+		const markerStyles = getMarkerStyleArray(markerStyleOption);
+		const defaultTextStyles = getTextStyleArray();
+		const customTextStyles = getTextStyleArray(textStyleOption);
 		const clusterStyles = defaultClusterStyleFunction()(clusterFeature, null);
 
 		expect(markerStyles.some((style) => hasTextStyle(style))).toBeTrue();
@@ -1798,18 +1798,18 @@ describe('util functions creating a text style', () => {
 		const modifyFeatureMock = { get: () => [lineStringFeature] };
 
 		const measureStyles = measureStyleFunction(lineStringFeature, resolution);
-		const nullStyles = nullStyleFunction();
-		const defaultStyles = defaultStyleFunction(rgbaColor)(lineStringFeature);
-		const defaultGeoJsonStyles = geojsonStyleFunction();
-		const customGeoJsonStyles = geojsonStyleFunction(geojsonLineStringFeature);
-		const defaultLineStyles = lineStyleFunction();
-		const customLineStyles = lineStyleFunction(lineStyleOption);
-		const defaultPolygonStyles = polygonStyleFunction();
-		const customPolygonStyles = polygonStyleFunction(polygonStyleOption);
-		const noTextMarkerStyles = markerStyleFunction(noTextMarkerStyleOption);
+		const nullStyles = getNullStyleArray();
+		const defaultStyles = getDefaultStyleFunction(rgbaColor)(lineStringFeature);
+		const defaultGeoJsonStyles = getGeojsonStyleArray();
+		const customGeoJsonStyles = getGeojsonStyleArray(geojsonLineStringFeature);
+		const defaultLineStyles = getLineStyleArray();
+		const customLineStyles = getLineStyleArray(lineStyleOption);
+		const defaultPolygonStyles = getPolygonStyleArray();
+		const customPolygonStyles = getPolygonStyleArray(polygonStyleOption);
+		const noTextMarkerStyles = getMarkerStyleArray(noTextMarkerStyleOption);
 		const modifyStyles = modifyStyleFunction(modifyFeatureMock);
-		const selectStyles = selectStyleFunction()(lineStringFeature);
-		const sketchStyles = createSketchStyleFunction(measureStyleFunction)(lineStringFeature, null);
+		const selectStyles = getSelectStyleFunction()(lineStringFeature);
+		const sketchStyles = getSketchStyleFunction(measureStyleFunction)(lineStringFeature, null);
 
 		expect(measureStyles.some((style) => hasTextStyle(style))).toBeFalse();
 		expect(nullStyles.some((style) => hasTextStyle(style))).toBeFalse();


### PR DESCRIPTION


- remove necessary methods `getStyleFunction`, `getFeatureStyleFunction`

...and also:
- refactor usage of **_olStyleUtil_** methods
- rename/refine **_olStyleUtil_** method names
