### PR TITLE
MeasurementOverlayStyle: handle empty overlays property correctly

### DIFF
--- a/src/modules/olMap/overlayStyle/MeasurementOverlayStyle.js
+++ b/src/modules/olMap/overlayStyle/MeasurementOverlayStyle.js
@@ -68,13 +68,14 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 		}
 
 		const listener = olMap.getView().on('change:resolution', () => {
-			const overlays = olFeature.get('overlays');
+			const overlays = olFeature.get('overlays') ?? [];
 			// current display/opacity property for all overlays of the feature are the same, therefore
 			// it is sufficient to only look at the first one
-			const currentProperties = overlays
+			const overlay = overlays[0];
+			const currentProperties = overlay
 				? {
-						visible: overlays[0].getElement().style.display === 'inherit',
-						opacity: overlays[0].getElement().style.opacity
+						visible: overlay.getElement().style.display === 'inherit',
+						opacity: overlay.getElement().style.opacity
 					}
 				: {};
 			this.update(olFeature, olMap, currentProperties);

--- a/src/modules/olMap/services/OverlayService.js
+++ b/src/modules/olMap/services/OverlayService.js
@@ -68,6 +68,13 @@ export class OverlayService {
 				return new MeasurementOverlayStyle();
 			case StyleTypes.DEFAULT:
 				return new OverlayStyle();
+			case StyleTypes.DRAW:
+			case StyleTypes.MARKER:
+			case StyleTypes.LINE:
+			case StyleTypes.POINT:
+			case StyleTypes.POLYGON:
+			case StyleTypes.TEXT:
+				return null;
 			default:
 				console.warn('Could not provide a style for unknown style-type:', styleType);
 				return null;

--- a/test/modules/olMap/overlayStyle/MeasurementOverlayStyle.test.js
+++ b/test/modules/olMap/overlayStyle/MeasurementOverlayStyle.test.js
@@ -955,6 +955,8 @@ describe('MeasurementOverlayStyle', () => {
 			];
 			const featureWithInvisibleOverlays = { get: (key) => (key === 'overlays' ? invisibleOverlays : {}), set: () => {} };
 			const featureWithVisibleOverlays = { get: (key) => (key === 'overlays' ? visibleOverlays : {}), set: () => {} };
+			const featureWithoutOverlays = { get: (key) => (key === 'overlays' ? [] : {}), set: () => {} };
+
 			const viewMock = { getResolution: () => 1, on: () => {} };
 			const mapMock = {
 				getView: () => viewMock
@@ -972,39 +974,50 @@ describe('MeasurementOverlayStyle', () => {
 				.withArgs(featureWithVisibleOverlays, mapMock)
 				.and.callFake(() => {})
 				.withArgs(featureWithInvisibleOverlays, mapMock)
+				.and.callFake(() => {})
+				.withArgs(featureWithoutOverlays, mapMock)
 				.and.callFake(() => {});
 			spyOn(classUnderTest, '_createOrRemoveAreaOverlay')
 				.withArgs(featureWithVisibleOverlays, mapMock)
 				.and.callFake(() => {})
 				.withArgs(featureWithInvisibleOverlays, mapMock)
+				.and.callFake(() => {})
+				.withArgs(featureWithoutOverlays, mapMock)
 				.and.callFake(() => {});
 			spyOn(classUnderTest, '_createOrRemovePartitionOverlays')
 				.withArgs(featureWithVisibleOverlays, mapMock)
 				.and.callFake(() => {})
 				.withArgs(featureWithInvisibleOverlays, mapMock)
+				.and.callFake(() => {})
+				.withArgs(featureWithoutOverlays, mapMock)
 				.and.callFake(() => {});
 			spyOn(classUnderTest, '_restoreManualOverlayPosition')
 				.withArgs(featureWithVisibleOverlays, mapMock)
 				.and.callFake(() => {})
 				.withArgs(featureWithInvisibleOverlays, mapMock)
+				.and.callFake(() => {})
+				.withArgs(featureWithoutOverlays, mapMock)
 				.and.callFake(() => {});
 
 			classUnderTest.add(featureWithVisibleOverlays, mapMock);
 			classUnderTest.add(featureWithInvisibleOverlays, mapMock);
+			classUnderTest.add(featureWithoutOverlays, mapMock);
 
 			expect(addListenerSpy).toHaveBeenCalled();
-			expect(listeners.length).toBe(2);
+			expect(listeners.length).toBe(3);
 
 			const updateSpy = spyOn(classUnderTest, 'update')
 				.withArgs(featureWithInvisibleOverlays, mapMock, jasmine.objectContaining({ visible: false, opacity: 0 }))
 				.and.callFake(() => {})
 				.withArgs(featureWithVisibleOverlays, mapMock, jasmine.objectContaining({ visible: true, opacity: 0.4 }))
+				.and.callFake(() => {})
+				.withArgs(featureWithoutOverlays, mapMock, jasmine.objectContaining({}))
 				.and.callFake(() => {});
 
 			// mocking 'change:resolution'-event by calling the saved listener
 			listeners.forEach((l) => l());
 
-			expect(updateSpy).toHaveBeenCalledTimes(2);
+			expect(updateSpy).toHaveBeenCalledTimes(3);
 		});
 	});
 

--- a/test/modules/olMap/services/OverlayService.test.js
+++ b/test/modules/olMap/services/OverlayService.test.js
@@ -100,7 +100,33 @@ describe('OverlayService', () => {
 			expect(addListenerSpy).toHaveBeenCalled();
 		});
 
-		it('adds overlays to a feature with unknown style-type fails', () => {
+		it('does NOT add overlays to a feature with draw specific style-type', () => {
+			const drawSpecificStyleTypes = ['draw', 'point', 'line', 'polygon', 'marker', 'text'];
+			const feature = new Feature({
+				geometry: new Polygon([
+					[
+						[0, 0],
+						[1, 0],
+						[1, 1],
+						[0, 1],
+						[0, 0]
+					]
+				])
+			});
+			feature.setId('measure_123');
+			const warnSpy = spyOn(console, 'warn');
+			const addOverlaySpy = jasmine.createSpy();
+			const propertySetterSpy = spyOn(feature, 'set');
+			mapMock.addOverlay = addOverlaySpy;
+
+			drawSpecificStyleTypes.forEach((t) => instanceUnderTest.add(feature, mapMock, t));
+
+			expect(propertySetterSpy).not.toHaveBeenCalledWith('overlays', jasmine.any(Object));
+			expect(addOverlaySpy).not.toHaveBeenCalled();
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it('adding overlays to a feature with unknown style-type fails', () => {
 			const feature = new Feature({
 				geometry: new Polygon([
 					[


### PR DESCRIPTION
cherry pick from (#3087)

handle empty overlays property correctly