### PR TITLE
Fix of Common Component Searchable Select

### DIFF
--- a/src/modules/commons/components/searchableSelect/SearchableSelect.js
+++ b/src/modules/commons/components/searchableSelect/SearchableSelect.js
@@ -122,21 +122,21 @@ export class SearchableSelect extends MvuElement {
 
 		const onSearchInputChange = (evt) => {
 			this.#showDropdown();
-			this.signal(Update_Search, evt.target.value);
+			this.signal(Update_Search, evt.currentTarget.value);
 		};
 
 		const onPointerEnterOption = (evt) => {
-			this.#hoverOption(evt.target);
+			this.#hoverOption(evt.currentTarget);
 		};
 
 		const onPointerLeaveOption = (evt) => {
-			evt.target.classList.remove('hovered');
+			evt.currentTarget.classList.remove('hovered');
 		};
 
 		const onOptionChosen = (evt) => {
 			// Prevents global click handler to trigger s. onInitialize()
 			evt.stopPropagation();
-			this.#hoverOption(evt.target);
+			this.#hoverOption(evt.currentTarget);
 			this.#confirmAction();
 		};
 
@@ -225,6 +225,7 @@ export class SearchableSelect extends MvuElement {
 
 	#confirmAction() {
 		const hoveredOption = this.shadowRoot.querySelector('.option.hovered');
+
 		if (!hoveredOption) return;
 
 		this.#hideDropdown();

--- a/src/modules/commons/components/searchableSelect/searchableSelect.css
+++ b/src/modules/commons/components/searchableSelect/searchableSelect.css
@@ -50,7 +50,6 @@
 }
 
 .dropdown {
-	position: absolute;
+	position: fixed;
 	z-index: var(--z-mapbuttons);
-	width: 100%;
 }


### PR DESCRIPTION
- Fixed: event target was not same as the element that invoked the event - led to unresponsive clicking behaviour.
- Fixed: dropdown crops if had not enough space from its parent element.