### PR TITLE
v4.4: Revert "RoutingStyle: prevent rendering of large icons (#3113) (#3118)"

### DIFF
--- a/src/modules/olMap/formats/kml.js
+++ b/src/modules/olMap/formats/kml.js
@@ -58,7 +58,7 @@ const sanitizeStyle = (styles) => {
 		return firstStyle ?? new Style();
 	};
 
-	const style = getFirstOrDefault(styles ?? []);
+	const style = getFirstOrDefault(styles);
 	const kmlStyleProperties = toKmlStyleProperties(style);
 
 	if (kmlStyleProperties.image instanceof CircleStyle) {

--- a/src/modules/olMap/handler/routing/OlRoutingHandler.js
+++ b/src/modules/olMap/handler/routing/OlRoutingHandler.js
@@ -728,17 +728,7 @@ export class OlRoutingHandler extends OlLayerHandler {
 			// let's ensure each request is executed one after each other
 			this._promiseQueue.add(async () => {
 				this._catId = catId;
-				this._map.once('rendercomplete', () => {
-					/**
-					 * To prevent graphic issues due to a incomplete rendering process, we synchronize
-					 * our actions with the ol map render lifecycle. We wait for the next completed rendering
-					 * to give openLayers time to build the complete environment (after the initialization phase,
-					 * mostly the first render loop).
-					 * Otherwise the rendering uses occasionally incomplete style results, when the timing is bad,
-					 * which leads to large icons and uncalled styleFunctions.
-					 */
-					this._requestRouteFromCoordinates([...coordinates3857.map((c) => [...c])], status);
-				});
+				await this._requestRouteFromCoordinates([...coordinates3857.map((c) => [...c])], status);
 			});
 		};
 		const addIntermediatePointAndRequestRoute = (coordinate3857) => {

--- a/test/modules/olMap/formats/kml.test.js
+++ b/test/modules/olMap/formats/kml.test.js
@@ -259,19 +259,6 @@ describe('kml', () => {
 			expect(containsDummyIcon).toBeFalse();
 		});
 
-		it('provides an empty style for feature with stylefunction returning null', () => {
-			const nullStyleFunction = () => null;
-			aPointFeature.setStyle(nullStyleFunction);
-			const features = [aPointFeature];
-			const layer = createLayerMock(features);
-
-			const actual = create(layer, projection);
-
-			const containsEmptyStyle = actual.includes('<Style/>');
-
-			expect(containsEmptyStyle).toBeTrue();
-		});
-
 		it('reads and converts icon style-properties from feature', () => {
 			const color = [255, 42, 42];
 			const iconSrc =

--- a/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
+++ b/test/modules/olMap/handler/routing/OlRoutingHandler.test.js
@@ -19,7 +19,7 @@ import { Vector } from 'ol/layer';
 import { Modify, Select, Translate } from 'ol/interaction';
 import { setCategory, setHighlightedSegments, setIntermediate, setWaypoints } from '../../../../../src/store/routing/routing.action';
 import MapBrowserEventType from 'ol/MapBrowserEventType';
-import { Feature, MapBrowserEvent, MapEvent } from 'ol';
+import { Feature, MapBrowserEvent } from 'ol';
 import Event from 'ol/events/Event';
 import { LineString, Point } from 'ol/geom';
 import { ModifyEvent } from 'ol/interaction/Modify';
@@ -170,7 +170,6 @@ describe('OlRoutingHandler', () => {
 		const getModifyOptionsSpy = spyOn(instanceUnderTest, '_getModifyOptions').and.callThrough();
 		const layer = instanceUnderTest.activate(map);
 		await TestUtils.timeout();
-		map.dispatchEvent(new MapEvent('rendercomplete', map, null));
 		return { map, instanceUnderTest, store, layer, getSelectOptionsSpy, getModifyOptionsSpy };
 	};
 
@@ -320,7 +319,6 @@ describe('OlRoutingHandler', () => {
 
 				await TestUtils.timeout();
 				expect(instanceUnderTest._catId).toBe(catId);
-				map.dispatchEvent(new MapEvent('rendercomplete', map, null));
 				expect(requestRouteFromCoordinatesSpy).toHaveBeenCalledWith(coordinates, RoutingStatusCodes.Ok);
 			});
 		});
@@ -408,13 +406,12 @@ describe('OlRoutingHandler', () => {
 					[44, 55]
 				];
 				const catId = 'catId';
-				const { map, instanceUnderTest } = await newTestInstance();
+				const { instanceUnderTest } = await newTestInstance();
 				const requestRouteFromCoordinatesSpy = spyOn(instanceUnderTest, '_requestRouteFromCoordinates');
 
 				setCategory(catId);
 				await TestUtils.timeout();
 				expect(instanceUnderTest._catId).toBe(catId);
-				map.dispatchEvent(new MapEvent('rendercomplete', map, null));
 				expect(requestRouteFromCoordinatesSpy).toHaveBeenCalledWith([], RoutingStatusCodes.Start_Destination_Missing);
 
 				requestRouteFromCoordinatesSpy.calls.reset();
@@ -422,7 +419,6 @@ describe('OlRoutingHandler', () => {
 				setWaypoints(coordinates);
 				await TestUtils.timeout();
 				expect(instanceUnderTest._catId).toBe(catId);
-				map.dispatchEvent(new MapEvent('rendercomplete', map, null));
 				expect(requestRouteFromCoordinatesSpy).toHaveBeenCalledWith(coordinates, RoutingStatusCodes.Ok);
 			});
 		});
@@ -453,7 +449,7 @@ describe('OlRoutingHandler', () => {
 					[22, 55],
 					[33, 66]
 				];
-				const { map, instanceUnderTest } = await newTestInstance({
+				const { instanceUnderTest } = await newTestInstance({
 					status: RoutingStatusCodes.Ok
 				});
 				const addIntermediateSpy = spyOn(instanceUnderTest, '_addIntermediate').and.returnValue(coordinates);
@@ -461,7 +457,6 @@ describe('OlRoutingHandler', () => {
 
 				setIntermediate([22, 55]);
 				await TestUtils.timeout();
-				map.dispatchEvent(new MapEvent('rendercomplete', map, null));
 				expect(addIntermediateSpy).toHaveBeenCalledWith([22, 55], instanceUnderTest._routeLayerCopy);
 				expect(requestRouteFromCoordinatesSpy).toHaveBeenCalledWith(coordinates, RoutingStatusCodes.Ok);
 			});


### PR DESCRIPTION
This reverts commit 4acaa589aa1e2a06050f1ee5ca712a3759372af3.

Fixes #3137