### PR TITLE
ShareApi: use fallback dialog (v4.4)

### DIFF
--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -112,9 +112,10 @@ export class ShareChip extends AbstractAssistChip {
 			};
 			await this._environmentService.getWindow().navigator.share(content);
 		} catch (error) {
-			// In some rare cases we need a fallback. This happens when the webbrowser can basically
-			// use the share-API but enterprise policies on operating system level rejects the calls,
-			// due to missing user privileges.
+			/**
+			 * In some rare cases, we need a fallback. This occurs when the web browser can use the Share-API,
+			 * but enterprise policies at the operating system level reject the call due to a lack of user privileges.
+			 */
 			if (!(error instanceof DOMException && error.name === 'AbortError')) {
 				this._shareUrlDialog(url, title);
 			}

--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -5,7 +5,6 @@ import { html } from 'lit-html';
 import { QueryParameters } from '../../../../domain/queryParameters';
 import { $injector } from '../../../../injection/index';
 import { openModal } from '../../../../store/modal/modal.action';
-import { LevelTypes, emitNotification } from '../../../../store/notifications/notifications.action';
 import { isCoordinate } from '../../../../utils/checks';
 import { AbstractAssistChip } from './AbstractAssistChip';
 import shareIcon from './assets/share.svg';

--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -112,7 +112,7 @@ export class ShareChip extends AbstractAssistChip {
 			};
 			await this._environmentService.getWindow().navigator.share(content);
 		} catch (error) {
-			// In some rare cases we need a fallback. this happens when the webbrowser can basically
+			// In some rare cases we need a fallback. This happens when the webbrowser can basically
 			// use the share-API but enterprise policies on operating system level rejects the calls,
 			// due to missing user privileges.
 			if (!(error instanceof DOMException && error.name === 'AbortError')) {

--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -81,7 +81,7 @@ export class ShareChip extends AbstractAssistChip {
 		const translate = (key) => this._translationService.translate(key);
 		const title = center ? translate('chips_assist_chip_share_position_label') : translate('chips_assist_chip_share_state_label_default');
 		const url = await this._buildShareUrl(center);
-		const shareAction = useShareApi ? (url) => this._shareUrlWithApi(url) : (url) => this._shareUrlDialog(url, title);
+		const shareAction = useShareApi ? (url) => this._shareUrlWithApi(url, title) : (url) => this._shareUrlDialog(url, title);
 		shareAction(url);
 	}
 
@@ -105,7 +105,7 @@ export class ShareChip extends AbstractAssistChip {
 		}
 	}
 
-	async _shareUrlWithApi(url) {
+	async _shareUrlWithApi(url, title) {
 		try {
 			const content = {
 				// title-property is absent; browser automatically creates a meaningful title
@@ -113,8 +113,11 @@ export class ShareChip extends AbstractAssistChip {
 			};
 			await this._environmentService.getWindow().navigator.share(content);
 		} catch (error) {
+			// In some rare cases we need a fallback. this happens when the webbrowser can basically
+			// use the share-API but enterprise policies on operating system level rejects the calls,
+			// due to missing user privileges.
 			if (!(error instanceof DOMException && error.name === 'AbortError')) {
-				emitNotification(this._translationService.translate('chips_assist_chip_share_position_api_failed'), LevelTypes.WARN);
+				this._shareUrlDialog(url, title);
 			}
 		}
 	}

--- a/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
+++ b/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
@@ -129,7 +129,7 @@ export class ShareToolContent extends AbstractToolContent {
 
 						await this._window.navigator.share(shareData);
 					} catch (e) {
-						// In some rare cases we need a fallback. this happens when the webbrowser can basically
+						// In some rare cases we need a fallback. This happens when the webbrowser can basically
 						// use the share-API but enterprise policies on operating system level rejects the calls,
 						// due to missing user privileges.
 						if (!(e instanceof DOMException && e.name === 'AbortError')) {

--- a/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
+++ b/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
@@ -7,7 +7,6 @@ import { AbstractToolContent } from '../toolContainer/AbstractToolContent';
 import { $injector } from '../../../../injection';
 import css from './shareToolContent.css';
 import { openModal } from '../../../../store/modal/modal.action';
-import { LevelTypes, emitNotification } from '../../../../store/notifications/notifications.action';
 import { setQueryParams } from '../../../../utils/urlUtils';
 import { QueryParameters } from '../../../../domain/queryParameters';
 

--- a/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
+++ b/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
@@ -129,9 +129,10 @@ export class ShareToolContent extends AbstractToolContent {
 
 						await this._window.navigator.share(shareData);
 					} catch (e) {
-						// In some rare cases we need a fallback. This happens when the webbrowser can basically
-						// use the share-API but enterprise policies on operating system level rejects the calls,
-						// due to missing user privileges.
+						/**
+						 * In some rare cases, we need a fallback. This occurs when the web browser can use the Share-API,
+						 * but enterprise policies at the operating system level reject the call due to a lack of user privileges.
+						 */
 						if (!(e instanceof DOMException && e.name === 'AbortError')) {
 							shareUrlWithDialog();
 						}

--- a/test/modules/chips/components/ShareChip.test.js
+++ b/test/modules/chips/components/ShareChip.test.js
@@ -4,7 +4,6 @@ import { ShareChip } from '../../../../src/modules/chips/components/assistChips/
 import shareSvg from '../../../../src/modules/chips/components/assistChips/assets/share.svg';
 import { ShareDialogContent } from '../../../../src/modules/share/components/dialog/ShareDialogContent';
 import { modalReducer } from '../../../../src/store/modal/modal.reducer';
-import { LevelTypes } from '../../../../src/store/notifications/notifications.action';
 import { notificationReducer } from '../../../../src/store/notifications/notifications.reducer';
 import { TestUtils } from '../../../test-utils';
 

--- a/test/modules/chips/components/ShareChip.test.js
+++ b/test/modules/chips/components/ShareChip.test.js
@@ -136,7 +136,7 @@ describe('ShareChip', () => {
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 			});
 
-			it('uses dialog on share api reject as fallback', async () => {
+			it('uses a dialog as fallback on share api reject', async () => {
 				const element = await setup({ share: () => Promise.resolve(true) }, { center: [42, 21] });
 				const shareServiceSpy = spyOn(shareServiceMock, 'encodeStateForPosition').and.callThrough();
 
@@ -159,7 +159,7 @@ describe('ShareChip', () => {
 				expect(shareDialogContentElement.shadowRoot.querySelector('input').value).toBe('http://shorten.foo');
 			});
 
-			it('does NOT opens fallback dialog on share api canceled', async () => {
+			it('does NOT open the fallback dialog on share api canceled', async () => {
 				const element = await setup({ share: () => Promise.resolve(true) }, { center: [42, 21] });
 				const shareServiceSpy = spyOn(shareServiceMock, 'encodeStateForPosition').and.callThrough();
 

--- a/test/modules/chips/components/ShareChip.test.js
+++ b/test/modules/chips/components/ShareChip.test.js
@@ -137,7 +137,7 @@ describe('ShareChip', () => {
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 			});
 
-			it('emits a warn notification when shareApi fails', async () => {
+			it('uses dialog on share api reject as fallback', async () => {
 				const element = await setup({ share: () => Promise.resolve(true) }, { center: [42, 21] });
 				const shareServiceSpy = spyOn(shareServiceMock, 'encodeStateForPosition').and.callThrough();
 
@@ -153,11 +153,14 @@ describe('ShareChip', () => {
 
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 
-				expect(store.getState().notifications.latest.payload.content).toBe('chips_assist_chip_share_position_api_failed');
-				expect(store.getState().notifications.latest.payload.level).toEqual(LevelTypes.WARN);
+				expect(store.getState().modal.data.title).toBe('chips_assist_chip_share_position_label');
+
+				const contentElement = TestUtils.renderTemplateResult(store.getState().modal.data.content);
+				const shareDialogContentElement = contentElement.querySelector('ba-share-content');
+				expect(shareDialogContentElement.shadowRoot.querySelector('input').value).toBe('http://shorten.foo');
 			});
 
-			it('does NOT emit a warn notification on share api canceled', async () => {
+			it('does NOT opens fallback dialog on share api canceled', async () => {
 				const element = await setup({ share: () => Promise.resolve(true) }, { center: [42, 21] });
 				const shareServiceSpy = spyOn(shareServiceMock, 'encodeStateForPosition').and.callThrough();
 
@@ -173,7 +176,7 @@ describe('ShareChip', () => {
 
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 
-				expect(store.getState().notifications.latest).toBeNull();
+				expect(store.getState().modal.data).toBeNull();
 			});
 		});
 

--- a/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
+++ b/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
@@ -113,7 +113,7 @@ describe('ShareToolContent', () => {
 					expect(windowShareSpy).toHaveBeenCalledWith(mockShareData);
 				});
 
-				it('uses dialog on share api reject as fallback', async () => {
+				it('uses a dialog as fallback on share api reject', async () => {
 					const mockShortUrl = 'https://short/url';
 					const mockErrorMsg = 'something got wrong';
 					const windowMock = {
@@ -137,7 +137,7 @@ describe('ShareToolContent', () => {
 					expect(shareDialogContentElement.shadowRoot.querySelector('input').value).toBe('https://short/url');
 				});
 
-				it('does NOT opens fallback dialog on share api canceled', async () => {
+				it('does NOT open the fallback dialog on share api canceled', async () => {
 					const mockShortUrl = 'https://short/url';
 					const windowMock = {
 						navigator: {

--- a/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
+++ b/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
@@ -114,7 +114,7 @@ describe('ShareToolContent', () => {
 					expect(windowShareSpy).toHaveBeenCalledWith(mockShareData);
 				});
 
-				it('emits a warn statement on share api reject', async () => {
+				it('uses dialog on share api reject as fallback', async () => {
 					const mockShortUrl = 'https://short/url';
 					const mockErrorMsg = 'something got wrong';
 					const windowMock = {
@@ -131,11 +131,14 @@ describe('ShareToolContent', () => {
 					shareButton.click();
 
 					await TestUtils.timeout();
-					expect(store.getState().notifications.latest.payload.content).toBe('toolbox_shareTool_share_api_failed');
-					expect(store.getState().notifications.latest.payload.level).toEqual(LevelTypes.WARN);
+					expect(store.getState().modal.data.title).toBe('toolbox_shareTool_share');
+
+					const contentElement = TestUtils.renderTemplateResult(store.getState().modal.data.content);
+					const shareDialogContentElement = contentElement.querySelector('ba-share-content');
+					expect(shareDialogContentElement.shadowRoot.querySelector('input').value).toBe('https://short/url');
 				});
 
-				it('does NOT emit a warn statement on share api canceled', async () => {
+				it('does NOT opens fallback dialog on share api canceled', async () => {
 					const mockShortUrl = 'https://short/url';
 					const windowMock = {
 						navigator: {
@@ -151,7 +154,7 @@ describe('ShareToolContent', () => {
 					shareButton.click();
 
 					await TestUtils.timeout();
-					expect(store.getState().notifications.latest).toBeNull();
+					expect(store.getState().modal.data).toBeNull();
 				});
 			});
 		});

--- a/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
+++ b/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
@@ -6,7 +6,6 @@ import { modalReducer } from '../../../../../src/store/modal/modal.reducer';
 import { IframeGenerator } from '../../../../../src/modules/iframe/components/generator/IframeGenerator';
 import { ShareDialogContent } from '../../../../../src/modules/share/components/dialog/ShareDialogContent';
 import { notificationReducer } from '../../../../../src/store/notifications/notifications.reducer';
-import { LevelTypes } from '../../../../../src/store/notifications/notifications.action';
 import { QueryParameters } from '../../../../../src/domain/queryParameters';
 
 window.customElements.define(ShareDialogContent.tag, ShareDialogContent);


### PR DESCRIPTION
refactor share-api usage to use fallback dialog instead of warning notification