### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/ldbv-by/bav4/security/code-scanning/2](https://github.com/ldbv-by/bav4/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for each job. For the `build` job, read-only access to `contents` is sufficient. For the `deploy` job, write access to `contents` is required to deploy the app. 

The `permissions` block can be added at the job level to ensure that each job has the appropriate permissions. This involves editing the `.github/workflows/node.js.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
