### PR TITLE
LocationResultItem: update max zoom level

### DIFF
--- a/src/modules/search/components/menu/types/location/LocationResultItem.js
+++ b/src/modules/search/components/menu/types/location/LocationResultItem.js
@@ -46,7 +46,7 @@ export class LocationResultItem extends AbstractResultItem {
 	}
 
 	static get _maxZoomLevel() {
-		return 19;
+		return 17;
 	}
 
 	update(type, data, model) {

--- a/test/modules/search/components/menu/types/location/LocationResultItem.test.js
+++ b/test/modules/search/components/menu/types/location/LocationResultItem.test.js
@@ -60,7 +60,7 @@ describe('LocationResultItem', () => {
 
 	describe('static properties', () => {
 		it('_maxZoomValue', async () => {
-			expect(LocationResultItem._maxZoomLevel).toBe(19);
+			expect(LocationResultItem._maxZoomLevel).toBe(17);
 		});
 	});
 


### PR DESCRIPTION
Adjust the zoom level for coordinates to common viewers (e.g., Google Maps, ...). So far, we've zoomed in a bit too far.